### PR TITLE
Re-enable Uglify on Webpack Production Build

### DIFF
--- a/build-tools/gulp-tasks/build-webpack/webpack.config.release.js
+++ b/build-tools/gulp-tasks/build-webpack/webpack.config.release.js
@@ -65,6 +65,8 @@ module.exports = (options) => {
       allChunks: true
     }),
     new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.optimize.ModuleConcatenationPlugin(),
+    new UglifyJSPlugin(),
     new webpack.LoaderOptionsPlugin(
       {
         minimize: true


### PR DESCRIPTION
Addresses previous regression w/ production output not being minified as expected