### PR TITLE
Fix Flag Object Vertical Alignment 

### DIFF
--- a/src/_patterns/02-components/bolt-figure/src/_figure.scss
+++ b/src/_patterns/02-components/bolt-figure/src/_figure.scss
@@ -9,3 +9,12 @@
 /* ------------------------------------ *\
    Figure
 \* ------------------------------------ */
+
+/**
+  * 1. Change the default custom element layout from inline to block to fix an IE 11 layout
+  *  issue with the vertical alignment of the flag object's `figure` not being vertically
+  *  aligned as expected (internally the flag object uses a nested figure)
+  */
+bolt-figure {
+  display: block; /* [1] */
+}

--- a/src/_patterns/02-components/components-all/components-all.scss
+++ b/src/_patterns/02-components/components-all/components-all.scss
@@ -15,6 +15,7 @@
 @import '@bolt/components-color-swatch';
 @import '@bolt/components-device-viewer';
 // @import '@bolt/components-video';
+@import '@bolt/components-figure';
 @import '@bolt/components-headline';
 @import '@bolt/components-image';
 @import '@bolt/components-icon';

--- a/src/_patterns/02-components/components-all/package.json
+++ b/src/_patterns/02-components/components-all/package.json
@@ -45,6 +45,7 @@
     "@bolt/components-button-group": "^0.3.0-beta.0",
     "@bolt/components-card": "^0.6.0-beta.3",
     "@bolt/components-chip": "^0.3.0-beta.0",
+    "@bolt/components-figure": "^0.2.0-beta.0",
     "@bolt/components-chip-list": "^0.3.0-beta.0",
     "@bolt/components-color-swatch": "^0.5.0",
     "@bolt/components-critical-fonts": "^0.5.0-beta.3",


### PR DESCRIPTION
Update the figure component's <custom-element> default layout from inline (inherited default) to block to fix an IE 11 rendering issue when being vertically aligned via flexbox (aka. fixes vertical alignment inside of the flag object because of this)