### PR TITLE
Refactor Ratio Object + Improve Cross Browser Support

### DIFF
--- a/packages/bolt/bolt-wwwd8.js
+++ b/packages/bolt/bolt-wwwd8.js
@@ -8,7 +8,7 @@
 import { polyfillLoader } from '@bolt/core';
 
 polyfillLoader.then(res => {
-  // import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
+  import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
 
   import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-device-viewer' */ '@bolt/components-device-viewer/src/device-viewer.standalone');
 

--- a/packages/bolt/bolt.js
+++ b/packages/bolt/bolt.js
@@ -3,7 +3,7 @@
 import { polyfillLoader } from '@bolt/core';
 
 polyfillLoader.then(res => {
-  // import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
+  import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
 
   import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-device-viewer' */ '@bolt/components-device-viewer/src/device-viewer.standalone');
 

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.scss
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.scss
@@ -2,28 +2,32 @@
    #BOLT RATIO OBJECT
    ========================================================================== */
 
+bolt-ratio {
+  display: inline-block;
+  position: relative;
+  width: 100%;
 
-bolt-ratio,
-:host {
   --aspect-ratio-width: 1;
   --aspect-ratio-height: 1;
-  position: relative;
-  display: inline-block;
-  width: 100%;
 
   @supports (--custom:property) {
     padding-top: calc( var(--aspect-ratio-height, 1) / var(--aspect-ratio-width, 1) * 100%);
   }
-
-  > * {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    min-width: 100%; // workaround for content w/ hard-coded height & width 
-    min-height: 100%; // workaround for content w/ hard-coded height & width
-  }
 }
 
 
+/**
+  * 1. Fallback selector if JS isn't disabled, but hasn't kicked in yet.
+  * 2. Fallback selector for browsers not supporting ::slotted(*) selector
+  */
+bolt-ratio > *, /* [1] */
+.o-bolt-ratio__inner, /* [2] */
+.o-bolt-ratio__inner ::slotted(*) {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  min-width: 100%; // workaround for content w/ hard-coded height & width
+  min-height: 100%; // workaround for content w/ hard-coded height & width
+}

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.scss
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.scss
@@ -1,18 +1,6 @@
-/**
-  * @define o-bolt-ratio
-  */
-
 /* ==========================================================================
    #BOLT RATIO OBJECT
    ========================================================================== */
-// bolt-ratio {
-//   display: inline;
-// }
-
-// :host {
-//   display: inline-block;
-//   overflow: hidden;
-// }
 
 
 bolt-ratio,
@@ -38,34 +26,4 @@ bolt-ratio,
   }
 }
 
-// @mixin bolt-aspect-ratio($width, $height) {
-//   padding-bottom: ($height / $width) * 100%;
-// }
 
-// .o-bolt-ratio--16x9:after {
-//   @include bolt-aspect-ratio(16,9);
-// }
-
-// .o-bolt-ratio--2x1:after {
-//   @include bolt-aspect-ratio(16,8);
-// }
-
-// .o-bolt-ratio--16x7:after {
-//   @include bolt-aspect-ratio(16,7);
-// }
-
-// .o-bolt-ratio--20x9:after {
-//   @include bolt-aspect-ratio(20,9);
-// }
-
-// .o-bolt-ratio--1x1:after {
-//   @include bolt-aspect-ratio(1,1);
-// }
-
-// .o-bolt-ratio--3x4:after {
-//   @include bolt-aspect-ratio(3,4);
-// }
-
-// .o-bolt-ratio--4x3:after {
-//   @include bolt-aspect-ratio(4,3);
-// }

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
@@ -25,25 +25,11 @@ export class BoltRatio extends withComponent(withPreact()) {
     super();
     this.supportsCSSVars = window.CSS.supports('--fake-var', 0);
   }
-
-  // get renderRoot() {
-  //   return this;
-  // }
-
   // Called when props have been set regardless of if they've changed.
   updating(props) {
     this._computeRatio();
   }
 
-  // Called to check whether or not the component should call
-  // updated(), much like React's shouldComponentUpdate().
-  // shouldUpdate(props, state) {
-  //   return true;
-  // }
-
-  // // Called if shouldUpdate returned true.
-  // updated() {
-    
   /**
    * sets the style so that the height is based on a ratio of width to height
    * @param {Number} aspH - the height component of the ratio
@@ -71,12 +57,6 @@ export class BoltRatio extends withComponent(withPreact()) {
     );
 
     return (
-      // <div className={classes}>
-        <slot>
-          <style>{styles[0][1]}</style>
-
-        </slot>
-      // </div>
     )
   }
 }

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
@@ -67,7 +67,7 @@ export class BoltRatio extends withComponent(withPreact()) {
 
   render() {
     const classes = css(
-      'o-bolt-ratio__content'
+      'o-bolt-ratio__inner'
     );
 
     return (

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
@@ -23,11 +23,7 @@ export class BoltRatio extends withComponent(withPreact()) {
 
   constructor(){
     super();
-    this.supportsCSSVars = window.CSS.supports('--fake-var', 0);
-  }
-  // Called when props have been set regardless of if they've changed.
-  updating(props) {
-    this._computeRatio();
+    this.supportsCSSVars = window.CSS && CSS.supports('color', 'var(--primary)');
   }
 
   /**
@@ -42,8 +38,11 @@ export class BoltRatio extends withComponent(withPreact()) {
     if (this.supportsCSSVars){
       this.style.setProperty(`--aspect-ratio-height`, h);
       this.style.setProperty(`--aspect-ratio-width`, w);
+      this.style.paddingTop = '';
     } else {
       this.style.paddingTop = (100 * h / w) + "%";
+      this.style.removeProperty('--aspect-ratio-height');
+      this.style.removeProperty('--aspect-ratio-width');
     }
   }
 

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.twig
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.twig
@@ -1,9 +1,12 @@
 {% set classes = [
-  "o-bolt-ratio"
+
 ] %}
 
 {% set attributes = create_attribute(attributes | default({})) %}
 
+
+{% set aspectRatioHeight = aspectRatioHeight ? aspectRatioHeight : "1" %}
+{% set aspectRatioWidth = aspectRatioWidth ? aspectRatioWidth : "1" %}
 
 {% if aspectRatioHeight and aspectRatioWidth %}
   {% set attributes = attributes.addClass(classes) %}
@@ -15,6 +18,13 @@
     "--aspect-ratio-height: " ~ aspectRatioHeight ~ ";",
     "--aspect-ratio-width: " ~ aspectRatioWidth ~ ";"
   ]) %}
+
+  {# set attributes = attributes.setAttribute("style", [
+    "--aspect-ratio-height: " ~ aspectRatioHeight ~ ";",
+    "--aspect-ratio-width: " ~ aspectRatioWidth ~ ";",
+    "padding-top: " ~ (aspectRatioHeight / aspectRatioWidth * 100) ~ "%;",
+    "padding-top: calc( var(--aspect-ratio-height," ~ aspectRatioHeight ~ ") / var(--aspect-ratio-width," ~  aspectRatioWidth ~ ") * 100%);"
+  ]) #}
 {% endif %}
 
 <bolt-ratio {{ attributes }}>

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.twig
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.twig
@@ -18,13 +18,6 @@
     "--aspect-ratio-height: " ~ aspectRatioHeight ~ ";",
     "--aspect-ratio-width: " ~ aspectRatioWidth ~ ";"
   ]) %}
-
-  {# set attributes = attributes.setAttribute("style", [
-    "--aspect-ratio-height: " ~ aspectRatioHeight ~ ";",
-    "--aspect-ratio-width: " ~ aspectRatioWidth ~ ";",
-    "padding-top: " ~ (aspectRatioHeight / aspectRatioWidth * 100) ~ "%;",
-    "padding-top: calc( var(--aspect-ratio-height," ~ aspectRatioHeight ~ ") / var(--aspect-ratio-width," ~  aspectRatioWidth ~ ") * 100%);"
-  ]) #}
 {% endif %}
 
 <bolt-ratio {{ attributes }}>

--- a/src/_patterns/02-components/bolt-image/src/image.twig
+++ b/src/_patterns/02-components/bolt-image/src/image.twig
@@ -94,11 +94,6 @@
   {% endif %}
 
 {% set attributes = create_attribute(attributes | default({})).addClass('c-bolt-image') %}
-{% set styles = attributes.getAttribute('style') | split(' ') | merge([
-  "padding-top: #{ratio};"
-]) %}
-{% set attributes = attributes.setAttribute('style', styles | join(' ')) %}
-
 
 {% set imageAttributes = create_attribute(imageAttributes | default({})).addClass([
     "c-bolt-image__img",
@@ -147,9 +142,11 @@
 {% endset %}
 <bolt-image>
   {% block image_content %}
-    {% if ratio == true %}
+    {% if width > 0 and height > 0 and ratio == true %}
       {% embed "@bolt/ratio.twig" with {
-        attributes: attributes
+        attributes: attributes,
+        aspectRatioHeight: height * 1,
+        aspectRatioWidth: width * 1
       } %}
         {% block ratio_content %}
           {{ ext == "jpg" ? imagePlaceholder : "" }}


### PR DESCRIPTION
- Re-enabled including the ratio object JavaScript in the Bolt and Pega.com D8 JS bundles

- Simplifies and cleans up the ratio object Sass partial

- Fixes some gaps in the original JS logic + significantly improves cross browser support in browsers that don't fully support Shadow Dom (ie. IE 11) -- now visually much more consistant across the board!

- Adds new `aspectRatioHeight` and `aspectRatioWidth` parameters that can get passed into the ratio object for configuring the dimensions directly (which the original didn't have) -- updates the Image component to now take advantage of this these new params

CC @theSadowski @EvanLovely @mikemai2awesome 