### PR TITLE
Setup feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,36 @@ brew install graphicsmagick
 
 
 ## Installing
-Once Bolt is cloned down locally (and you’ve already gone ahead and installed the prerequisites)  all you need to do to finish setting up Bolt is run `npm run setup` to install the required NPM dependencies, run Lerna bootstrap, and install Pattern Lab + any composer dependencies for the very first time.
+
+### First time setup
+
+If this is a fresh clone, run the commands below, then go get lunch.
+
+```bash
+npm install
+npm run setup
+npm start
+```
+
+<details>
+<summary>**What's that all doing? I wanna know details! (click me)**</summary>
+Well, since you asked:
+
+- `npm install` - Installing node dependencies listed in `package.json` into `node_modules/`
+- `npm run setup` - This runs these commands:
+    - `npm run bootstrap` - Runs `lerna bootstrap --hoist` 
+        - Looks at `lerna.json` to find where all packages are, then goes to those directories and runs `npm install`. 
+        - Since we use `--hoist`, that installs shared dependencies up in the repo roots `node_modules/` folder.
+    - `npm run composer:setup`
+        - Checks to see if this is a fresh install and if not:
+        - deletes `composer.lock` and `vendor`
+        - Runs `composer install` to get dependencies from `composer.json` and put them in `vendor`, these are mainly Pattern Lab dependencies.
+- `npm start`
+    - Compiles everything
+    - Starts watches on files that will trigger builds for what was changed
+    - Starts up a server
+
+</details>
 
 ## Start up local server, compile, and watch for changes
 ```

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 v: 2.6.0
-overrideConfig: q
+overrideConfig: false
 ie:
   - DS_Store
   - less

--- a/config/config.yml
+++ b/config/config.yml
@@ -41,7 +41,7 @@ lineageMatch: >-
   |\()[&quot;\&#039;]([\/.@A-Za-z0-9-_]+)[&quot;\&#039;]([\s\S+]*?)%}
 lineageMatchKey: 3
 patternExtension: twig
-twigDebug: false
+twigDebug: true
 twigAutoescape: false
 twigDefaultDateFormat: ''
 twigDefaultIntervalFormat: ''


### PR DESCRIPTION
Initial setup of the repo results in the PL `config.yml` file being altered, which breaks the build since the Twig Namespaces aren't configured correctly. I've set `overrideConfig` to false to prevent that from happening. I've also enabled Twig Debug, so devs can use the [`{{ dump(var) }}` function](https://twig.symfony.com/doc/1.x/functions/dump.html). 

Finally, I typed up some quick setup notes - let me know what you all think of my use of `<details>` (make sure you [see it here](https://github.com/bolt-design-system/bolt/blob/feature/setup-feedback/README.md#installing) with the markdown rendered): I think that could be a good way of having less used, but detailed info available but not getting in the way of first time users.