### PR TITLE
Fix: Update the Flag Object's CSS to use longhand flexbox rules.

### DIFF
--- a/src/_patterns/01-core/05-objects/bolt-flag-object/src/flag.scss
+++ b/src/_patterns/01-core/05-objects/bolt-flag-object/src/flag.scss
@@ -24,7 +24,9 @@ $bolt-flag-alignments: (
 }
 
 .o-bolt-flag__body {
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
 }
 
 


### PR DESCRIPTION
Proactively this approach helps reduce encountering one of the most frequently seen flexbox gotchas / browser quirks in IE10 and IE11.

https://github.com/philipwalton/flexbugs#flexbug-6