### PR TITLE
Refactor: removing version number from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "bolt",
-  "version": "0.4.0",
   "description": "Pega Digital Design System",
   "private": true,
   "files": [


### PR DESCRIPTION
Removing version number from Bolt's root package.json file (since it doesn't do / mean anything)