### PR TITLE
Add workaround for embedding band in nav-bar.

### DIFF
--- a/src/_patterns/02-components/bolt-nav-bar/src/nav-bar.twig
+++ b/src/_patterns/02-components/bolt-nav-bar/src/nav-bar.twig
@@ -72,6 +72,8 @@
 <bolt-{{ componentName }} bolt-component>
 
   {% embed "@bolt/band.twig" with {
+    componentName: 'band',
+    baseClass: 'c-band',
     size: vspacing,
     theme: theme,
     fullBleed: true


### PR DESCRIPTION
This is a quick fix for band embedding in nav-bar.

However, IMO, componentName and baseClass should be static variables, so I'm not sure this is part of a long-term solution.