### PR TITLE
CI build improvements - deploy / false positives, speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,9 @@ addons:
     - graphicsmagick
 
 before_install:
-- nvm install 7 # or 5, 6, or whatever
-- npm update -g npm # if necessary
+- nvm install 8 # or 5, 6, or whatever
+- node --version && npm --version && composer --version
+#- npm update -g npm # if necessary
 #- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
 #- export PATH=$HOME/.yarn/bin:$PATH
 - composer global require hirak/prestissimo

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,7 @@ before_script:
 - phpenv config-rm xdebug.ini
 
 install:
-- npm install gulpjs/gulp-cli -g
-- npm install gulpjs/gulp#4.0
-- npm install --global now
-- npm install --global lerna
-- npm install --global webpack
-- npm install && npm run bootstrap && npm run composer:setup
+- npm install && npm run setup
 # - gem install --file packages/website-jekyll/Gemfile
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ cache:
   apt: true
 #  yarn: true
   directories:
-  - "$HOME/.cache/yarn"
-  - node_modules
+#  - "$HOME/.cache/yarn"
+#  - node_modules
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,7 @@ install:
 
 script:
 - npm run test
-- travis_wait npm run build
-
-after_success:
-- npm run deploy
+- travis_wait npm run build && npm run deploy # only run deploy if build is successful. Can't do `after_success` b/c if deploy fails, the build still reports success. Can't use `deploy` step b/c Travis skips that on PRs.
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ addons:
 before_install:
 - nvm install 7 # or 5, 6, or whatever
 - npm update -g npm # if necessary
-- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
-- export PATH=$HOME/.yarn/bin:$PATH
+#- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
+#- export PATH=$HOME/.yarn/bin:$PATH
 - composer global require hirak/prestissimo
 - if [[ -n "$GITHUB_TOKEN" ]]; then composer config -g github-oauth.github.com ${GITHUB_TOKEN};
   fi;
@@ -63,7 +63,7 @@ script:
 
 cache:
   apt: true
-  yarn: true
+#  yarn: true
   directories:
   - "$HOME/.cache/yarn"
   - node_modules


### PR DESCRIPTION
This adjusts a few things I saw in the Travis build process:

- Ensure that a successful compile and a failed deploy will mark the CI build as failed. [See here for example](https://travis-ci.org/bolt-design-system/bolt/builds/313187189#L1515)
    - This is fixed by moving the deploy step from `after_success` (which can't fail and mark as failed as the build has already been marked as a success) to the `install` step after a successful build, done via `npm run build && npm run deploy`
- Not globally installing some npm modules (gulp, lerna, now, webpack) as they are installed locally from `package.json` and the CLIs get added to `$PATH` when used via `npm run`. Results in a sightly faster CI build.
- Not installing and configuring yarn since we're not using it yet
- Bumping up node version from 7 to 8 since it's faster. Not updating npm, since an up to date one comes with node v8.

I removed `node_modules` from cache, because I got [an error on a previous CI build due to node-sass being compiled for node 7](https://travis-ci.org/bolt-design-system/bolt/builds/313208275#L890-L898) already and we're using node 8 now. We could turn that back on if you'd like.

Just looking at last couple CI builds, this one took ~13 minutes and a few of the last ones before took ~18-20 minutes, so that's nice!
