### PR TITLE
Update Webpack Config to Include Sourcemaps, Strip Console Logs in Production

### DIFF
--- a/build-tools/gulp-tasks/build-webpack/webpack.config.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.js
@@ -41,7 +41,7 @@ const defaultConfig = {
     chunkFilename: `[name]-chunk.min.js`,
     libraryTarget: 'umd'
   },
-  devtool: 'cheap-module-source-map',
+  devtool: 'cheap-module-eval-source-map',
   // devtool: 'cheap-source-map',
   resolve: {
     // Help webpack find local Bolt code in the src folder

--- a/build-tools/gulp-tasks/build-webpack/webpack.config.release.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.release.js
@@ -37,33 +37,38 @@ module.exports = (options) => {
   // const ExtractTextPlugin = require('extract-text-webpack-plugin');
   // // const outputPath = isDev ? resolve('src') : resolve('dist');
   // const WorkboxPlugin = require('workbox-webpack-plugin');
-  
+
   const commonConfig = require('./webpack.config');
   const releaseConfig = Object.create(commonConfig({
-    devtool: 'sourcemap'
+    devtool: 'cheap-module-eval-source-map'
   }));
-  
 
-  releaseConfig.plugins = releaseConfig.plugins.concat(
-    new CleanWebpackPlugin([!process.env.cli && releaseConfig.output.path ? releaseConfig.output.path : ''], {
-      verbose: true,
-      root: process.cwd() // set root context to wherever webpack is getting run (globally or at the component level)
-    }),
-    new webpack.DefinePlugin({
+
+  releaseConfig.plugins = releaseConfig.plugins.concat(new CleanWebpackPlugin(
+      [
+        !process.env.cli && releaseConfig.output.path
+          ? releaseConfig.output.path
+          : ''
+      ],
+      {
+        verbose: true,
+        root: process.cwd() // set root context to wherever webpack is getting run (globally or at the component level)
+      }
+    ), new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"'
-    }),
-    new ExtractTextPlugin({
+    }), new ExtractTextPlugin({
       filename: '[name].min.css?[hash]-[chunkhash]-[contenthash]-[name]',
       disable: false,
       allChunks: true
-    }),
-    new webpack.NoEmitOnErrorsPlugin(),
-    new UglifyJSPlugin(),
-    new webpack.LoaderOptionsPlugin({
-      minimize: true,
-      debug: false
-    })
-  );
+    }), new webpack.NoEmitOnErrorsPlugin(), new UglifyJSPlugin(), new webpack.LoaderOptionsPlugin(
+      {
+        minimize: true,
+        debug: false,
+        compress: {
+          drop_console: true
+        }
+      }
+    ));
 
   releaseConfig.performance = {
     maxAssetSize: 250000,


### PR DESCRIPTION
1. Including sourcemaps in the production JS build should help at least help some of the pains in #247 for the short term (ie. inspecting minified JS from the console should be at least a tad better with this)

2. Enabling Config option w/ UglifyJS to strip out stray console.logs in production build. Addresses issue brought up in [BK-85](http://vjira2:8080/browse/BK-85)

CC @charginghawk 

