### PR TITLE
Fix Headline Text Alignment + Allow Alignment via Text Align Utility Class

### DIFF
--- a/src/_patterns/02-components/bolt-headline/src/_tools.headlines.scss
+++ b/src/_patterns/02-components/bolt-headline/src/_tools.headlines.scss
@@ -9,19 +9,11 @@
   color: inherit;
   color: var(--bolt-theme-heading, inherit);
 
-  @supports (display: flex) {
-    display: flex;
-    align-items: center;
-  }
 
   &:last-child {
     @include bolt-margin-bottom(0);
   }
 
-  /* stylelint-disable-next-line */
-  > * {
-    align-self: center;
-  }
 
   // Headline + Icon and/or Icon + Headline Spacing
   &__text ~ &__icon,

--- a/src/_patterns/02-components/bolt-headline/src/_typography.twig
+++ b/src/_patterns/02-components/bolt-headline/src/_typography.twig
@@ -24,7 +24,7 @@
 {% set _defaultStyle = "normal" %}
 {% set _defaultType = "text" %}
 {% set _defaultSize = "medium" %}
-{% set _defaultAlignment = "left" %}
+{% set _defaultAlignment = "" %}
 
 
 {% if tags != "any" %}
@@ -52,7 +52,7 @@
   baseClass,
   quoted ? baseClass ~ "--" ~ "quoted" : "",
   weight in weights ? baseClass ~ "--" ~ weight : "",
-  align ? baseClass ~ "--" ~ align : "",
+  align and align != "" ? baseClass ~ "--" ~ align : "",
   style in styles and type == "text" ? baseClass ~ "--" ~ style : "",
   size in sizes and type != "eyebrow" ? baseClass ~ "--" ~ size : "",
   transform in transformProps and transform != "" ? baseClass ~ "--" ~ transform : "",


### PR DESCRIPTION
- Remove auto-selecting selecting a text alignment option from the headline component by default so that the component can inherit text alignment (ex. by a utility class)

- Remove display: flex from headline to fix utility class text align behavior (@todo: re-evaluate when we add nested icons -- we might need to adjust based on vertical alignment behavior CC @mikemai2awesome @theSadowski)