### PR TITLE
Fixes 'Notice: Array to string conversion' in PL compiles

### DIFF
--- a/src/_meta/_00-head.twig
+++ b/src/_meta/_00-head.twig
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html class="{{ htmlClass }}">
   <head>
-    <title>{{ title }}</title>
+    <title>Bolt Design System</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width" />
 
     <link rel="stylesheet" href="../../../styles/bolt.css?{{ cacheBuster }}" media="all" />
-    
-    
+
+
     <meta name="bolt-javascript-path"  content="/vendor/">
 
     {# Inline Critical Font-specific CSS automatically #}


### PR DESCRIPTION
Just in case you were ever wondering why browser tabs said "Notice: Array to string conversion" in some place ;) - `title` isn't a string in most places; for example in the `nav-bar`.