### PR TITLE
Change magnify js to depend on the js- class.

### DIFF
--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-landscape-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-landscape-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "ipad",
+  "orientation": "landscape",
+  "color": "black",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--tablet.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-landscape-silver-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-landscape-silver-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "ipad",
+  "orientation": "landscape",
+  "color": "silver",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--tablet.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-portrait-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-portrait-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "ipad",
+  "orientation": "portrait",
+  "color": "black",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--tablet-portrait.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-portrait-silver-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~ipad-portrait-silver-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "ipad",
+  "orientation": "portrait",
+  "color": "silver",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--tablet-portrait.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-black-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-black-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "iphone8",
+  "orientation": "portrait",
+  "color": "black",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--phone.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-gold-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-gold-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "iphone8",
+  "orientation": "portrait",
+  "color": "gold",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--phone.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-landscape-black-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-landscape-black-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "iphone8",
+  "orientation": "landscape",
+  "color": "black",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--phone.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-landscape-gold-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-landscape-gold-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "iphone8",
+  "orientation": "landscape",
+  "color": "gold",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--phone.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-landscape-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~iphone8-landscape-magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "iphone8",
+  "orientation": "landscape",
+  "color": "white",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--phone.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~macbook-magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~macbook-magnify.json
@@ -1,0 +1,7 @@
+{
+  "device": "macbook",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--desktop.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~magnify.json
+++ b/src/_patterns/02-components/bolt-device-viewer/demo/device-viewer~magnify.json
@@ -1,0 +1,9 @@
+{
+  "device": "iphone8",
+  "orientation": "portrait",
+  "color": "white",
+  "magnify": "true",
+  "image": {
+    "src": "/images/sample/product-device-screenshot--phone.jpg"
+  }
+}

--- a/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.standalone.js
+++ b/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.standalone.js
@@ -53,7 +53,7 @@ class BoltDeviceViewer extends withComponent(withPreact()) {
     //   paneContainer: document.querySelector('p')
     // });
 
-    
+
 
     // drift.enable();
 
@@ -67,7 +67,7 @@ class BoltDeviceViewer extends withComponent(withPreact()) {
 
   connectedCallback() {
 
-    
+
     // HIDE
     // Shim Shadow DOM styles. This needs to be run in `connectedCallback()`
     // because if you shim Custom Properties (CSS variables) the element
@@ -89,7 +89,7 @@ class BoltDeviceViewer extends withComponent(withPreact()) {
     // this._upgradeProperty('checked');
     // this._upgradeProperty('disabled');
 
-    var drift = new Drift(this.querySelector('bolt-device-screen'), {
+    var drift = new Drift(this.querySelector('.js-bolt-device-viewer-screen'), {
       // inlineOffsetX: -15,
       // inlineOffsetY: -10,
       containInline: false,
@@ -151,7 +151,7 @@ class BoltDeviceViewer extends withComponent(withPreact()) {
       // touchBoundingBox: false,
     });
 
-    
+
 
     // drift.setZoomImageURL(driftZoomImageUrl);
   }

--- a/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.twig
+++ b/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.twig
@@ -47,7 +47,7 @@
       <div class="{{ baseClass ~ "__camera"}}"></div>
       <div class="{{ baseClass ~ "__speaker"}}"></div>
 
-      <bolt-device-screen class="{{ baseClass ~ "__screen"}} c-bolt-device-viewer__screen {% if magnify %} c-bolt-device-viewer__screen--magnify js-device-viewer-screen {% endif %}">
+      <bolt-device-screen class="{{ baseClass ~ "__screen"}} c-bolt-device-viewer__screen {% if magnify %} c-bolt-device-viewer__screen--magnify js-bolt-device-viewer-screen {% endif %}">
         {% if magnify %}
           {% include "@bolt/_screen-tilt.twig" %}
         {% endif %}


### PR DESCRIPTION
The key change:

```
-    var drift = new Drift(this.querySelector('bolt-device-screen'), {
+    var drift = new Drift(this.querySelector('.js-bolt-device-viewer-screen'), { 
```

Magnify was triggering for every bolt-device-screen, but I changed it work off the unused js-bolt-device-viewer-screen class.