### PR TITLE
More Consistant UI List Border Rendering

### DIFF
--- a/src/_patterns/01-core/05-objects/bolt-ui-list-object/src/ui-list.scss
+++ b/src/_patterns/01-core/05-objects/bolt-ui-list-object/src/ui-list.scss
@@ -26,6 +26,10 @@ $bolt-ui-list-border-color: var(--bolt-theme-border, currentColor);
   list-style: none;
 }
 
+/**
+  * 1. Workaround to force browser hardware acceleration and avoid sub-pixel rendering issues.
+  *    Without this, borders sometimes disappear in IE11 when viewing in Patternlab
+  */
 .o-bolt-ui-list__item {
   position: relative;
 
@@ -39,8 +43,8 @@ $bolt-ui-list-border-color: var(--bolt-theme-border, currentColor);
     right: 0;
     bottom: 0;
     left: 0;
-
     opacity: $bolt-global-border-opacity;
+    transform: translate3d(0, 0, 0); /* [1] */
 
     @supports(--css: variables) {
       opacity: 1; // Remove fallback opacity and let theme decide.


### PR DESCRIPTION
Force hardware accelerated rendering of the UI list border (via CSS 3d transform trick) to significantly improve rendering consistently -- especially inside of Pattern Lab's iframe viewer.

Before half the time only some of the UI List borders would show up inside of PL but would always be visible outside of it -- now it just works!

Inconsistent Rendering in IE11 inside of Pattern Lab (Before) -- **Broken**
![image](https://user-images.githubusercontent.com/1617209/34424424-65080b48-ebf1-11e7-9e37-b10749439827.png)

When Viewed Outside of Iframe Viewer in IE11:
![image](https://user-images.githubusercontent.com/1617209/34424445-b1069078-ebf1-11e7-83c8-4f105668b7b7.png)

Now with this 3d Transform Rendering Hack in Pattern Lab (After):
![image](https://user-images.githubusercontent.com/1617209/34424441-97067580-ebf1-11e7-8c71-9dfeee6218b8.png)


CC @EvanLovely - thought you'd get a kick out of this one ;)