### PR TITLE
Set smooth scroll offset for nav-bar, body class during scrolling.

### DIFF
--- a/src/_patterns/02-components/bolt-smooth-scroll/src/smooth-scroll.js
+++ b/src/_patterns/02-components/bolt-smooth-scroll/src/smooth-scroll.js
@@ -2,7 +2,8 @@ import SmoothScroll from 'smooth-scroll';
 
 const scroll = new SmoothScroll();
 
-const defaultScrollOffset = 0;
+// Set offset to 50 for nav-bar.
+const defaultScrollOffset = 50;
 const defaultScrollSpeed = 500;
 
 const customScrollElems = document.querySelectorAll('a[href*="#"]');
@@ -28,8 +29,8 @@ customScrollElems.forEach(elem => {
         easing: 'easeInOutCubic', // Easing pattern to use
 
         // Callback API
-        before: function () {}, // Callback to run before scroll
-        after: function () {} // Callback to run after scroll
+        before: function () { document.body.className += ' ' + 'js-bolt-smooth-scroll-scrolling'; }, // Callback to run before scroll
+        after: function () { document.body.className = document.body.className.replace('js-bolt-smooth-scroll-scrolling', ''); } // Callback to run after scroll
     };
 
     let scrollElemHref = scrollElem.getAttribute('href');


### PR DESCRIPTION
The current method for setting offset (adding class .js-bolt-smooth-scroll-offset to the fixed element) doesn't work for sticky elements. It uses the element's location on the page instead of the element's height when fixed. With a sticky element halfway down the page, it sets the offset to halfway down the page. Instead I'm just setting the offset directly to the nav-bar's height, and we can figure out how to accommodate other sticky elements when we cross that bridge.

This change also sets a class on the body while scrolling, which will allow us to keep the header collapsed. Right now, using the headroom.js, the header is collapsed when scrolling down, but opens when scrolling up, which messes up the offset. Instead of offsetting for the height of the nav-bar, it'd need to offset for the combined height of the header and the navbar. Rather than getting into dynamic offsets for different scenarios, it's easier (and probably more user-friendly) to keep the header collapsed using a scrolling-specific class.