### PR TITLE
Feature: Enable Webpack Hot Module Replacement (HMR)

### DIFF
--- a/build-tools/gulp-tasks/build-webpack/package.json
+++ b/build-tools/gulp-tasks/build-webpack/package.json
@@ -55,9 +55,9 @@
 		"style-loader": "^0.18.2",
 		"typescript": "^2.5.3",
 		"uglifyjs-webpack-plugin": "1.0.0",
-		"webpack": "^3.8.1",
+		"webpack": "^3.10.0",
 		"webpack-concat-plugin": "^1.4.1",
-		"webpack-dev-server": "^2.9.1",
+		"webpack-dev-server": "^2.9.7",
 		"webpack-manifest-plugin": "^1.3.2"
 	},
 	"devDependencies": {

--- a/build-tools/gulp-tasks/build-webpack/webpack.config.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.js
@@ -221,7 +221,7 @@ const defaultConfig = {
       errors: true
     },
     host: '0.0.0.0',
-    disableHostCheck: true
+    disableHostCheck: true,
     hot: true,
     inline: true,
     watchContentBase: true,

--- a/build-tools/gulp-tasks/build-webpack/webpack.config.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.js
@@ -184,6 +184,7 @@ const defaultConfig = {
     maxEntrypointSize: 1500000
   },
   plugins: [
+    new webpack.HotModuleReplacementPlugin(),
     new CommonsChunkPlugin({
       deepChildren: true,
       children: true,
@@ -221,6 +222,13 @@ const defaultConfig = {
     port: 3000,
     host: '0.0.0.0',
     disableHostCheck: true
+    hot: true,
+    inline: true,
+    watchContentBase: true,
+    watchOptions: {
+      aggregateTimeout: 500,
+      ignored: /(annotations|fonts|node_modules|styleguide|images|fonts|assets)/
+    }
   }
 };
 

--- a/build-tools/gulp-tasks/build-webpack/webpack.config.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.js
@@ -53,7 +53,7 @@ const defaultConfig = {
     rules: [
       {
         test: /\.js$/,
-        exclude: /(node_modules\/@skatejs\/renderer-lit-html\/dist\/node\/index\.js|native-shim\.js|node_modules\/\@webcomponents\/webcomponentsjs\/custom-elements-es5-adapter\.js|\@webcomponents\/webcomponentsjs\/custom-elements-es5-adapter\.js|custom-elements-es5-adapter\.js|bower_components)/,
+        exclude: /(node_modules\/\@webcomponents\/webcomponentsjs\/custom-elements-es5-adapter\.js)/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/build-tools/gulp-tasks/build-webpack/webpack.config.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.js
@@ -214,7 +214,7 @@ const defaultConfig = {
     })
   ],
   devServer: {
-    contentBase: path.resolve(outputPath),
+    contentBase: path.resolve('./dist'),
     compress: true,
     port: 8080,
     overlay: {

--- a/build-tools/gulp-tasks/build-webpack/webpack.config.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.js
@@ -216,10 +216,10 @@ const defaultConfig = {
   devServer: {
     contentBase: path.resolve(outputPath),
     compress: true,
+    port: 8080,
     overlay: {
       errors: true
     },
-    port: 3000,
     host: '0.0.0.0',
     disableHostCheck: true
     hot: true,

--- a/package.json
+++ b/package.json
@@ -181,8 +181,6 @@
     "validate-commit-msg": "^2.12.2",
     "web-component-refs": "^0.0.2",
     "web-component-tester": "^6.3.0",
-    "webpack": "^3.8.1",
-    "webpack-dev-server": "^2.9.1",
     "webpack-manifest-plugin": "^1.3.2",
     "workbox-webpack-plugin": "^2.1.0",
     "xo": "^0.18.2"


### PR DESCRIPTION
TLDR: Updates leading us to a much faster, much less painful local front-end dev environment :)

- Switch on Webpack's awesome HMR feature in prep of even more substantial build tool upgrades in flight
- Update Webpack Dev Server rules to automatically reload the page whenever Pattern Lab finishes compiling AND not cause multiple page refreshes in the progress
- Remove old regex in the babel-loader config exclude rules which aren't getting used and no longer apply
- Update Webpack Dev Server to another port to avoid conflicts with current BrowserSync server setup