### PR TITLE
Chore: Remove Non-Existant Image References in Placeholder Page Header Component

### DIFF
--- a/src/_patterns/02-components/bolt-page-header/src/_page-header.scss
+++ b/src/_patterns/02-components/bolt-page-header/src/_page-header.scss
@@ -426,13 +426,11 @@
 
 @media screen and (max-width:999px) {
   .has-children > .c-mega-nav__link {
-    background: url(/themes/custom/pegawww_theme/images/icons/right-chevron.colored.svg) right 1rem center no-repeat;
     background-size: 10px;
   }
 
   .go-back .c-mega-nav__link {
     text-align: center;
-    background: url(/themes/custom/pegawww_theme/images/icons/arrow-left.colored.svg) left 1rem center no-repeat;
     font-weight: bold;
   }
 


### PR DESCRIPTION
Remove none-existent image references from the placeholder page-header component - begone 404 errors!