### PR TITLE
Feature/bk 26 background shapes fixes

### DIFF
--- a/src/_patterns/02-components/05-bolt-background-shapes/src/background-shapes.twig
+++ b/src/_patterns/02-components/05-bolt-background-shapes/src/background-shapes.twig
@@ -29,7 +29,7 @@
 
           {% cell "u-bolt-width-1/3" %}
             <div {{ attributes.addClass(classes) }}>
-              {{ source(element.shape ~ '.svg') }}
+              {{ source('@bolt/' ~ element.shape ~ '.svg') }}
             </div>
           {% endcell %}
         {% endfor %}

--- a/src/_patterns/02-components/bolt-background/src/background.scss
+++ b/src/_patterns/02-components/bolt-background/src/background.scss
@@ -17,11 +17,11 @@ $bolt-background-dark-overlay-opacity--medium: 0.55;
 $bolt-background-dark-overlay-opacity--heavy: 0.8;
 
 $bolt-bg-shape-offset-bottom-default: -100px;
-$bolt-bg-shape-offset-side-default: $bold-bg-shape-offset-bottom-default * 1.2;
+$bolt-bg-shape-offset-side-default: $bolt-bg-shape-offset-bottom-default * 1.2;
 $bolt-bg-shape-offset-bottom-small: -150px;
-$bolt-bg-shape-offset-side-small: $bold-bg-shape-offset-bottom-small * 1.2;
-$bold-bg-shape-offset-bottom-large: -300px;
-$bolt-bg-shape-offset-side-large: $bold-bg-shape-offset-bottom-large * 1.2;
+$bolt-bg-shape-offset-side-small: $bolt-bg-shape-offset-bottom-small * 1.2;
+$bolt-bg-shape-offset-bottom-large: -300px;
+$bolt-bg-shape-offset-side-large: $bolt-bg-shape-offset-bottom-large * 1.2;
 
 
 


### PR DESCRIPTION
- Most importantly, this resolves the errors in Drupal where the svgs could not be found using their relative paths (such a simple fix, doh!)
- It also fixes some variable name typos (also doh!)

@charginghawk @barnettrob, once this is merged, we should be able to update Drupal so that it properly pulls the background shapes pattern from Bolt rather than duplicating it.