### PR TITLE
Fix Grid Layout Flex Behavior + Maintain Equal Height Cards

### DIFF
--- a/src/_patterns/01-core/05-objects/bolt-grid-object/_objects.grid.scss
+++ b/src/_patterns/01-core/05-objects/bolt-grid-object/_objects.grid.scss
@@ -176,10 +176,6 @@
   display: flex;
   flex-flow: row wrap;
 
-  > .o-bolt-grid__cell {
-    display: flex;
-    flex-direction: column;
-  }
 }
 
 

--- a/src/_patterns/02-components/bolt-card/src/card.scss
+++ b/src/_patterns/02-components/bolt-card/src/card.scss
@@ -35,8 +35,7 @@ $bolt-card-translate--active: $bolt-translate-raised--medium;
 
 bolt-card {
   display: flex;
-  flex-grow: 1; // If used in a flex box container, grow to fill available space.
-  height: 100%; // Alternative, try to fill vertical space if available, even if parent's isn't display: flex;
+  height: 100%; // Try to fill vertical space if available, even if parent's isn't display: flex;
 }
 
 .c-bolt-card {

--- a/src/_patterns/02-components/bolt-card/src/card.scss
+++ b/src/_patterns/02-components/bolt-card/src/card.scss
@@ -35,7 +35,8 @@ $bolt-card-translate--active: $bolt-translate-raised--medium;
 
 bolt-card {
   display: flex;
-  flex-grow: 1; //If used in a flex box container, grow to fill available space.
+  flex-grow: 1; // If used in a flex box container, grow to fill available space.
+  height: 100%; // Alternative, try to fill vertical space if available, even if parent's isn't display: flex;
 }
 
 .c-bolt-card {


### PR DESCRIPTION
- Removes automatically making the children of a "flex grid" to also be set to display flex as well. This fixes an unreported issue where misc components like buttons are stretched horizontally

Before:
![image](https://user-images.githubusercontent.com/1617209/34424227-0b4a3f82-ebf0-11e7-9246-967efc2d7672.png)

After:
![image](https://user-images.githubusercontent.com/1617209/34424239-1a3c6cd6-ebf0-11e7-900a-6b55156b4a15.png)

- Updates the card component to still allow for equal column layouts when used with the grid system set to "flex"

CC @theSadowski 