### PR TITLE
Minimizing output of webpack compiles when in dev mode

### DIFF
--- a/build-tools/gulp-tasks/build-webpack/webpack.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.js
@@ -12,11 +12,15 @@ function webpackTask(gulp, devConfig, releaseConfig) {
   const getDevCompiler = options => webpack(devConfig(options));
   const getReleaseCompiler = options => webpack(releaseConfig(options));
 
-  const handleWebpackOutput = (err, stats) => {
+  const handleWebpackOutput = (err, stats, verbose) => {
     if (err) throw new gutil.PluginError('es6Pipeline', err);
     gutil.log('[es6Pipeline]', stats.toString({
       colors: true,
-      chunks: false
+      chunks: false,
+      assets: verbose,
+      version: verbose,
+      modules: verbose,
+      timings: verbose,
     }));
   };
 
@@ -24,7 +28,7 @@ function webpackTask(gulp, devConfig, releaseConfig) {
   gulp.task('webpack:dev', (done) => {
     const compiler = getDevCompiler(devConfig.webpack ? devConfig.webpack : devConfig);
     compiler.run((err, stats) => {
-      handleWebpackOutput(err, stats);
+      handleWebpackOutput(err, stats, false);
       done();
     });
   });
@@ -33,14 +37,14 @@ function webpackTask(gulp, devConfig, releaseConfig) {
   gulp.task('webpack:prod', (done) => {
     const compiler = getReleaseCompiler(releaseConfig.webpack ? releaseConfig.webpack : releaseConfig);
     compiler.run((err, stats) => {
-      handleWebpackOutput(err, stats);
+      handleWebpackOutput(err, stats, true);
       done();
     });
   });
 
 
 
-  
+
 
   // Copy built js files to PL
   gulp.task('webpack:copypl', (done) => {


### PR DESCRIPTION
I want to improve the signal to noise ratio in the command line output. Here's a simple start: this PR changes this output:

```
[14:45:38] Starting 'webpack:dev'...
[14:45:47] [es6Pipeline] Hash: b5d2d0ca3749ddd699fe
Version: webpack 3.10.0
Time: 8472ms
                                                                                                                   Asset     Size  Chunks             Chunk Names
                                                                                                          0.chunk.js.map   134 kB       0  [emitted]
                                                                                                              0.chunk.js   138 kB       0  [emitted]
                                                                                                              2.chunk.js  2.25 kB       2  [emitted]  bolt-wc-polyfill--sd
                                                                                                              3.chunk.js  1.74 kB       3  [emitted]  bolt-wc-polyfill--es5-adapter
                                                                                                              4.chunk.js   196 kB       4  [emitted]
                                                                                                              5.chunk.js  54.1 kB       5  [emitted]
                                                                                                         bolt-app.min.js   244 kB       6  [emitted]  bolt-app
                                                                                               bolt-critical-path.min.js  54.8 kB    7, 8  [emitted]  bolt-critical-path
                                                                                                   critical-fonts.min.js  54.8 kB       8  [emitted]  critical-fonts
            critical-fonts.css?b5d2d0ca3749ddd699fe-f11dd94294998ac6256a-15db7f734c7972241d26e7f681dc29f9-critical-fonts  10.8 kB       8  [emitted]  critical-fonts
    bolt-critical-path.css?b5d2d0ca3749ddd699fe-685795beb5160ccce2d0-15db7f734c7972241d26e7f681dc29f9-bolt-critical-path  10.8 kB    7, 8  [emitted]  bolt-critical-path
                                                                                                              1.chunk.js  94.2 kB       1  [emitted]  bolt-wc-polyfill--ce-sd
                                                                                                          1.chunk.js.map  95.4 kB       1  [emitted]  bolt-wc-polyfill--ce-sd
                                                                                                          2.chunk.js.map  2.75 kB       2  [emitted]  bolt-wc-polyfill--sd
                                                                                                          3.chunk.js.map  2.08 kB       3  [emitted]  bolt-wc-polyfill--es5-adapter
                                                                                                          4.chunk.js.map   233 kB       4  [emitted]
                                                                                                          5.chunk.js.map  52.8 kB       5  [emitted]
                                                                                                     bolt-app.min.js.map   260 kB       6  [emitted]  bolt-app
                                                                                           bolt-critical-path.min.js.map  57.3 kB    7, 8  [emitted]  bolt-critical-path
bolt-critical-path.css.map?b5d2d0ca3749ddd699fe-685795beb5160ccce2d0-15db7f734c7972241d26e7f681dc29f9-bolt-critical-path  11.2 kB    7, 8  [emitted]  bolt-critical-path
                                                                                               critical-fonts.min.js.map  57.1 kB       8  [emitted]  critical-fonts
        critical-fonts.css.map?b5d2d0ca3749ddd699fe-f11dd94294998ac6256a-15db7f734c7972241d26e7f681dc29f9-critical-fonts  11.2 kB       8  [emitted]  critical-fonts
                                                                                                      bolt-manifest.json  1.45 kB          [emitted]
   [0] ./node_modules/es6-promise/dist/es6-promise.js 30.9 kB {6} {7} {8} [built]
   [4] (webpack)/buildin/module.js 521 bytes {6} {7} {8} [built]
   [6] (webpack)/buildin/global.js 823 bytes {6} {7} {8} [built]
  [11] ./node_modules/node-libs-browser/node_modules/process/browser.js 5.45 kB {6} {7} {8} [built]
  [20] ./src/_patterns/02-components/bolt-critical-fonts/src/critical-fonts.js 2.56 kB {7} {8} [built]
  [21] ./src/_patterns/02-components/bolt-critical-fonts/src/critical-fonts.scoped.scss 2.12 kB {7} {8} [built]
  [22] ./node_modules/fontfaceobserver/fontfaceobserver.js 8.37 kB {7} {8} [built]
  [62] multi ./src/scripts/bolt-app 28 bytes {6} [built]
  [63] ./src/scripts/bolt-app.js 292 bytes {6} [built]
  [64] ./src/_patterns/02-components/bolt-image/src/image.js 839 bytes {6} [built]
  [67] ./src/_patterns/02-components/bolt-device-viewer/src/device-viewer.js 495 bytes {6} [built]
 [106] ./src/_patterns/02-components/bolt-icon/src/icon.js 1.37 kB {6} [built]
 [107] ./src/_patterns/02-components/bolt-nav-bar/src/nav-bar.js 805 bytes {6} [built]
 [118] ./src/_patterns/02-components/bolt-smooth-scroll/src/smooth-scroll.js 2.12 kB {6} [built]
 [120] ./src/scripts/bolt-critical-path.js 58 bytes {7} [built]
    + 234 hidden modules
Child extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/index.js??ref--2-2!node_modules/postcss-loader/lib/index.js??ref--2-3!node_modules/clean-css-loader/dist/index.js??ref--2-4!node_modules/sass-loader/lib/loader.js??ref--2-5!src/_patterns/02-components/bolt-critical-fonts/src/critical-fonts.scoped.scss:
       [0] ./node_modules/css-loader?{"sourceMap":true,"modules":true,"importLoaders":true,"localIdentName":"[local]"}!./node_modules/postcss-loader/lib?{}!./node_modules/clean-css-loader/dist?{"skipWarn":true,"compatibility":"ie9","level":2,"inline":["remote"]}!./node_modules/sass-loader/lib/loader.js?{"functions":{},"outputStyle":"compressed","precision":2}!./src/_patterns/02-components/bolt-critical-fonts/src/critical-fonts.scoped.scss 27 kB {0} [built]
       [1] ./node_modules/css-loader/lib/css-base.js 2.28 kB {0} [built]
[14:45:47] Finished 'webpack:dev' after 8.58 s
```

to simply this:

```
[14:53:10] Starting 'webpack:dev'...
[14:53:19] [es6Pipeline] Hash: b5d2d0ca3749ddd699fe
[14:53:19] Finished 'webpack:dev' after 8.85 s
```

The previous full output is visible on prod compiles still.