### PR TITLE
Chore: Very Minor Cleanup of <bolt-band-collection> JavaScript

### DIFF
--- a/src/_patterns/02-components/bolt-band/src/band-collection.standalone.js
+++ b/src/_patterns/02-components/bolt-band/src/band-collection.standalone.js
@@ -24,7 +24,7 @@ bandCollectionTemplate.innerHTML = `
 ShadyCSS.prepareTemplate(bandCollectionTemplate, 'bolt-band-collection');
   // /HIDE
 
-  
+
 
 @define
 export class BoltBandCollection extends withComponent(withPreact()) {
@@ -107,7 +107,7 @@ export class BoltBandCollection extends withComponent(withPreact()) {
       } else {
         initialHeight = band.getBoundingClientRect().height;
       }
-      
+
       if (band.expandedHeight){
         expandedHeight = band.expandedHeight;
       } else {
@@ -261,10 +261,9 @@ export class BoltBandCollection extends withComponent(withPreact()) {
   }
 
 
-  
+
 
   connectedCallback() {
-
     // HIDE
     // Shim Shadow DOM styles. This needs to be run in `connectedCallback()`
     // because if you shim Custom Properties (CSS variables) the element

--- a/src/_patterns/02-components/bolt-band/src/band-collection.standalone.js
+++ b/src/_patterns/02-components/bolt-band/src/band-collection.standalone.js
@@ -264,7 +264,6 @@ export class BoltBandCollection extends withComponent(withPreact()) {
   
 
   connectedCallback() {
-    console.log('band collection connected callback');
 
     // HIDE
     // Shim Shadow DOM styles. This needs to be run in `connectedCallback()`


### PR DESCRIPTION
1. Remove stray console.log
2. Automatically fix whitespace issues. How'd those tabs get there!? ;)