### PR TITLE
Add Standalone JavaScript Bundle for Pega.com D8, Disable Smooth Scroll + Sticky JS Packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -794,33 +794,10 @@
 				"@types/node": "6.0.89"
 			}
 		},
-		"@webcomponents/custom-elements": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.0.4.tgz",
-			"integrity": "sha512-klwpl/zR4JnVPDBbZYj52xqpPclxKyNGoCzpRuFAAEIUn4V1UCUuSrj5JhkAES4OoO90Z5glsrbZa2a4lNtLnw=="
-		},
-		"@webcomponents/shadycss": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.0.6.tgz",
-			"integrity": "sha512-4yGifxIQkDzf3SRQIRE4e4cI09yawgZ6GHsnrkSLdohesKo4oMgxc5sF0wv2DQN7o7mCAjBYnunQXcHmC62qhw=="
-		},
-		"@webcomponents/shadydom": {
-			"version": "github:bolt-design-system/shadydom#5ce5a74abe7fc71064d7d46a989213e6b41ede97"
-		},
-		"@webcomponents/template": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@webcomponents/template/-/template-1.1.0.tgz",
-			"integrity": "sha512-qEbLU4MXH/pjiIZc6x1YNsgJDYtbsmfJZEzS+nJRu2c4BdDvTiBSluEQ2e0hDZSn/NAtwoNzO6UWi35tEGvNYA=="
-		},
-		"@webcomponents/webcomponents-platform": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponents-platform/-/webcomponents-platform-1.0.0.tgz",
-			"integrity": "sha1-iHkUY4DdvsuGF+MiSX1Z53w/9Gg="
-		},
 		"@webcomponents/webcomponentsjs": {
-			"version": "1.0.18",
-			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.18.tgz",
-			"integrity": "sha512-F/Gn3zcJMc0FaxedKPyOKoiIQxg5p9HyDwRC1VRBvAc7+FA6oBDf39GqWsZ9nKtarsx1RslwkrHDIHLYETdIAA=="
+			"version": "1.0.22",
+			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.22.tgz",
+			"integrity": "sha512-VREMJxIe5ydR6LdMpg27ojyfL635jH03680na5X2LNLY2UF1GOzNrNOAVaEf2mr+SDUpc9Rey+gt+qCvtbCGhQ=="
 		},
 		"JSONStream": {
 			"version": "1.3.1",
@@ -34894,7 +34871,7 @@
 			"requires": {
 				"@polymer/sinonjs": "1.17.1",
 				"@polymer/test-fixture": "0.0.3",
-				"@webcomponents/webcomponentsjs": "1.0.18",
+				"@webcomponents/webcomponentsjs": "1.0.22",
 				"accessibility-developer-tools": "2.12.0",
 				"async": "1.5.2",
 				"body-parser": "1.18.2",

--- a/packages/bolt-core/package.json
+++ b/packages/bolt-core/package.json
@@ -10,12 +10,7 @@
   },
   "dependencies": {
     "@bolt/core-data": "^0.2.0-beta.0",
-    "@webcomponents/custom-elements": "^1.0.4",
-    "@webcomponents/shadycss": "^1.0.6",
-    "@webcomponents/shadydom": "bolt-design-system/shadydom#hotfix/fix-text-undefined-IE11",
-    "@webcomponents/template": "^1.1.0",
-    "@webcomponents/webcomponents-platform": "^1.0.0",
-    "@webcomponents/webcomponentsjs": "^1.0.14",
+    "@webcomponents/webcomponentsjs": "^1.0.22",
     "core-js": "^2.5.1",
     "es6-promise": "^4.1.1",
     "preact": "^8.2.5",

--- a/packages/bolt-core/polyfills/polyfill-loader.js
+++ b/packages/bolt-core/polyfills/polyfill-loader.js
@@ -2,18 +2,19 @@ require('es6-promise').polyfill();
 require('core-js/modules/es6.array.iterator');
 require('core-js/modules/es6.symbol');
 require('core-js/modules/es6.array.from');
+require('core-js/modules/es7.array.includes');
 
 export const polyfillLoader = new Promise(function (resolve, reject) {
   if (window.customElements !== undefined) {
     Promise.all([
       import(/* webpackChunkName: "custom-elements-es5-adapter" */ '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js'),
-      import(/* webpackChunkName: "wc-polyfill-sd" */ './wc-polyfill-sd')
+      import(/* webpackChunkName: "webcomponents-hi-sd-ce" */ '@webcomponents/webcomponentsjs/webcomponents-hi-sd-ce.js')
     ]).then(() => {
       resolve();
     });
   } else {
     Promise.all([
-      import(/* webpackChunkName: "wc-polyfill-ce-sd" */ './wc-polyfill-ce-sd')
+      import(/* webpackChunkName: "webcomponents-lite" */ '@webcomponents/webcomponentsjs/webcomponents-lite.js')
     ]).then(() => {
       resolve();
     });

--- a/packages/bolt/bolt-wwwd8.js
+++ b/packages/bolt/bolt-wwwd8.js
@@ -1,4 +1,9 @@
-// Temporarily disabling ratio JS on both builds -- IE11 issue being debugged
+// Temporary workaround till Pega.com D8 can compile JS locally
+// Exact same as bolt.js, minus:
+//
+// 1. Removed Sticky JS
+// 2. Removed smooth scroll JS
+// 3. Temporarily disabling ratio JS on both builds
 
 import { polyfillLoader } from '@bolt/core';
 
@@ -19,9 +24,9 @@ polyfillLoader.then(res => {
 
   import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-button' */ '@bolt/components-button/src/button.standalone');
 
-  import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-smooth-scroll' */ '@bolt/components-smooth-scroll/src/smooth-scroll');
+  // import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-smooth-scroll' */ '@bolt/components-smooth-scroll/src/smooth-scroll');
 
-  import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-sticky' */ '@bolt/components-sticky/src/sticky');
+  // import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-sticky' */ '@bolt/components-sticky/src/sticky');
 
   import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-video' */ '@bolt/components-video/src/video.standalone');
 });

--- a/packages/bolt/package.json
+++ b/packages/bolt/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "npm-run-all --parallel build:*",
-    "build:wwwd8": "./node_modules/.bin/webpack --env.production --env.cli --config ./node_modules/@bolt/build-webpack/webpack.config.cli.js bolt=./bolt --output-chunk-filename='[name]-wwwd8.min.js' --output-filename='bolt-wwwd8.min.js' --output-public-path /bolt-scripts/",
+    "build:wwwd8": "./node_modules/.bin/webpack --env.production --env.cli --config ./node_modules/@bolt/build-webpack/webpack.config.cli.js bolt=./bolt-wwwd8 --output-chunk-filename='[name]-wwwd8.min.js' --output-filename='bolt-wwwd8.min.js' --output-public-path /bolt-scripts/",
     "build:bolt": "./node_modules/.bin/webpack --env.production --env.cli --config ./node_modules/@bolt/build-webpack/webpack.config.cli.js bolt=./bolt --output-chunk-filename='[name].min.js' --output-filename='bolt.min.js' --output-public-path /dist/"
   },
   "devDependencies": {


### PR DESCRIPTION
Temporary workaround till a solution is in place that'll allow Drupal to compile JS on it's own and/or some of the more finicky components involved in sticky positioning (ie. Global Nav) are added to the Design System.

This update creates a separate standalone JS bundle for Pega.com D8 with the Bolt sticky and smooth scroll packages temporarily disabled.

Side notes (based on the diff below): 

1. The non-critical ratio object javascript component is being temporarily disabled in both the main Bolt JS bundle and the wwwd8 JS package until an existing IE11 bug is fixed. This JavaScript only handles adding additional cross-browser support to the ratio object however isn't required in order for the component to work in most situations.

2. The webcomponentjs shims updated in #259 are also included below since these are required before this particular update gets published.

CC @charginghawk @theSadowski @mikemai2awesome @christophersmith262 