### PR TITLE
Fix publicpath() getting called in Drupal

### DIFF
--- a/src/_patterns/02-components/bolt-image/src/image.twig
+++ b/src/_patterns/02-components/bolt-image/src/image.twig
@@ -11,7 +11,7 @@
 {% set srcset = srcset ?? "" %}
 {% set imageSizes = globalBoltImageSizes %}
 
-{% if placeholderImage is empty || placeholderColor is empty || srcset == "" %}
+{% if placeholderImage is empty or placeholderColor is empty or srcset == "" %}
   {% set path = publicpath(src|split('.' ~ ext)|first) %}
 {% endif %}
 
@@ -20,7 +20,7 @@
 {% endif %}
 
 {# smaller image src used for calculating color -- already resized for less of a perf hit #}
-{% if placeholderImage is empty || placeholderColor is empty %}
+{% if placeholderImage is empty or placeholderColor is empty %}
   {% set sampleImageSrc = path ~ '-' ~ globalBoltImageSizes[0] ~ '.' ~ ext %}
 
   {% if placeholderImage is empty %}

--- a/src/_patterns/02-components/bolt-image/src/image.twig
+++ b/src/_patterns/02-components/bolt-image/src/image.twig
@@ -9,23 +9,28 @@
 
 
 {% set srcset = srcset ?? "" %}
-{% set path = publicpath(src|split('.' ~ ext)|first) %}
 {% set imageSizes = globalBoltImageSizes %}
+
+{% if placeholderImage is empty || placeholderColor is empty || srcset == "" %}
+  {% set path = publicpath(src|split('.' ~ ext)|first) %}
+{% endif %}
 
 {% if src %}
   {% set ext = src|split('.')|last %}
 {% endif %}
 
 {# smaller image src used for calculating color -- already resized for less of a perf hit #}
-{% set sampleImageSrc = path ~ '-' ~ globalBoltImageSizes[0] ~ '.' ~ ext %}
+{% if placeholderImage is empty || placeholderColor is empty %}
+  {% set sampleImageSrc = path ~ '-' ~ globalBoltImageSizes[0] ~ '.' ~ ext %}
 
-{% if placeholderImage is empty %}
-  {% set placeholderImage = base64(sampleImageSrc) %}
-{% endif %}
+  {% if placeholderImage is empty %}
+    {% set placeholderImage = base64(sampleImageSrc) %}
+  {% endif %}
 
-{# only calculate a placeholder color if not using a placeholder image #}
-{% if placeholderColor is empty %}
-  {% set placeholderColor = bgcolor(sampleImageSrc) %}
+  {# only calculate a placeholder color if not using a placeholder image #}
+  {% if placeholderColor is empty %}
+    {% set placeholderColor = bgcolor(sampleImageSrc) %}
+  {% endif %}
 {% endif %}
 
 {% if height is empty %}


### PR DESCRIPTION
This throws warnings in Drupal as we are not currently "officially supporting" publicpath, even though the extension is technically there.

@charginghawk