### PR TITLE
Safari Bug Fixes for Grid System spacing and Cropped Images in Blockquote Component

### DIFF
--- a/src/_patterns/01-core/05-objects/bolt-grid-object/_objects.grid.scss
+++ b/src/_patterns/01-core/05-objects/bolt-grid-object/_objects.grid.scss
@@ -2,12 +2,17 @@
    #GRID
    ========================================================================== */
 
+/**
+ * 1. Workaround to Safari layout getting thrown off when using a negative letter-spacing to remove inline-block whitespace
+ *    @TODO: remove when v1 grid with CSS Grid support rolls out
+ * 2. Reset local font-size inheritance to prevent components w/o default font sizes from breaking
+ */
 .o-bolt-grid {
+  font-size: 0; /* stylelint-disable-line */ /* [1] */
   margin: 0;
   padding: 0;
   list-style: none;
   margin-left: bolt-spacing(medium) * -1;
-  letter-spacing: bolt-spacing(medium) * -1;
   flex: 1 1 auto; //Automatically auto fill any available space, in case a grid is nested inside of a flexbox-friendly parent container.
 }
 
@@ -15,7 +20,7 @@
   display: inline-block;
   vertical-align: top;
   padding-left: bolt-spacing(medium);
-  letter-spacing: normal;
+  font-size: 1rem; /* stylelint-disable-line */ /* [2] */
 }
 
 

--- a/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
+++ b/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
@@ -126,9 +126,16 @@ bolt-blockquote {
 }
 
 
+/**
+ * 1. Workaround to address weird Safari bug w/ overflow + border radius
+ *    https://gist.github.com/adamcbrewer/5859738#gistcomment-2008691
+ */
+
 // Attribution
 .c-bolt-blockquote__image {
   display: inline-block;
+  position: relative; /* [1] */
+  z-index: 1; /* [1] */
   width: $bolt-blockquote-image-size;
   height: $bolt-blockquote-image-size;
   border-width: $bolt-blockquote-image-border-width;

--- a/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
+++ b/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
@@ -134,7 +134,7 @@ bolt-blockquote {
   border-width: $bolt-blockquote-image-border-width;
   border-style: $bolt-blockquote-image-border-style;
   border-color: $bolt-blockquote-image-border-color;
-  border-radius: 100em;
+  border-radius: 50%;
   overflow: hidden;
 }
 

--- a/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
+++ b/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
@@ -75,10 +75,11 @@ bolt-blockquote {
 .c-bolt-blockquote {
   @include bolt-margin(0);
 
-  &:before, &:after {
+  &:before,
+  &:after {
     width: 100%;
-    max-width: 300px;
     height: $bolt-blockquote-border-width;
+    max-width: 300px;
     content: '';
     vertical-align: top;
     background-color: $bolt-blockquote-border-color;
@@ -110,7 +111,8 @@ bolt-blockquote {
   color: inherit;
   color: var(--bolt-theme-heading, inherit);
 
-  p:first-child:before, p:last-child:after {
+  p:first-child:before,
+  p:last-child:after {
     font-family: 'Georgia', serif; // TODO: Replace with Noto Serif when it is added.
   }
 

--- a/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
+++ b/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
@@ -75,10 +75,11 @@ bolt-blockquote {
 .c-bolt-blockquote {
   @include bolt-margin(0);
 
-  &:before, &:after {
+  &:before,
+  &:after {
     width: 100%;
-    max-width: 300px;
     height: $bolt-blockquote-border-width;
+    max-width: 300px;
     content: '';
     vertical-align: top;
     background-color: $bolt-blockquote-border-color;
@@ -110,7 +111,8 @@ bolt-blockquote {
   color: inherit;
   color: var(--bolt-theme-heading, inherit);
 
-  p:first-child:before, p:last-child:after {
+  p:first-child:before,
+  p:last-child:after {
     font-family: 'Georgia', serif; // TODO: Replace with Noto Serif when it is added.
   }
 
@@ -124,15 +126,22 @@ bolt-blockquote {
 }
 
 
+/**
+ * 1. Workaround to address weird Safari bug w/ overflow + border radius
+ *    https://gist.github.com/adamcbrewer/5859738#gistcomment-2008691
+ */
+
 // Attribution
 .c-bolt-blockquote__image {
   display: inline-block;
+  position: relative; /* [1] */
+  z-index: 1; /* [1] */
   width: $bolt-blockquote-image-size;
   height: $bolt-blockquote-image-size;
   border-width: $bolt-blockquote-image-border-width;
   border-style: $bolt-blockquote-image-border-style;
   border-color: $bolt-blockquote-image-border-color;
-  border-radius: 100em;
+  border-radius: 50%;
   overflow: hidden;
 }
 

--- a/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
+++ b/src/_patterns/02-components/bolt-blockquote/src/blockquote.scss
@@ -75,11 +75,10 @@ bolt-blockquote {
 .c-bolt-blockquote {
   @include bolt-margin(0);
 
-  &:before,
-  &:after {
+  &:before, &:after {
     width: 100%;
-    height: $bolt-blockquote-border-width;
     max-width: 300px;
+    height: $bolt-blockquote-border-width;
     content: '';
     vertical-align: top;
     background-color: $bolt-blockquote-border-color;
@@ -111,8 +110,7 @@ bolt-blockquote {
   color: inherit;
   color: var(--bolt-theme-heading, inherit);
 
-  p:first-child:before,
-  p:last-child:after {
+  p:first-child:before, p:last-child:after {
     font-family: 'Georgia', serif; // TODO: Replace with Noto Serif when it is added.
   }
 
@@ -126,22 +124,15 @@ bolt-blockquote {
 }
 
 
-/**
- * 1. Workaround to address weird Safari bug w/ overflow + border radius
- *    https://gist.github.com/adamcbrewer/5859738#gistcomment-2008691
- */
-
 // Attribution
 .c-bolt-blockquote__image {
   display: inline-block;
-  position: relative; /* [1] */
-  z-index: 1; /* [1] */
   width: $bolt-blockquote-image-size;
   height: $bolt-blockquote-image-size;
   border-width: $bolt-blockquote-image-border-width;
   border-style: $bolt-blockquote-image-border-style;
   border-color: $bolt-blockquote-image-border-color;
-  border-radius: 50%;
+  border-radius: 100em;
   overflow: hidden;
 }
 


### PR DESCRIPTION
1. Fixes issue mentioned in [BK-104](http://vjira2:8080/browse/BK-104) - spacing in the grid system on Safari being off due to cross browser differences in how the inline-block spacing workarounds are getting calculated. Switches us over to using the font-size: 0; workaround which appears to be working much more consistently 

Note: this adds a default 1rem font size rule to prevent issues w/ nested expecting font sizes to be inherited (ie. font size isn't defined on the nested component itself).

2. Also includes a separate Safari browser quirk w/ overflowing content via border-radius not getting cropped off as expected. Apparently setting position relative + a z-index does the trick!