### PR TITLE
Improving Git Hooks system

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,10 @@
     "test": "npm run mocha",
     "test:ci": "node browserstack.js",
     "pretest": "node build-tools/scripts/check-imports.js",
+    "precommit": "npm run lint:scss",
+    "prepush": "npm test && npm run build:full",
     "snyk-protect": "snyk protect"
   },
-  "pre-commit": [
-    "test",
-    "lint:scss",
-    "build:full"
-  ],
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-lerna-changelog"
@@ -144,7 +141,6 @@
     "gulp": "gulpjs/gulp#4.0",
     "gulp-util": "^3.0.8",
     "http-server": "^0.10.0",
-    "husky": "^0.14.3",
     "inquirer": "^3.2.0",
     "js-yaml": "^3.9.1",
     "json-server": "^0.12.0",
@@ -167,8 +163,6 @@
     "postcss": "^6.0.13",
     "postcss-cssnext": "^3.0.2",
     "postcss-loader": "^2.0.8",
-    "pre-commit": "^1.2.2",
-    "precommit": "^1.2.2",
     "prettier-eslint-cli": "^4.2.1",
     "publish-please": "^2.3.1",
     "read-pkg-up": "^2.0.0",
@@ -202,6 +196,9 @@
     "webpack-manifest-plugin": "^1.3.2",
     "workbox-webpack-plugin": "^2.1.0",
     "xo": "^0.18.2"
+  },
+  "devDependencies": {
+    "husky": "^0.14.3"
   },
   "snyk": true,
   "lint-staged": {


### PR DESCRIPTION
This removes the `pre-commit` and `precommit` package in favor of [`husky`](https://www.npmjs.com/package/husky), which can do [all of the git hooks](https://github.com/typicode/husky/blob/HEAD/HOOKS.md). I've also broken the precommit hook out into precommit and prepush so the precommit hooks takes a few seconds to run.

@sghoweri - what do you think about moving `npm run build:full` into the `prepublish` hook?