### PR TITLE
Hotfix: Address Unexpected JS Errors, Ratio Object Issue in IE11

### DIFF
--- a/build-tools/gulp-tasks/build-webpack/webpack.config.release.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.release.js
@@ -40,11 +40,12 @@ module.exports = (options) => {
 
   const commonConfig = require('./webpack.config');
   const releaseConfig = Object.create(commonConfig({
-    devtool: 'cheap-module-eval-source-map'
+    devtool: 'source-map'
   }));
 
 
-  releaseConfig.plugins = releaseConfig.plugins.concat(new CleanWebpackPlugin(
+  releaseConfig.plugins = releaseConfig.plugins.concat(
+    new CleanWebpackPlugin(
       [
         !process.env.cli && releaseConfig.output.path
           ? releaseConfig.output.path
@@ -54,19 +55,19 @@ module.exports = (options) => {
         verbose: true,
         root: process.cwd() // set root context to wherever webpack is getting run (globally or at the component level)
       }
-    ), new webpack.DefinePlugin({
+    ),
+    new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"'
-    }), new ExtractTextPlugin({
+    }),
+    new ExtractTextPlugin({
       filename: '[name].min.css?[hash]-[chunkhash]-[contenthash]-[name]',
       disable: false,
       allChunks: true
-    }), new webpack.NoEmitOnErrorsPlugin(), new UglifyJSPlugin(), new webpack.LoaderOptionsPlugin(
+    }),
+    new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.LoaderOptionsPlugin(
       {
-        minimize: true,
-        debug: false,
-        compress: {
-          drop_console: true
-        }
+        minimize: true
       }
     ));
 

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.scss
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.scss
@@ -20,8 +20,17 @@ bolt-ratio {
   * 1. Fallback selector if JS isn't disabled, but hasn't kicked in yet.
   * 2. Fallback selector for browsers not supporting ::slotted(*) selector
   */
-bolt-ratio > *, /* [1] */
-.o-bolt-ratio__inner, /* [2] */
+bolt-ratio > *,
+.o-bolt-ratio__inner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  min-width: 100%; // workaround for content w/ hard-coded height & width
+  min-height: 100%; // workaround for content w/ hard-coded height & width
+}
+
 .o-bolt-ratio__inner ::slotted(*) {
   position: absolute;
   top: 0;


### PR DESCRIPTION
- Temporarily disable UglifyJS's mangle option after encountered an unexpected JS error in testing prior to release

- CSS workaround to address layout issue in IE11 with ratio object -- temp solution till problem further looked into (basically the ShadyCSS polyfill randomly stopped working after getting it to work yesterday - therefore the selector for getting the ratio object's contents positioned isn't working at all, ShadyCSS or not.... bizarre)