### PR TITLE
Update Cross Browser Shims + Fix IE11 array.includes via Polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -794,33 +794,10 @@
 				"@types/node": "6.0.89"
 			}
 		},
-		"@webcomponents/custom-elements": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.0.4.tgz",
-			"integrity": "sha512-klwpl/zR4JnVPDBbZYj52xqpPclxKyNGoCzpRuFAAEIUn4V1UCUuSrj5JhkAES4OoO90Z5glsrbZa2a4lNtLnw=="
-		},
-		"@webcomponents/shadycss": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.0.6.tgz",
-			"integrity": "sha512-4yGifxIQkDzf3SRQIRE4e4cI09yawgZ6GHsnrkSLdohesKo4oMgxc5sF0wv2DQN7o7mCAjBYnunQXcHmC62qhw=="
-		},
-		"@webcomponents/shadydom": {
-			"version": "github:bolt-design-system/shadydom#5ce5a74abe7fc71064d7d46a989213e6b41ede97"
-		},
-		"@webcomponents/template": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webcomponents/template/-/template-1.1.0.tgz",
-			"integrity": "sha512-qEbLU4MXH/pjiIZc6x1YNsgJDYtbsmfJZEzS+nJRu2c4BdDvTiBSluEQ2e0hDZSn/NAtwoNzO6UWi35tEGvNYA=="
-		},
-		"@webcomponents/webcomponents-platform": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponents-platform/-/webcomponents-platform-1.0.0.tgz",
-			"integrity": "sha1-iHkUY4DdvsuGF+MiSX1Z53w/9Gg="
-		},
 		"@webcomponents/webcomponentsjs": {
-			"version": "1.0.18",
-			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.18.tgz",
-			"integrity": "sha512-F/Gn3zcJMc0FaxedKPyOKoiIQxg5p9HyDwRC1VRBvAc7+FA6oBDf39GqWsZ9nKtarsx1RslwkrHDIHLYETdIAA=="
+			"version": "1.0.22",
+			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.22.tgz",
+			"integrity": "sha512-VREMJxIe5ydR6LdMpg27ojyfL635jH03680na5X2LNLY2UF1GOzNrNOAVaEf2mr+SDUpc9Rey+gt+qCvtbCGhQ=="
 		},
 		"JSONStream": {
 			"version": "1.3.1",
@@ -34894,7 +34871,7 @@
 			"requires": {
 				"@polymer/sinonjs": "1.17.1",
 				"@polymer/test-fixture": "0.0.3",
-				"@webcomponents/webcomponentsjs": "1.0.18",
+				"@webcomponents/webcomponentsjs": "1.0.22",
 				"accessibility-developer-tools": "2.12.0",
 				"async": "1.5.2",
 				"body-parser": "1.18.2",

--- a/packages/bolt-core/package.json
+++ b/packages/bolt-core/package.json
@@ -10,12 +10,7 @@
   },
   "dependencies": {
     "@bolt/core-data": "^0.2.0-beta.0",
-    "@webcomponents/custom-elements": "^1.0.4",
-    "@webcomponents/shadycss": "^1.0.6",
-    "@webcomponents/shadydom": "bolt-design-system/shadydom#hotfix/fix-text-undefined-IE11",
-    "@webcomponents/template": "^1.1.0",
-    "@webcomponents/webcomponents-platform": "^1.0.0",
-    "@webcomponents/webcomponentsjs": "^1.0.14",
+    "@webcomponents/webcomponentsjs": "^1.0.22",
     "core-js": "^2.5.1",
     "es6-promise": "^4.1.1",
     "preact": "^8.2.5",

--- a/packages/bolt-core/polyfills/polyfill-loader.js
+++ b/packages/bolt-core/polyfills/polyfill-loader.js
@@ -2,18 +2,19 @@ require('es6-promise').polyfill();
 require('core-js/modules/es6.array.iterator');
 require('core-js/modules/es6.symbol');
 require('core-js/modules/es6.array.from');
+require('core-js/modules/es7.array.includes');
 
 export const polyfillLoader = new Promise(function (resolve, reject) {
   if (window.customElements !== undefined) {
     Promise.all([
       import(/* webpackChunkName: "custom-elements-es5-adapter" */ '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js'),
-      import(/* webpackChunkName: "wc-polyfill-sd" */ './wc-polyfill-sd')
+      import(/* webpackChunkName: "webcomponents-hi-sd-ce" */ '@webcomponents/webcomponentsjs/webcomponents-hi-sd-ce.js')
     ]).then(() => {
       resolve();
     });
   } else {
     Promise.all([
-      import(/* webpackChunkName: "wc-polyfill-ce-sd" */ './wc-polyfill-ce-sd')
+      import(/* webpackChunkName: "webcomponents-lite" */ '@webcomponents/webcomponentsjs/webcomponents-lite.js')
     ]).then(() => {
       resolve();
     });


### PR DESCRIPTION
Update webcomponentjs shims to the latest version to address known IE11 errors with current build. 

Also switches on ES7 array.includes shim using the existing `core-js` package already in place to address a silent error w/ IE11 displaying icons correctly w/ backgrounds switched on.