### PR TITLE
Feature / Refactor: Limit Lerna Publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -20,7 +20,7 @@
   ],
   "command": {
     "publish": {
-      "message": "chore(release): publish %s"
+      "allowBranch": "master"
     },
     "bootstrap": {
       "hoist": true


### PR DESCRIPTION
Updates global Lerna config to limit publishing to only be done on the master branch