### PR TITLE
Upgrade Babel Config, Remove Plugins No Longer Needed

### DIFF
--- a/build-tools/gulp-tasks/build-webpack/package.json
+++ b/build-tools/gulp-tasks/build-webpack/package.json
@@ -23,7 +23,7 @@
 	],
 	"dependencies": {
 		"awesome-typescript-loader": "^3.2.3",
-		"babel-loader": "^7.1.2",
+		"babel-loader": "^8.0.0-beta.0",
 		"clean-css-loader": "^0.1.3",
 		"clean-webpack-plugin": "^0.1.17",
 		"copy-webpack-plugin": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,72 +2,95 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
-			"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+		"@babel/core": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.36.tgz",
+			"integrity": "sha512-r3oSIr0RVHtIvIXO4nWOX1Bya7+9XO9pHNRllPYP3pM9VreEvnaV5/qd3p0crx3X6F3qXZLZekAhPEN9Fsu6ag==",
 			"requires": {
-				"chalk": "2.0.1",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
-			}
-		},
-		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
-			"integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
-			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.31",
-				"@babel/template": "7.0.0-beta.31",
-				"@babel/traverse": "7.0.0-beta.31",
-				"@babel/types": "7.0.0-beta.31"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
-			"integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
-			"requires": {
-				"@babel/types": "7.0.0-beta.31"
-			}
-		},
-		"@babel/template": {
-			"version": "7.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
-			"integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.31",
-				"@babel/types": "7.0.0-beta.31",
-				"babylon": "7.0.0-beta.31",
-				"lodash": "4.17.4"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ=="
-				}
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
-			"integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.31",
-				"@babel/helper-function-name": "7.0.0-beta.31",
-				"@babel/types": "7.0.0-beta.31",
-				"babylon": "7.0.0-beta.31",
+				"@babel/code-frame": "7.0.0-beta.36",
+				"@babel/generator": "7.0.0-beta.36",
+				"@babel/helpers": "7.0.0-beta.36",
+				"@babel/template": "7.0.0-beta.36",
+				"@babel/traverse": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36",
+				"babylon": "7.0.0-beta.36",
+				"convert-source-map": "1.5.0",
 				"debug": "3.1.0",
-				"globals": "10.4.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4"
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"micromatch": "2.3.11",
+				"resolve": "1.3.3",
+				"source-map": "0.5.6"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.36.tgz",
+					"integrity": "sha512-OTUb6iSKVR/98dGThRJ1BiyfwbuX10BVnkz89IpaerjTPRhDfMBfLsqmzxz5MiywUOW4M0Clta0o7rSxkfcuzw==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/helper-function-name": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"debug": "3.1.0",
+						"globals": "11.1.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
 				"babylon": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ=="
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -78,27 +101,1775 @@
 					}
 				},
 				"globals": {
-					"version": "10.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
-					"integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA=="
-				}
-			}
-		},
-		"@babel/types": {
-			"version": "7.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
-			"integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
-			"requires": {
-				"esutils": "2.0.2",
-				"lodash": "4.17.4",
-				"to-fast-properties": "2.0.0"
-			},
-			"dependencies": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.36.tgz",
+			"integrity": "sha512-lsFehk83UlzT+5ZTC+4p8WI16zkWYGgGQGqQFgdhCdcvt9yLHZ3bUORHC0H9+Wyp/7cJ68xjlYMDsTf48EcbDQ==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.36",
+				"jsesc": "2.5.1",
+				"lodash": "4.17.4",
+				"source-map": "0.5.6",
+				"trim-right": "1.0.1"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"jsesc": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.36.tgz",
+			"integrity": "sha512-tEtiA7u7ez+GLAX5nrRsrqfCzK5m1VOG82xZ9EHACn2vHphYd3aJA35JvNT7w34MtV8yCjM95r3lnenrIxpbNw==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.36.tgz",
+			"integrity": "sha512-uBrsv+Tnh1krKXdQMh7825n8u8RSXQg1lWRjYZ6STNi+OUu63mmZU10rT+7mVwhAj2NHg5AEVwqrlVjXPEPl/w==",
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-builder-react-jsx": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.36.tgz",
+			"integrity": "sha512-JUxvBbQ7Lvif5i9i1ToEozj9t0RzSQzLOaM9qbWjXcRXh0Fi6MPAeQxU4xHuH0+tRNVMmtMMItkrt9teyepXqA==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.36",
+				"esutils": "2.0.2"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-call-delegate": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.36.tgz",
+			"integrity": "sha512-q1cogJgiWYTgH8/c0tYrvfFqygSZnwRT2F3wbBk+pVq2lRmX1LvpoLHylfs/MamJtIC8lAj5auMAIPVj1sh8yw==",
+			"requires": {
+				"@babel/helper-hoist-variables": "7.0.0-beta.36",
+				"@babel/traverse": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.36.tgz",
+					"integrity": "sha512-OTUb6iSKVR/98dGThRJ1BiyfwbuX10BVnkz89IpaerjTPRhDfMBfLsqmzxz5MiywUOW4M0Clta0o7rSxkfcuzw==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/helper-function-name": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"debug": "3.1.0",
+						"globals": "11.1.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.36.tgz",
+			"integrity": "sha512-jTBSskGKkYlWbQ/4rZp6leG7A8HimkJ9CT3PS7SVZRKzQ/ODTpMTTuPa48XPkkbicIhxngUqBxuUBgnSjAGdkw==",
+			"requires": {
+				"@babel/helper-function-name": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.36.tgz",
+			"integrity": "sha512-ecBgSDw9ICxWJi4aSNCQ45SFqMOgUmuz4vhfDQ9lwadqqHafDNe2z/45RMtVc5a6VIfgWJ9PZekaQJAjtIdCkw==",
+			"requires": {
+				"@babel/traverse": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.36.tgz",
+					"integrity": "sha512-OTUb6iSKVR/98dGThRJ1BiyfwbuX10BVnkz89IpaerjTPRhDfMBfLsqmzxz5MiywUOW4M0Clta0o7rSxkfcuzw==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/helper-function-name": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"debug": "3.1.0",
+						"globals": "11.1.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.36.tgz",
+			"integrity": "sha512-YGw1l4GJ+Q/xlXH71w8oWUuu2CY+6UmShmsfDxzC7tvFCVCJUj8q2NpR+HRVEnh0SpXmJUzWNR5UVk0+JWT/eQ==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.36.tgz",
+			"integrity": "sha512-SNNOWnWMbgD1ilJ3RfayD87lLGNvrsIQCUBYrk1q3jFh3Al218XOlY1N+sV2l+vFOo43qMJUNGRXTH5w1WjfYw==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.36",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.36.tgz",
+			"integrity": "sha512-M4lyGz8AM7WtCUxX54gB9HuUbY1TJswv0MexoytS2Pj/dMk9OIXN3Mt8rmkRIO+Akq02iTXOtKY8rh+ZfKI3QQ==",
+			"requires": {
+				"@babel/helper-module-imports": "7.0.0-beta.36",
+				"@babel/helper-simple-access": "7.0.0-beta.36",
+				"@babel/template": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.36.tgz",
+			"integrity": "sha512-xKqC//WIWVzgN4Z7yNvA/i/F2jEHfpu9P1PVxW0+1TREi80OSSu92c0V6lh+wASngFpbpBabZZiRFfX5FD3DNQ==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-regex": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.36.tgz",
+			"integrity": "sha512-Vl64v5VLLKXjE2XoICzh5h4jEpcKC7unTmSjHR/+92ibXoEi2czUokyRTl5XbEo3gF4+wTZhO8SYiiPlMFcNkw==",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.36.tgz",
+			"integrity": "sha512-zQkwENaCl6yEQbxNUvbkPHT6Pu4vlUKuElsebfD1ra2ljgHdJ0Q9BJH7fSV/tZ87jvlrRxXQaEB+xgqUx//RwA==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.36",
+				"@babel/helper-wrap-function": "7.0.0-beta.36",
+				"@babel/template": "7.0.0-beta.36",
+				"@babel/traverse": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.36.tgz",
+					"integrity": "sha512-OTUb6iSKVR/98dGThRJ1BiyfwbuX10BVnkz89IpaerjTPRhDfMBfLsqmzxz5MiywUOW4M0Clta0o7rSxkfcuzw==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/helper-function-name": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"debug": "3.1.0",
+						"globals": "11.1.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.36.tgz",
+			"integrity": "sha512-Dj5BG7qgRleK/97JNCarkif3avBf0ddSFIzqdYOTCquPVrDSWUMknZ5xsFVFpWMO1SXUhtZdBQDRHUcE7DsVdw==",
+			"requires": {
+				"@babel/helper-optimise-call-expression": "7.0.0-beta.36",
+				"@babel/template": "7.0.0-beta.36",
+				"@babel/traverse": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.36.tgz",
+					"integrity": "sha512-OTUb6iSKVR/98dGThRJ1BiyfwbuX10BVnkz89IpaerjTPRhDfMBfLsqmzxz5MiywUOW4M0Clta0o7rSxkfcuzw==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/helper-function-name": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"debug": "3.1.0",
+						"globals": "11.1.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.36.tgz",
+			"integrity": "sha512-fCZQFBtgTxWd+mKKKetvI2RroLADuHxo3A9XdoQ7zyaPBpM8P8vZ6rvcT6JJGa6O5/ofVbc3kyudoo+vNv79Kw==",
+			"requires": {
+				"@babel/template": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.36.tgz",
+			"integrity": "sha512-vSE9XaqXbgodc+r+mVBMj/XRiXYgVSdCo7ntt5dAJ31/6UCKRkHZFn732/7o4kPT2jdE3tWAmy0KHEpcTYNQ6g==",
+			"requires": {
+				"@babel/helper-function-name": "7.0.0-beta.36",
+				"@babel/template": "7.0.0-beta.36",
+				"@babel/traverse": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.36.tgz",
+					"integrity": "sha512-OTUb6iSKVR/98dGThRJ1BiyfwbuX10BVnkz89IpaerjTPRhDfMBfLsqmzxz5MiywUOW4M0Clta0o7rSxkfcuzw==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/helper-function-name": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"debug": "3.1.0",
+						"globals": "11.1.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.36.tgz",
+			"integrity": "sha512-4pYmI8k0RzrWvWl8DJHy08mqQqY8WggREfTVsvDkdXt+6R78ersl+nnXmqE6J+eFPX2sf26VVLmE1PkXPgvU+w==",
+			"requires": {
+				"@babel/template": "7.0.0-beta.36",
+				"@babel/traverse": "7.0.0-beta.36",
+				"@babel/types": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.36.tgz",
+					"integrity": "sha512-OTUb6iSKVR/98dGThRJ1BiyfwbuX10BVnkz89IpaerjTPRhDfMBfLsqmzxz5MiywUOW4M0Clta0o7rSxkfcuzw==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/helper-function-name": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"debug": "3.1.0",
+						"globals": "11.1.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/plugin-check-constants": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.36.tgz",
+			"integrity": "sha512-DHEAINGu/Hrvl0B02N/vpSNfj38JdfawBTzEPZJMPShdmpT+k+62pFCWoEqdxKG48xHBQqGGnKpyC9XPge1KUQ=="
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.36.tgz",
+			"integrity": "sha512-MchuPTmqkWDBHyO8Sn/Bi4tBuaHjmqTnXlAI/nN1WexvTmb3GHkH6fCpdM8N5I9tTJ3WptIps9eElDrysokdMw==",
+			"requires": {
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.36",
+				"@babel/plugin-syntax-async-generators": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.36.tgz",
+			"integrity": "sha512-HqnbDiYiACRv91BxFe5pmCSK7+2mmYtLoOHRsCiezB5LL/A9OEnZx5YAxZZQq9+rPWplIxRx/xlP0SomG3djfw==",
+			"requires": {
+				"@babel/helper-function-name": "7.0.0-beta.36",
+				"@babel/plugin-syntax-class-properties": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/plugin-proposal-decorators": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.0.0-beta.36.tgz",
+			"integrity": "sha512-3tCIefmjv5q8t/2uycGNMSBGLvdT0S12/AuxrVsLNkl3yO54a0zP5arm2TJUwa5Cg3Iy7r72xQAaaydzy6eI7A==",
+			"requires": {
+				"@babel/plugin-syntax-decorators": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-export-namespace-from": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.0.0-beta.36.tgz",
+			"integrity": "sha512-nb4JAp+qHb5aj3MIPWA8Q9w8Xif1YhfFJdjuVKwssWaDkNxpmc5F0Vby3nPTj4ikmGB3yKlmtJuE8GUZqLN3ZA==",
+			"requires": {
+				"@babel/plugin-syntax-export-namespace-from": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-function-sent": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-function-sent/-/plugin-proposal-function-sent-7.0.0-beta.36.tgz",
+			"integrity": "sha512-GXMYCsXsLr7rD96aVqHbYir4rUgk/Pd/NzXGL5TyL7+j8UNKucBfHStw7cSvlTIbimbHHRUF6a8+pry9f+jczA==",
+			"requires": {
+				"@babel/helper-wrap-function": "7.0.0-beta.36",
+				"@babel/plugin-syntax-function-sent": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-numeric-separator": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.0.0-beta.36.tgz",
+			"integrity": "sha512-7JI8JnwDQ1PQuBM/HMuTKiYxdVIdaVwVv8G3BBRKKhvD+53/aV12og0vbfQGycVgSSDnufH+KKi8cSy+uc41oA==",
+			"requires": {
+				"@babel/plugin-syntax-numeric-separator": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.36.tgz",
+			"integrity": "sha512-jlS8AhgV/EOzmluo897rFtP/ZPOrmiYGRyHfPzbDvxjoaPjP/YA0e407V/DpjGbDv4esRGXs6cI2ykjEyo2dLg==",
+			"requires": {
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.36.tgz",
+			"integrity": "sha512-KLkyx+rvvpFEGVbYFjlKdGlcm52N8IXNbJeMz4G5oCvhpIBskPA0HhMRUCVHYm1M4Frz2imXpI+3V5KaJ5M65A==",
+			"requires": {
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-throw-expressions": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.0.0-beta.36.tgz",
+			"integrity": "sha512-UO6RyUYyRqqbchDA+6vW3dEv5Em9IMH0S6R/ZITLa7ACNJJGrCXmHtECQ3IRkDLHEGzd5yYjXZ/uu/0cM+UDZQ==",
+			"requires": {
+				"@babel/plugin-syntax-throw-expressions": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.36.tgz",
+			"integrity": "sha512-sJEBuQ6mp7QfTp4KaB+h71lnF8UNz23t016PYDwYVSYGU3AZanSmpHU86rp4mEyMcT4ftCywFaJilfpQ36gnZg==",
+			"requires": {
+				"@babel/helper-regex": "7.0.0-beta.36",
+				"regexpu-core": "4.1.3"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				},
+				"regenerate": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+					"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+				},
+				"regexpu-core": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+					"integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+					"requires": {
+						"regenerate": "1.3.3",
+						"regenerate-unicode-properties": "5.1.3",
+						"regjsgen": "0.3.0",
+						"regjsparser": "0.2.1",
+						"unicode-match-property-ecmascript": "1.0.3",
+						"unicode-match-property-value-ecmascript": "1.0.1"
+					}
+				},
+				"regjsgen": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+					"integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
+				},
+				"regjsparser": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+					"integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+					"requires": {
+						"jsesc": "0.5.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.36.tgz",
+			"integrity": "sha512-jBtmcbbDSCCI5IA7QC8Wvhw6YMjTKgc8FCKGiZAl4GTI6PApW9fZQCf0DoQU/P69lxG4cFKYddb8GIItEBm98w=="
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.36.tgz",
+			"integrity": "sha512-Xw383kt3/htX5JjiwoSvjpoVs6n7Vk6COG1DfdDY4uJ8ccsJ8UZT09iJ4s7ckPgVeQCFgcfOb4xAUoAqLdOizQ=="
+		},
+		"@babel/plugin-syntax-decorators": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.0.0-beta.36.tgz",
+			"integrity": "sha512-jDhxU326BkczSAiNlzi1PIDlcuWNFSWlVznllmAXAwx3lEUmCy9STcjjnu1eKTMUalESoT4Y5PU08bYU/bnSSg=="
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.36.tgz",
+			"integrity": "sha512-G12hDcv6AOs8xTyO5GVqcemxyFBJR+4zWK2S+7GYNgDf8vfav8DiGWflwGnZ5fnbUeofS/jTds6dqZDl6co9ng=="
+		},
+		"@babel/plugin-syntax-export-namespace-from": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.0.0-beta.36.tgz",
+			"integrity": "sha512-DY60SsIDGIk4gneQdqDVHqZ/8FvcGAoxT/V/yFWNzBlJVb4h8Ik6WTy19mmb9r1NPArwB5MGPlDT0Cfv2tt1cw=="
+		},
+		"@babel/plugin-syntax-function-sent": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-sent/-/plugin-syntax-function-sent-7.0.0-beta.36.tgz",
+			"integrity": "sha512-F9jMofyAj8Mxe9dtI69S0GxaxJ1R/pl/tTHsDFFjoCthpiTPdUvePX1joAGJyJ3FScKPjbiWm/TrBZL1hPj/HQ=="
+		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-beta.36.tgz",
+			"integrity": "sha512-wl/6rUeViE1T+c6Zc05pbavniXO7djr1TMo9wz5AbSZxNOHTwGWTVdt46lz3seyMmAQ526ijqp7PS4mIUaIgHQ=="
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.36.tgz",
+			"integrity": "sha512-j0dwdk3frPLYxGWLn4113/Z27YBS2qCBRSdMOMhUN8fldbQEW5n27IEcGaQ+cvyBQdVqog9Hhot+BNCn6srXbA=="
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.0.0-beta.36.tgz",
+			"integrity": "sha512-PgrhhYtut37uOEPv335D/xGEAHk1THFDtLSdBWVxvODI6xvANelwo8QAyC/QszRGO2VxWCqq2AfAeODzZHh7Ew=="
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.36.tgz",
+			"integrity": "sha512-m8GVq8u0zGT0qJd396tHYckY5VduRVSpVaf5XS4gVYHjLmwwMDSQl16GwFmv3yS6YUi6TO9ldBqsPNFz0nbxZQ=="
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.36.tgz",
+			"integrity": "sha512-k/kQYxD7oQd2H6CPGu8R0iVNqLMW6Udcge1vs1cUyMdDpMuVaTKYknhxDhd6S5ovZFgHyQC2QbguMHHQbipWPA=="
+		},
+		"@babel/plugin-syntax-throw-expressions": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.0.0-beta.36.tgz",
+			"integrity": "sha512-EpE4FGJzB5oRfUaGR6ZZoMdAQBGD9Ii9CroGpFrdozA118BwM4l0Y19x2e2oEnVx4sqsO+4uDiWqV3dj2kEuEA=="
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.36.tgz",
+			"integrity": "sha512-lgOyrX8gPHo0rQzzfzGx0atocEdKgvq3jjIN7XBkDMW672ivZwrz8tAd/NJufNK6mbDUZm0Qq/JoLf+C4S4YpQ=="
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.36.tgz",
+			"integrity": "sha512-2OmUmLZOGdVFRJXpisc4VSSwbAXoOvA9s8EF8IiKEzHbFs+GVmjadDMnkNbMK8w5ATm150jbwRvNPMV7Ztfavw==",
+			"requires": {
+				"@babel/helper-module-imports": "7.0.0-beta.36",
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.36.tgz",
+			"integrity": "sha512-iP3mXx38S7ouFJ9Sydu48ArVPNqh9+Y8VWSuv3XXMyZagm27Xzp3Pnmvm1lPWOqhkWMHZb5qK1M6ngC/GEC5ZA=="
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.36.tgz",
+			"integrity": "sha512-seF/NY6BCOf1f75987VeEElUM4x9FA7gVw0INYfTQrf8KfWnYGa+9T0/JasK8gJikkZ9xNs9rJ8ui9d3zuA+9Q==",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.36.tgz",
+			"integrity": "sha512-VamoOsbL4mJ4xAHvTcM8RvTFhFQ8VXc+M3/VeFgPGFAZ6gOb7dyjuluE2G5CzPSQstMuEoCcoOawTsjtgLWl3w==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.36",
+				"@babel/helper-define-map": "7.0.0-beta.36",
+				"@babel/helper-function-name": "7.0.0-beta.36",
+				"@babel/helper-optimise-call-expression": "7.0.0-beta.36",
+				"@babel/helper-replace-supers": "7.0.0-beta.36",
+				"globals": "11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.36.tgz",
+			"integrity": "sha512-i/e4mQCFspfldzsqli4YozI9ghQdu7zivWnbaBXWdvIq6mttwMP9n0F8kzDjmNvCbQU8DTzlHySr6vhUPDyvOg=="
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.36.tgz",
+			"integrity": "sha512-qiY+lSuXiG/ppO5W4Ajt8yHW4BXdKltScSDAzAI/FayKXDOjXOpmXXrsZPPKtsbIaUTZSxzPfke+8hRjpF9H6w=="
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.36.tgz",
+			"integrity": "sha512-b46NEiKIf9wT1Id/nUDjqy8MZkcwAAxaC9CZSCacA6uB9+MdR5weh/vA6u8gxNKBTEE00hmNloBWoRZ9e52FWw==",
+			"requires": {
+				"@babel/helper-regex": "7.0.0-beta.36",
+				"regexpu-core": "4.1.3"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				},
+				"regenerate": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+					"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+				},
+				"regexpu-core": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+					"integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+					"requires": {
+						"regenerate": "1.3.3",
+						"regenerate-unicode-properties": "5.1.3",
+						"regjsgen": "0.3.0",
+						"regjsparser": "0.2.1",
+						"unicode-match-property-ecmascript": "1.0.3",
+						"unicode-match-property-value-ecmascript": "1.0.1"
+					}
+				},
+				"regjsgen": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+					"integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
+				},
+				"regjsparser": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+					"integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+					"requires": {
+						"jsesc": "0.5.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.36.tgz",
+			"integrity": "sha512-MgFmoRipky5qNgeMf1PnYmfYIXpydlIVDbpskRYT5mOzi7q+demNWdA4rRM9W5vbLFagwTuOCPFZ+DyITq2vLg=="
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.36.tgz",
+			"integrity": "sha512-Xw80I0Jpf8Rv++hTEetvVKcUE2+nZMJd1zEbcioDcdkLy6pr1GEkUcB1GAvKu7TSDOWis4niHaDDnRpzIs/p5w==",
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.36.tgz",
+			"integrity": "sha512-KuBEFkwwp1Rwb782nBJi0FpObFyexTtclNIbqzWgMna7HQsMpJtmVBBC7encRK31ZpTQnWKHz1IyHnVTO2FdQA=="
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.36.tgz",
+			"integrity": "sha512-pet0HtP9hmklcxUc0c4TEDH7FVEYYvp5OVPhF2HNQZYuERZq+1jx5uv4Bw+lbttvd1dKnIO6tZmZIVc74suW3Q==",
+			"requires": {
+				"@babel/helper-function-name": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
+					"integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+					"requires": {
+						"chalk": "2.0.1",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz",
+					"integrity": "sha512-/SGPOyifPf20iTrMN+WdlY2MbKa7/o4j7B/4IAsdOusASp2icT+Wcdjf4tjJHaXNX8Pe9bpgVxLNxhRvcf8E5w==",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.36",
+						"@babel/template": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
+					"integrity": "sha512-mUBi90WRyZ9iVvlWLEdeo8gn/tROyJdjKNC4W5xJTSZL+9MS89rTJSqiaJKXIkxk/YRDL/g/8snrG/O0xl33uA==",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.36",
+						"@babel/types": "7.0.0-beta.36",
+						"babylon": "7.0.0-beta.36",
+						"lodash": "4.17.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.36.tgz",
+					"integrity": "sha512-rw4YdadGwajAMMRl6a5swhQ0JCOOFyaYCfJ0AsmNBD8uBD/r4J8mux7wBaqavvFKqUKQYWOzA1Speams4YDzsQ=="
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.36.tgz",
+			"integrity": "sha512-7Ao2jQa5B4+ofN2wmZSM/vK5zQKyg5f4BUReQOcy/ypXrdvU+Z/YeIsD4lN4Tr32BTGVkVRwAx35KNy4Xa5LAA=="
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.36.tgz",
+			"integrity": "sha512-/rB1vki3iPfurd+r1EneEBK13TOCE/6NYgqVtqW3amlzLWwzr39cLf1+6DZqQCdo358hHHC5sIVoiXBU+GM2Bg==",
+			"requires": {
+				"@babel/helper-module-transforms": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.36.tgz",
+			"integrity": "sha512-HLQIJSUF8QuzJYmLzwCCKlVbRSGIbbifzYLLfuLQusgCFx6BFRC7JhtYuAh9fQRFD0YSVSCBbeOEpVK9sMonjg==",
+			"requires": {
+				"@babel/helper-module-transforms": "7.0.0-beta.36",
+				"@babel/helper-simple-access": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.36.tgz",
+			"integrity": "sha512-o+1uL5N3+9mcqj4xxOsb97QCBX9RbezSpf5GZp+nN7zbDuL4/tBFUZbR6RnU5dTw+y2xVGPsqAWH9wo0Hs5QhA==",
+			"requires": {
+				"@babel/helper-hoist-variables": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.36.tgz",
+			"integrity": "sha512-d6WWXCwA91HKxFXpgahlG1DE9UH1JQRWkIFmQjsbQ75kQHWu9WZQ1dXwo79SSmeCeVe/p+gV+4Phb2iXt4J6UA==",
+			"requires": {
+				"@babel/helper-module-transforms": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.36.tgz",
+			"integrity": "sha512-QJ/gN712/zKFQs3KdG5ph0nN9hHSfxrCY2fkEF2w+Uhe219qGqGuCTpbwMRJHk7KzeLgW8WmBcmikMIku+MeLg=="
+		},
+		"@babel/plugin-transform-object-assign": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0-beta.36.tgz",
+			"integrity": "sha512-BM3QBAc09Cztc6/kkGIKfBr+i8xqbz/1HXdOGhl0ZwGjZlJs/ldziDfmMT3a6WUZQet4gwXfuOJYuNs66GO9fA=="
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.36.tgz",
+			"integrity": "sha512-+wY8eQ8H7uQx2Zphkw6TRqAfRitgfcSgPtyHMpM0mpB9+JH2x1PZkd4s0E05/rcFHVvt3Dnhswe6braf2aZQkw==",
+			"requires": {
+				"@babel/helper-replace-supers": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.36.tgz",
+			"integrity": "sha512-1y6X6on5H4AWudyJD00WvCvuUNnKUHeG/yJpNQW5bgmJCZYhuvs4lgCZlwKO0GuoymPULGjOToUun3agCX+39A==",
+			"requires": {
+				"@babel/helper-call-delegate": "7.0.0-beta.36",
+				"@babel/helper-get-function-arity": "7.0.0-beta.36"
+			},
+			"dependencies": {
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz",
+					"integrity": "sha512-vPPcx2vsSoDbcyWr9S3nd0FM3B4hEXnt0p1oKpwa08GwK0fSRxa98MyaRGf8suk8frdQlG1P3mDrz5p/Rr3pbA==",
+					"requires": {
+						"@babel/types": "7.0.0-beta.36"
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.36",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.36.tgz",
+					"integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
+					"requires": {
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.36.tgz",
+			"integrity": "sha512-OzBufQ6yt3nUZGU2bcJFdTEOQLRq9mi5wnoCFyw+AARXhWwuwQ9mxpuPp9CLOORHOMNY8lfyASPpDxmBShGyGw==",
+			"requires": {
+				"@babel/helper-builder-react-jsx": "7.0.0-beta.36",
+				"@babel/plugin-syntax-jsx": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.36.tgz",
+			"integrity": "sha512-Mwo4gfH8r7FaITIkkGx1S9cedxHhx4exkxa794wgTfaQyVEfiqnt1W+B42aWlW34iKedDuvCRuQxsGw55o+MUA==",
+			"requires": {
+				"regenerator-transform": "0.12.3"
+			},
+			"dependencies": {
+				"regenerator-transform": {
+					"version": "0.12.3",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.3.tgz",
+					"integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
+					"requires": {
+						"private": "0.1.7"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.36.tgz",
+			"integrity": "sha512-iwyn7SuvUcp4uvm5mHC261kTOijMoTJwdj8R2d3piOVO9dUll4ENzg2xcXiZ6KkFHToaCHMKbCe7jXV0v4+BKg=="
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.36.tgz",
+			"integrity": "sha512-mGCjhmLrpIzCQ+WAJnQzoGDd8/rv709Bce7IXPJLsw3pseHurVhHCGU9x5YzERnVHMh7zE9RVqyvARrp9XnS9A=="
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.36.tgz",
+			"integrity": "sha512-DcMR//iXgOhYFj1FeRXweSfO7Iyw5DMDgRxl7n/7uqj+BfjGL7X2O8OOqDQWlk8nYE7MuUmCiMLg6E52vWyxqw==",
+			"requires": {
+				"@babel/helper-regex": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.36.tgz",
+			"integrity": "sha512-wQkEeOUcz9+1SqLm0OHu+cqCfO0L7aAxdAWBwBx6H8+4YA9QEDOq8jstVk+1wUZRxemdg2ETjs2fe0c2lCnzwQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "7.0.0-beta.36"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.36.tgz",
+			"integrity": "sha512-1w/EdTveqnYe37O8hCvizL/KmZRHSG59Hh00mOnLc7/Ue5wnV1TLAA1rlNp+4d+D9OJsjf1Qvi7pTYMfLqHADQ=="
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.36.tgz",
+			"integrity": "sha512-FdNNjIgXAscKRNwsOg+h6JKW0ZmJvM26jtusKtCf6A7WVpxEYtBKKWylxemeHF6S1JcT6kjxPvdQyJonfsNGQg==",
+			"requires": {
+				"@babel/helper-regex": "7.0.0-beta.36",
+				"regexpu-core": "4.1.3"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				},
+				"regenerate": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+					"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+				},
+				"regexpu-core": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+					"integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+					"requires": {
+						"regenerate": "1.3.3",
+						"regenerate-unicode-properties": "5.1.3",
+						"regjsgen": "0.3.0",
+						"regjsparser": "0.2.1",
+						"unicode-match-property-ecmascript": "1.0.3",
+						"unicode-match-property-value-ecmascript": "1.0.1"
+					}
+				},
+				"regjsgen": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+					"integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
+				},
+				"regjsparser": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+					"integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+					"requires": {
+						"jsesc": "0.5.0"
+					}
+				}
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.36.tgz",
+			"integrity": "sha512-zJgsAxg2wAZ83/HWM8HUmQlyMd8SYEnsukhu8m1wZO120fHkrf+T9Uqi0QMZuI0eLuYCbE3sWrdcff7O3ak/ig==",
+			"requires": {
+				"@babel/plugin-check-constants": "7.0.0-beta.36",
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.36",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.36",
+				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.36",
+				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.36",
+				"@babel/plugin-syntax-async-generators": "7.0.0-beta.36",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.36",
+				"@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.36",
+				"@babel/plugin-transform-arrow-functions": "7.0.0-beta.36",
+				"@babel/plugin-transform-async-to-generator": "7.0.0-beta.36",
+				"@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.36",
+				"@babel/plugin-transform-block-scoping": "7.0.0-beta.36",
+				"@babel/plugin-transform-classes": "7.0.0-beta.36",
+				"@babel/plugin-transform-computed-properties": "7.0.0-beta.36",
+				"@babel/plugin-transform-destructuring": "7.0.0-beta.36",
+				"@babel/plugin-transform-dotall-regex": "7.0.0-beta.36",
+				"@babel/plugin-transform-duplicate-keys": "7.0.0-beta.36",
+				"@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.36",
+				"@babel/plugin-transform-for-of": "7.0.0-beta.36",
+				"@babel/plugin-transform-function-name": "7.0.0-beta.36",
+				"@babel/plugin-transform-literals": "7.0.0-beta.36",
+				"@babel/plugin-transform-modules-amd": "7.0.0-beta.36",
+				"@babel/plugin-transform-modules-commonjs": "7.0.0-beta.36",
+				"@babel/plugin-transform-modules-systemjs": "7.0.0-beta.36",
+				"@babel/plugin-transform-modules-umd": "7.0.0-beta.36",
+				"@babel/plugin-transform-new-target": "7.0.0-beta.36",
+				"@babel/plugin-transform-object-super": "7.0.0-beta.36",
+				"@babel/plugin-transform-parameters": "7.0.0-beta.36",
+				"@babel/plugin-transform-regenerator": "7.0.0-beta.36",
+				"@babel/plugin-transform-shorthand-properties": "7.0.0-beta.36",
+				"@babel/plugin-transform-spread": "7.0.0-beta.36",
+				"@babel/plugin-transform-sticky-regex": "7.0.0-beta.36",
+				"@babel/plugin-transform-template-literals": "7.0.0-beta.36",
+				"@babel/plugin-transform-typeof-symbol": "7.0.0-beta.36",
+				"@babel/plugin-transform-unicode-regex": "7.0.0-beta.36",
+				"browserslist": "github:ai/browserslist#c32316d204c9a17e570962dec6b5abdfd39a2e24",
+				"invariant": "2.2.2",
+				"semver": "5.4.1"
+			}
+		},
+		"@babel/preset-stage-2": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/preset-stage-2/-/preset-stage-2-7.0.0-beta.36.tgz",
+			"integrity": "sha512-TRTIB7Aln6JLPIru4sQCcyfgVBYca6I/647T6R8viAomuRLG2i5n8Km6nmyuyh2LxC4qX3AU3Ayr7D3wjkh6Iw==",
+			"requires": {
+				"@babel/plugin-proposal-export-namespace-from": "7.0.0-beta.36",
+				"@babel/plugin-proposal-function-sent": "7.0.0-beta.36",
+				"@babel/plugin-proposal-numeric-separator": "7.0.0-beta.36",
+				"@babel/plugin-proposal-throw-expressions": "7.0.0-beta.36",
+				"@babel/preset-stage-3": "7.0.0-beta.36"
+			}
+		},
+		"@babel/preset-stage-3": {
+			"version": "7.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/@babel/preset-stage-3/-/preset-stage-3-7.0.0-beta.36.tgz",
+			"integrity": "sha512-eUmkC30SB9uS6TYpBFVWkmH/TrG//2cAO+rwIaiIV8EGR4LXab84gO/1PBQ5PJ8sTahmn4VBnqPlnRZYL9mJQA==",
+			"requires": {
+				"@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.36",
+				"@babel/plugin-proposal-class-properties": "7.0.0-beta.36",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.36",
+				"@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.36",
+				"@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.36",
+				"@babel/plugin-syntax-dynamic-import": "7.0.0-beta.36",
+				"@babel/plugin-syntax-import-meta": "7.0.0-beta.36"
+			}
+		},
+		"@bolt/babel-preset-bolt": {
+			"version": "file:packages/bolt-config-presets/babel-preset-bolt",
+			"requires": {
+				"@babel/core": "7.0.0-beta.36",
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.36",
+				"@babel/plugin-proposal-class-properties": "7.0.0-beta.36",
+				"@babel/plugin-proposal-decorators": "7.0.0-beta.36",
+				"@babel/plugin-syntax-class-properties": "7.0.0-beta.36",
+				"@babel/plugin-syntax-decorators": "7.0.0-beta.36",
+				"@babel/plugin-syntax-dynamic-import": "7.0.0-beta.36",
+				"@babel/plugin-syntax-jsx": "7.0.0-beta.36",
+				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.36",
+				"@babel/plugin-transform-classes": "7.0.0-beta.36",
+				"@babel/plugin-transform-object-assign": "7.0.0-beta.36",
+				"@babel/plugin-transform-react-jsx": "7.0.0-beta.36",
+				"@babel/plugin-transform-regenerator": "7.0.0-beta.36",
+				"@babel/preset-env": "7.0.0-beta.36",
+				"@babel/preset-stage-2": "7.0.0-beta.36",
+				"@babel/preset-stage-3": "7.0.0-beta.36",
+				"babel-plugin-dynamic-import-node": "1.2.0",
+				"babel-plugin-jsx-pragmatic": "1.0.2",
+				"babel-plugin-transform-builtin-classes": "0.6.1",
+				"babel-plugin-transform-custom-element-classes": "0.1.0"
 			}
 		},
 		"@bolt/build-core": {
@@ -809,11 +2580,6 @@
 				"through": "2.3.8"
 			}
 		},
-		"abab": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
-		},
 		"abbrev": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -847,21 +2613,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"requires": {
-				"acorn": "4.0.13"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				}
-			}
-		},
-		"acorn-globals": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
 			"requires": {
 				"acorn": "4.0.13"
 			},
@@ -1060,14 +2811,6 @@
 			"resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
 			"integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo="
 		},
-		"append-transform": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-			"requires": {
-				"default-require-extensions": "1.0.0"
-			}
-		},
 		"aproba": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
@@ -1205,11 +2948,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
 			"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
-		},
-		"array-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-filter": {
 			"version": "0.0.1",
@@ -1417,11 +3155,6 @@
 			"version": "0.9.12",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.12.tgz",
 			"integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k="
-		},
-		"astral-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
 		},
 		"async": {
 			"version": "2.5.0",
@@ -1954,23 +3687,14 @@
 			}
 		},
 		"babel-eslint": {
-			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.1.2.tgz",
-			"integrity": "sha512-IE+glF8t0lLoldylN7JyR8gT7e3jwyuNH2ds8g3UVUwGob/U4iT7Xpsiq2kQ8QGLb0eX4RcQXNqeW6mgPysu9A==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+			"integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.31",
-				"@babel/traverse": "7.0.0-beta.31",
-				"@babel/types": "7.0.0-beta.31",
-				"babylon": "7.0.0-beta.31",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "1.0.0"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ=="
-				}
+				"babel-code-frame": "6.22.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0"
 			}
 		},
 		"babel-generator": {
@@ -1986,52 +3710,6 @@
 				"lodash": "4.17.4",
 				"source-map": "0.5.6",
 				"trim-right": "1.0.1"
-			},
-			"dependencies": {
-				"babel-runtime": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-					"requires": {
-						"core-js": "2.5.1",
-						"regenerator-runtime": "0.11.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-				}
-			}
-		},
-		"babel-helper-bindify-decorators": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-builder-react-jsx": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
-			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"esutils": "2.0.2"
 			},
 			"dependencies": {
 				"babel-runtime": {
@@ -2086,27 +3764,6 @@
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
 					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
 				}
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-explode-class": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-			"requires": {
-				"babel-helper-bindify-decorators": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -2174,18 +3831,6 @@
 				}
 			}
 		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
 		"babel-helper-replace-supers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -2208,19 +3853,10 @@
 				"babel-template": "6.26.0"
 			}
 		},
-		"babel-jest": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-			"integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
-			"requires": {
-				"babel-plugin-istanbul": "4.1.5",
-				"babel-preset-jest": "21.2.0"
-			}
-		},
 		"babel-loader": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
-			"integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
+			"version": "8.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.0-beta.0.tgz",
+			"integrity": "sha512-qVXXyIqTrLBH3Ki2VCJog1fUd6qzKUk9lHS34WJPW93Bh0BUvXTFSD5ZkG3a5+Uxxje+RgCk8Y7RyB6zyK9rWw==",
 			"requires": {
 				"find-cache-dir": "1.0.0",
 				"loader-utils": "1.1.0",
@@ -2235,38 +3871,13 @@
 				"babel-runtime": "6.23.0"
 			}
 		},
-		"babel-plugin-check-es2015-constants": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+		"babel-plugin-dynamic-import-node": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.2.0.tgz",
+			"integrity": "sha512-yeDwKaLgGdTpXL7RgGt5r6T4LmnTza/hUn5Ul8uZSGGMtEjYo13Nxai7SQaGCTEzUtg9Zq9qJn0EjEr7SeSlTQ==",
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-dynamic-import": "6.18.0"
 			}
-		},
-		"babel-plugin-istanbul": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
-			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
-			"requires": {
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.9.1",
-				"test-exclude": "4.1.1"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "2.0.0"
-					}
-				}
-			}
-		},
-		"babel-plugin-jest-hoist": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-			"integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ=="
 		},
 		"babel-plugin-jsx-pragmatic": {
 			"version": "1.0.2",
@@ -2276,142 +3887,22 @@
 				"babel-plugin-syntax-jsx": "6.18.0"
 			}
 		},
-		"babel-plugin-module-resolver": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-2.7.1.tgz",
-			"integrity": "sha1-GL48Qt31n3pFbJ4FEs2ROU9uS+E=",
-			"requires": {
-				"find-babel-config": "1.1.0",
-				"glob": "7.1.2",
-				"resolve": "1.3.3"
-			}
-		},
-		"babel-plugin-syntax-async-functions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-		},
-		"babel-plugin-syntax-async-generators": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
-		},
-		"babel-plugin-syntax-class-constructor-call": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
-		},
-		"babel-plugin-syntax-class-properties": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-		},
-		"babel-plugin-syntax-decorators": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
-		},
-		"babel-plugin-syntax-do-expressions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
-			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0="
-		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
 			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-		},
-		"babel-plugin-syntax-export-extensions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
-		},
-		"babel-plugin-syntax-flow": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
-		},
-		"babel-plugin-syntax-function-bind": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
-			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
 			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-		},
-		"babel-plugin-transform-async-generator-functions": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-generators": "6.13.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
 		"babel-plugin-transform-builtin-classes": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-classes/-/babel-plugin-transform-builtin-classes-0.4.0.tgz",
-			"integrity": "sha512-snPxfDSaiOHjIflWtHRqKSBQK3KAHNETitbf/iasSDXXMgP4zqH9sOS91P0WcoPD9F1Kf840mJjHQuTjZMZAVw==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-classes/-/babel-plugin-transform-builtin-classes-0.6.1.tgz",
+			"integrity": "sha512-UfOmEFTc9i7ERkp77xnxiAIxrHwYetl6KYa42itb3ENi98KEVPwZxApse4C19oD7CzcJUiFrII+zgB6cZij77w==",
 			"requires": {
 				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-builtin-extend": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz",
-			"integrity": "sha1-Xpb+z1i4+h7XTvytiEdbKvPJEW4=",
-			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-class-constructor-call": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "6.18.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-class-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
 				"babel-runtime": "6.23.0",
 				"babel-template": "6.26.0"
 			}
@@ -2422,37 +3913,6 @@
 			"integrity": "sha1-RBTc7CP5aBUEHYULdXurqD3YxUI=",
 			"requires": {
 				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-decorators": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-			"requires": {
-				"babel-helper-explode-class": "6.24.1",
-				"babel-plugin-syntax-decorators": "6.13.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-decorators-legacy": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz",
-			"integrity": "sha1-dBtY9sW86eYCfgiC2cmU8E82aSU=",
-			"requires": {
-				"babel-plugin-syntax-decorators": "6.13.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-do-expressions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
-			"integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
-			"requires": {
-				"babel-plugin-syntax-do-expressions": "6.13.0",
-				"babel-runtime": "6.23.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -2604,26 +4064,6 @@
 				}
 			}
 		},
-		"babel-plugin-transform-es2015-modules-systemjs": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-umd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.26.0"
-			}
-		},
 		"babel-plugin-transform-es2015-object-super": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
@@ -2699,127 +4139,12 @@
 				"regexpu-core": "2.0.0"
 			}
 		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-export-extensions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-			"requires": {
-				"babel-plugin-syntax-export-extensions": "6.13.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-flow-strip-types": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-function-bind": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
-			"integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
-			"requires": {
-				"babel-plugin-syntax-function-bind": "6.13.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-object-assign": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
-			"integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
-			"requires": {
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-object-rest-spread": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.26.0"
-			},
-			"dependencies": {
-				"babel-runtime": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-					"requires": {
-						"core-js": "2.5.1",
-						"regenerator-runtime": "0.11.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-				}
-			}
-		},
-		"babel-plugin-transform-react-display-name": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-			"requires": {
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-			"requires": {
-				"babel-helper-builder-react-jsx": "6.26.0",
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-self": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-source": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.23.0"
-			}
-		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
 				"regenerator-transform": "0.10.1"
-			}
-		},
-		"babel-plugin-transform-skate-flow-props": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-skate-flow-props/-/babel-plugin-transform-skate-flow-props-0.1.0.tgz",
-			"integrity": "sha512-pDeiM2ockG9TV6O7XVN+pSHEDD1Ec59QmqdjSkKd878ykCYPiZgIrs1Eyc/qJjIlZU5wLnq1TY/VyHQnkD/GOg==",
-			"requires": {
-				"babel-types": "6.26.0",
-				"jest": "21.2.1"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -2857,173 +4182,6 @@
 						}
 					}
 				}
-			}
-		},
-		"babel-preset-env": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0",
-				"browserslist": "github:ai/browserslist#6c29b732531f33901cbc32953869196a7ba6dada",
-				"invariant": "2.2.2",
-				"semver": "5.4.1"
-			}
-		},
-		"babel-preset-es2015": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0"
-			}
-		},
-		"babel-preset-es2016": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz",
-			"integrity": "sha1-+QC/k+LrwNJ235uKtZck6/2Vn4s=",
-			"requires": {
-				"babel-plugin-transform-exponentiation-operator": "6.24.1"
-			}
-		},
-		"babel-preset-es2017": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.24.1.tgz",
-			"integrity": "sha1-WXvq37n38gi8/YoS6bKym4svFNE=",
-			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1"
-			}
-		},
-		"babel-preset-flow": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0"
-			}
-		},
-		"babel-preset-jest": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-			"integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
-			"requires": {
-				"babel-plugin-jest-hoist": "21.2.0",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0"
-			}
-		},
-		"babel-preset-preact": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-preact/-/babel-preset-preact-1.1.0.tgz",
-			"integrity": "sha1-NaxlWnOkm4Q4FjzgU4Fld+GYCGE=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-plugin-transform-react-jsx": "6.24.1"
-			}
-		},
-		"babel-preset-react": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-plugin-transform-react-display-name": "6.25.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-react-jsx-self": "6.22.0",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-preset-flow": "6.23.0"
-			}
-		},
-		"babel-preset-stage-0": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
-			"integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
-			"requires": {
-				"babel-plugin-transform-do-expressions": "6.22.0",
-				"babel-plugin-transform-function-bind": "6.22.0",
-				"babel-preset-stage-1": "6.24.1"
-			}
-		},
-		"babel-preset-stage-1": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
-			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-			"requires": {
-				"babel-plugin-transform-class-constructor-call": "6.24.1",
-				"babel-plugin-transform-export-extensions": "6.22.0",
-				"babel-preset-stage-2": "6.24.1"
-			}
-		},
-		"babel-preset-stage-2": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-			"requires": {
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-decorators": "6.24.1",
-				"babel-preset-stage-3": "6.24.1"
-			}
-		},
-		"babel-preset-stage-3": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-generator-functions": "6.24.1",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-object-rest-spread": "6.26.0"
 			}
 		},
 		"babel-register": {
@@ -4168,21 +5326,6 @@
 			"resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
 			"integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
 		},
-		"browser-resolve": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-			"requires": {
-				"resolve": "1.1.7"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-				}
-			}
-		},
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
@@ -4417,7 +5560,7 @@
 			}
 		},
 		"browserslist": {
-			"version": "github:ai/browserslist#6c29b732531f33901cbc32953869196a7ba6dada",
+			"version": "github:ai/browserslist#c32316d204c9a17e570962dec6b5abdfd39a2e24",
 			"requires": {
 				"caniuse-lite": "1.0.30000784",
 				"electron-to-chromium": "1.3.30"
@@ -4500,14 +5643,6 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
 			"integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
-		},
-		"bser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-			"requires": {
-				"node-int64": "0.4.0"
-			}
 		},
 		"buf-compare": {
 			"version": "1.0.1",
@@ -6154,11 +7289,6 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
-		"content-type-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-		},
 		"conventional-changelog": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.4.tgz",
@@ -7664,14 +8794,6 @@
 			"integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
 			"requires": {
 				"kind-of": "5.1.0"
-			}
-		},
-		"default-require-extensions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-			"requires": {
-				"strip-bom": "2.0.0"
 			}
 		},
 		"default-resolution": {
@@ -9247,11 +10369,6 @@
 				"estraverse": "4.2.0"
 			}
 		},
-		"eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
-		},
 		"espree": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
@@ -9452,14 +10569,6 @@
 				}
 			}
 		},
-		"exec-sh": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-			"requires": {
-				"merge": "1.2.0"
-			}
-		},
 		"execa": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
@@ -9524,33 +10633,124 @@
 				"os-homedir": "1.0.2"
 			}
 		},
-		"expect": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
-			"integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
-			"requires": {
-				"ansi-styles": "3.2.0",
-				"jest-diff": "21.2.1",
-				"jest-get-type": "21.2.0",
-				"jest-matcher-utils": "21.2.1",
-				"jest-message-util": "21.2.1",
-				"jest-regex-util": "21.2.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"requires": {
-						"color-convert": "1.9.0"
-					}
-				}
-			}
-		},
 		"expose-loader": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-0.7.4.tgz",
 			"integrity": "sha512-lweINkewAXcQtNjd7j1gO3cd8O/8lNYijsEwH4YZ+Dv3gT2Kh9/YvJov5Mdp2A75QIhgOvsSyRa/ZG3wYjNZpA=="
+		},
+		"express": {
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+			"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+			"requires": {
+				"accepts": "1.3.4",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.1",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.0",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.2",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.1",
+				"serve-static": "1.13.1",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.3.1",
+				"type-is": "1.6.15",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"accepts": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+					"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+					"requires": {
+						"mime-types": "2.1.17",
+						"negotiator": "0.6.1"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"finalhandler": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+					"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"on-finished": "2.3.0",
+						"parseurl": "1.3.2",
+						"statuses": "1.3.1",
+						"unpipe": "1.0.0"
+					}
+				},
+				"mime-db": {
+					"version": "1.30.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+					"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+				},
+				"mime-types": {
+					"version": "2.1.17",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+					"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+					"requires": {
+						"mime-db": "1.30.0"
+					}
+				},
+				"parseurl": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+					"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"serve-static": {
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+					"integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+					"requires": {
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"parseurl": "1.3.2",
+						"send": "0.16.1"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				},
+				"utils-merge": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+				}
+			}
 		},
 		"express-urlrewrite": {
 			"version": "1.2.0",
@@ -9764,14 +10964,6 @@
 				"websocket-driver": "0.7.0"
 			}
 		},
-		"fb-watchman": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-			"requires": {
-				"bser": "2.0.0"
-			}
-		},
 		"fd-slicer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -9870,15 +11062,6 @@
 				"trim-repeated": "1.0.0"
 			}
 		},
-		"fileset": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
-			}
-		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
@@ -9920,22 +11103,6 @@
 					"version": "0.7.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
 					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-				}
-			}
-		},
-		"find-babel-config": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.1.0.tgz",
-			"integrity": "sha1-rMAQQ6Z0n+w0Qpvmtk9ULrtdY1U=",
-			"requires": {
-				"json5": "0.5.1",
-				"path-exists": "3.0.0"
-			},
-			"dependencies": {
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 				}
 			}
 		},
@@ -13177,14 +14344,6 @@
 			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
 			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
 		},
-		"html-encoding-sniffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"requires": {
-				"whatwg-encoding": "1.0.3"
-			}
-		},
 		"html-entities": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
@@ -13603,6 +14762,30 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
 			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+		},
+		"import-local": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"requires": {
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
+			},
+			"dependencies": {
+				"resolve-cwd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+					"requires": {
+						"resolve-from": "3.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+				}
+			}
 		},
 		"import-modules": {
 			"version": "1.1.0",
@@ -14551,107 +15734,6 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
-		"istanbul-api": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
-			"integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
-			"requires": {
-				"async": "2.5.0",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.1.1",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.9.1",
-				"istanbul-lib-report": "1.1.2",
-				"istanbul-lib-source-maps": "1.2.2",
-				"istanbul-reports": "1.1.3",
-				"js-yaml": "3.9.1",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
-			}
-		},
-		"istanbul-lib-coverage": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
-		},
-		"istanbul-lib-hook": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
-			"requires": {
-				"append-transform": "0.4.0"
-			}
-		},
-		"istanbul-lib-instrument": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
-			"integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
-			"requires": {
-				"babel-generator": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.1.1",
-				"semver": "5.4.1"
-			}
-		},
-		"istanbul-lib-report": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-			"integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
-			"requires": {
-				"istanbul-lib-coverage": "1.1.1",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"istanbul-lib-source-maps": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-			"integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
-			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.1.1",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.1",
-				"source-map": "0.5.6"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"istanbul-reports": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-			"integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
-			"requires": {
-				"handlebars": "4.0.10"
-			}
-		},
 		"isurl": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
@@ -14659,601 +15741,6 @@
 			"requires": {
 				"has-to-string-tag-x": "1.4.0",
 				"is-object": "1.0.1"
-			}
-		},
-		"jest": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz",
-			"integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
-			"requires": {
-				"jest-cli": "21.2.1"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-					"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"jest-cli": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
-					"integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
-					"requires": {
-						"ansi-escapes": "3.0.0",
-						"chalk": "2.0.1",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"is-ci": "1.0.10",
-						"istanbul-api": "1.2.1",
-						"istanbul-lib-coverage": "1.1.1",
-						"istanbul-lib-instrument": "1.9.1",
-						"istanbul-lib-source-maps": "1.2.2",
-						"jest-changed-files": "21.2.0",
-						"jest-config": "21.2.1",
-						"jest-environment-jsdom": "21.2.1",
-						"jest-haste-map": "21.2.0",
-						"jest-message-util": "21.2.1",
-						"jest-regex-util": "21.2.0",
-						"jest-resolve-dependencies": "21.2.0",
-						"jest-runner": "21.2.1",
-						"jest-runtime": "21.2.1",
-						"jest-snapshot": "21.2.1",
-						"jest-util": "21.2.1",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.1.2",
-						"pify": "3.0.0",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.2.14",
-						"worker-farm": "1.5.0",
-						"yargs": "9.0.1"
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"string-length": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-					"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-					"requires": {
-						"astral-regex": "1.0.0",
-						"strip-ansi": "4.0.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-				},
-				"yargs": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"requires": {
-						"camelcase": "4.1.0"
-					}
-				}
-			}
-		},
-		"jest-changed-files": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
-			"integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
-			"requires": {
-				"throat": "4.1.0"
-			}
-		},
-		"jest-config": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
-			"integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
-			"requires": {
-				"chalk": "2.0.1",
-				"glob": "7.1.2",
-				"jest-environment-jsdom": "21.2.1",
-				"jest-environment-node": "21.2.1",
-				"jest-get-type": "21.2.0",
-				"jest-jasmine2": "21.2.1",
-				"jest-regex-util": "21.2.0",
-				"jest-resolve": "21.2.0",
-				"jest-util": "21.2.1",
-				"jest-validate": "21.2.1",
-				"pretty-format": "21.2.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"requires": {
-						"color-convert": "1.9.0"
-					}
-				},
-				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
-					}
-				}
-			}
-		},
-		"jest-diff": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
-			"integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
-			"requires": {
-				"chalk": "2.0.1",
-				"diff": "3.2.0",
-				"jest-get-type": "21.2.0",
-				"pretty-format": "21.2.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"requires": {
-						"color-convert": "1.9.0"
-					}
-				},
-				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
-					}
-				}
-			}
-		},
-		"jest-docblock": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw=="
-		},
-		"jest-environment-jsdom": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
-			"integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
-			"requires": {
-				"jest-mock": "21.2.0",
-				"jest-util": "21.2.1",
-				"jsdom": "9.12.0"
-			}
-		},
-		"jest-environment-node": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
-			"integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
-			"requires": {
-				"jest-mock": "21.2.0",
-				"jest-util": "21.2.1"
-			}
-		},
-		"jest-get-type": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-			"integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q=="
-		},
-		"jest-haste-map": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-			"integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
-			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.11",
-				"jest-docblock": "21.2.0",
-				"micromatch": "2.3.11",
-				"sane": "2.2.0",
-				"worker-farm": "1.5.0"
-			}
-		},
-		"jest-jasmine2": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
-			"integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
-			"requires": {
-				"chalk": "2.0.1",
-				"expect": "21.2.1",
-				"graceful-fs": "4.1.11",
-				"jest-diff": "21.2.1",
-				"jest-matcher-utils": "21.2.1",
-				"jest-message-util": "21.2.1",
-				"jest-snapshot": "21.2.1",
-				"p-cancelable": "0.3.0"
-			}
-		},
-		"jest-matcher-utils": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
-			"integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
-			"requires": {
-				"chalk": "2.0.1",
-				"jest-get-type": "21.2.0",
-				"pretty-format": "21.2.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"requires": {
-						"color-convert": "1.9.0"
-					}
-				},
-				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
-					}
-				}
-			}
-		},
-		"jest-message-util": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
-			"integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
-			"requires": {
-				"chalk": "2.0.1",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0"
-			}
-		},
-		"jest-mock": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
-			"integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw=="
-		},
-		"jest-regex-util": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
-			"integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ=="
-		},
-		"jest-resolve": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
-			"integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
-			"requires": {
-				"browser-resolve": "1.11.2",
-				"chalk": "2.0.1",
-				"is-builtin-module": "1.0.0"
-			}
-		},
-		"jest-resolve-dependencies": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz",
-			"integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
-			"requires": {
-				"jest-regex-util": "21.2.0"
-			}
-		},
-		"jest-runner": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
-			"integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
-			"requires": {
-				"jest-config": "21.2.1",
-				"jest-docblock": "21.2.0",
-				"jest-haste-map": "21.2.0",
-				"jest-jasmine2": "21.2.1",
-				"jest-message-util": "21.2.1",
-				"jest-runtime": "21.2.1",
-				"jest-util": "21.2.1",
-				"pify": "3.0.0",
-				"throat": "4.1.0",
-				"worker-farm": "1.5.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
-			}
-		},
-		"jest-runtime": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
-			"integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
-			"requires": {
-				"babel-core": "6.26.0",
-				"babel-jest": "21.2.0",
-				"babel-plugin-istanbul": "4.1.5",
-				"chalk": "2.0.1",
-				"convert-source-map": "1.5.0",
-				"graceful-fs": "4.1.11",
-				"jest-config": "21.2.1",
-				"jest-haste-map": "21.2.0",
-				"jest-regex-util": "21.2.0",
-				"jest-resolve": "21.2.0",
-				"jest-util": "21.2.1",
-				"json-stable-stringify": "1.0.1",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0",
-				"strip-bom": "3.0.0",
-				"write-file-atomic": "2.1.0",
-				"yargs": "9.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-				},
-				"yargs": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"requires": {
-						"camelcase": "4.1.0"
-					}
-				}
-			}
-		},
-		"jest-snapshot": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
-			"integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
-			"requires": {
-				"chalk": "2.0.1",
-				"jest-diff": "21.2.1",
-				"jest-matcher-utils": "21.2.1",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"pretty-format": "21.2.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"requires": {
-						"color-convert": "1.9.0"
-					}
-				},
-				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
-					}
-				}
-			}
-		},
-		"jest-util": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
-			"integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
-			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.0.1",
-				"graceful-fs": "4.1.11",
-				"jest-message-util": "21.2.1",
-				"jest-mock": "21.2.0",
-				"jest-validate": "21.2.1",
-				"mkdirp": "0.5.1"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
-				}
-			}
-		},
-		"jest-validate": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
-			"integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
-			"requires": {
-				"chalk": "2.0.1",
-				"jest-get-type": "21.2.0",
-				"leven": "2.1.0",
-				"pretty-format": "21.2.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"requires": {
-						"color-convert": "1.9.0"
-					}
-				},
-				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
-					}
-				}
 			}
 		},
 		"jimp": {
@@ -15369,39 +15856,6 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.2.tgz",
 			"integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo="
-		},
-		"jsdom": {
-			"version": "9.12.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
-			"requires": {
-				"abab": "1.0.4",
-				"acorn": "4.0.13",
-				"acorn-globals": "3.1.0",
-				"array-equal": "1.0.0",
-				"content-type-parser": "1.0.2",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"escodegen": "1.9.0",
-				"html-encoding-sniffer": "1.0.2",
-				"nwmatcher": "1.4.3",
-				"parse5": "1.5.1",
-				"request": "2.81.0",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.2",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "4.8.0",
-				"xml-name-validator": "2.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				}
-			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
@@ -16138,6 +16592,11 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
 			"integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
+		},
+		"killable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
 		},
 		"kind-of": {
 			"version": "5.1.0",
@@ -16890,11 +17349,6 @@
 					}
 				}
 			}
-		},
-		"leven": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
 		},
 		"levenshtein-edit-distance": {
 			"version": "1.0.0",
@@ -18078,14 +18532,6 @@
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"optional": true
 				}
-			}
-		},
-		"makeerror": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-			"requires": {
-				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -19309,11 +19755,6 @@
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
 				}
 			}
-		},
-		"node-int64": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
 		"node-libs-browser": {
 			"version": "2.0.0",
@@ -21340,11 +21781,6 @@
 				"mkdirp": "0.5.1",
 				"object-assign": "4.1.1"
 			}
-		},
-		"p-cancelable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -26445,6 +26881,21 @@
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
 			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
 		},
+		"regenerate-unicode-properties": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
+			"integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
+			"requires": {
+				"regenerate": "1.3.3"
+			},
+			"dependencies": {
+				"regenerate": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+					"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+				}
+			}
+		},
 		"regenerator-babel": {
 			"version": "0.8.10-2",
 			"resolved": "https://registry.npmjs.org/regenerator-babel/-/regenerator-babel-0.8.10-2.tgz",
@@ -28059,28 +28510,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
 			"integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
-		},
-		"sane": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
-			"integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
-			"requires": {
-				"anymatch": "1.3.0",
-				"exec-sh": "0.2.1",
-				"fb-watchman": "2.0.0",
-				"fsevents": "1.1.2",
-				"minimatch": "3.0.4",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.18.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
 		},
 		"sass-convert": {
 			"version": "0.5.2",
@@ -33563,29 +33992,6 @@
 				"through2": "2.0.3"
 			}
 		},
-		"test-exclude": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-			"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "2.3.11",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
-			},
-			"dependencies": {
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				}
-			}
-		},
 		"test-value": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
@@ -33671,11 +34077,6 @@
 			"requires": {
 				"thenify": "3.3.0"
 			}
-		},
-		"throat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"throttleit": {
 			"version": "1.0.0",
@@ -33788,11 +34189,6 @@
 				"bluebird": "3.4.6",
 				"tmp": "0.0.31"
 			}
-		},
-		"tmpl": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
 		},
 		"to-absolute-glob": {
 			"version": "0.1.1",
@@ -34410,6 +34806,30 @@
 				"inherits": "2.0.3",
 				"xtend": "4.0.1"
 			}
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
+			"integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
+			"integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "1.0.3",
+				"unicode-property-aliases-ecmascript": "1.0.3"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
+			"integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
+			"integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w=="
 		},
 		"unified": {
 			"version": "6.1.5",
@@ -35264,36 +35684,12 @@
 			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
 			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
 		},
-		"walker": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-			"requires": {
-				"makeerror": "1.0.11"
-			}
-		},
 		"ware": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
 			"integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
 			"requires": {
 				"wrap-fn": "0.1.5"
-			}
-		},
-		"watch": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-			"requires": {
-				"exec-sh": "0.2.1",
-				"minimist": "1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
 			}
 		},
 		"watchpack": {
@@ -36170,19 +36566,14 @@
 				}
 			}
 		},
-		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-		},
 		"webpack": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+			"integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
 			"requires": {
 				"acorn": "5.1.1",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.3.0",
+				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
 				"async": "2.5.0",
 				"enhanced-resolve": "3.4.1",
@@ -36205,9 +36596,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-					"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"requires": {
 						"co": "4.6.0",
 						"fast-deep-equal": "1.0.0",
@@ -36219,57 +36610,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
 					"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
 				},
 				"supports-color": {
 					"version": "4.5.0",
@@ -36287,39 +36627,6 @@
 						"source-map": "0.5.6",
 						"uglify-js": "2.8.29",
 						"webpack-sources": "1.0.1"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-				},
-				"yargs": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"requires": {
-						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -36353,9 +36660,9 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.1.tgz",
-			"integrity": "sha512-qFKs4Wg6JI6FkAQ6WFqeDCCxXEBLsDHkqJB3f9tmlqx8C68Y9vQWwcaMT4Q9H8WF32Q6QUNmgK4qQkdHfXvj/g==",
+			"version": "2.9.7",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.7.tgz",
+			"integrity": "sha512-Pu7uoQFgQj5RE5wmlfkpYSzihMKxulwEuO2xCsaMnAnyRSApwoVi3B8WCm9XbigyWTHaIMzYGkB90Vr6leAeTQ==",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"array-includes": "3.0.3",
@@ -36363,12 +36670,15 @@
 				"chokidar": "1.7.0",
 				"compression": "1.7.0",
 				"connect-history-api-fallback": "1.3.0",
+				"debug": "3.1.0",
 				"del": "3.0.0",
 				"express": "4.16.2",
 				"html-entities": "1.2.1",
 				"http-proxy-middleware": "0.17.4",
+				"import-local": "0.1.1",
 				"internal-ip": "1.2.0",
 				"ip": "1.1.5",
+				"killable": "1.0.0",
 				"loglevel": "1.4.1",
 				"opn": "5.1.0",
 				"portfinder": "1.0.13",
@@ -36378,134 +36688,23 @@
 				"sockjs-client": "1.1.4",
 				"spdy": "3.4.7",
 				"strip-ansi": "3.0.1",
-				"supports-color": "4.4.0",
+				"supports-color": "4.5.0",
 				"webpack-dev-middleware": "1.12.0",
 				"yargs": "6.6.0"
 			},
 			"dependencies": {
-				"accepts": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-					"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-					"requires": {
-						"mime-types": "2.1.17",
-						"negotiator": "0.6.1"
-					}
-				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				},
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"del": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-					"requires": {
-						"globby": "6.1.0",
-						"is-path-cwd": "1.0.0",
-						"is-path-in-cwd": "1.0.0",
-						"p-map": "1.1.1",
-						"pify": "3.0.0",
-						"rimraf": "2.6.1"
-					}
-				},
-				"etag": {
-					"version": "1.8.1",
-					"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-				},
-				"express": {
-					"version": "4.16.2",
-					"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-					"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
-					"requires": {
-						"accepts": "1.3.4",
-						"array-flatten": "1.1.1",
-						"body-parser": "1.18.2",
-						"content-disposition": "0.5.2",
-						"content-type": "1.0.4",
-						"cookie": "0.3.1",
-						"cookie-signature": "1.0.6",
-						"debug": "2.6.9",
-						"depd": "1.1.1",
-						"encodeurl": "1.0.1",
-						"escape-html": "1.0.3",
-						"etag": "1.8.1",
-						"finalhandler": "1.1.0",
-						"fresh": "0.5.2",
-						"merge-descriptors": "1.0.1",
-						"methods": "1.1.2",
-						"on-finished": "2.3.0",
-						"parseurl": "1.3.2",
-						"path-to-regexp": "0.1.7",
-						"proxy-addr": "2.0.2",
-						"qs": "6.5.1",
-						"range-parser": "1.2.0",
-						"safe-buffer": "5.1.1",
-						"send": "0.16.1",
-						"serve-static": "1.13.1",
-						"setprototypeof": "1.1.0",
-						"statuses": "1.3.1",
-						"type-is": "1.6.15",
-						"utils-merge": "1.0.1",
-						"vary": "1.1.2"
-					}
-				},
-				"finalhandler": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-					"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-					"requires": {
-						"debug": "2.6.9",
-						"encodeurl": "1.0.1",
-						"escape-html": "1.0.3",
-						"on-finished": "2.3.0",
-						"parseurl": "1.3.2",
-						"statuses": "1.3.1",
-						"unpipe": "1.0.0"
-					}
-				},
-				"fresh": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-				},
-				"mime-db": {
-					"version": "1.30.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-					"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-				},
-				"mime-types": {
-					"version": "2.1.17",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-					"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-					"requires": {
-						"mime-db": "1.30.0"
-					}
-				},
-				"parseurl": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-					"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
@@ -36516,34 +36715,13 @@
 						"read-pkg": "1.1.0"
 					}
 				},
-				"serve-static": {
-					"version": "1.13.1",
-					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-					"integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-					"requires": {
-						"encodeurl": "1.0.1",
-						"escape-html": "1.0.3",
-						"parseurl": "1.3.2",
-						"send": "0.16.1"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-				},
 				"supports-color": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"requires": {
 						"has-flag": "2.0.0"
 					}
-				},
-				"utils-merge": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 				},
 				"yargs": {
 					"version": "6.6.0",
@@ -36628,37 +36806,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
 			"integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0="
-		},
-		"whatwg-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-			"requires": {
-				"iconv-lite": "0.4.19"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.19",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-				}
-			}
-		},
-		"whatwg-url": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-			"requires": {
-				"tr46": "0.0.3",
-				"webidl-conversions": "3.0.1"
-			},
-			"dependencies": {
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-				}
-			}
 		},
 		"whatwg-url-compat": {
 			"version": "0.6.5",

--- a/packages/bolt-config-presets/babel-preset-bolt/index.js
+++ b/packages/bolt-config-presets/babel-preset-bolt/index.js
@@ -15,24 +15,15 @@ const preset = function (api, opts = {}) {
       }]
     ],
     plugins: [
-/**
- * 1. Required till github.com/github/babel-plugin-transform-custom-element-classes/issues/11
- *    is closed. Currently this is required for Bolt's SVG icon component
- *
- * 2. Allows us to dynamically import JS via Webpack. ex. import('button.standalone.js')
- */
       '@babel/plugin-syntax-decorators', // ex. @define
       '@babel/plugin-proposal-decorators',
-
-
 
       // critical for preact rendering
       [
         '@babel/plugin-transform-react-jsx',
         {
           pragma: 'h',
-          pragmaFrag: "\"span\"",
-          // pragmaFrag: "h",
+          pragmaFrag: '\"span\"',
           throwIfNamespace: false,
           useBuiltIns: false
         }

--- a/packages/bolt-config-presets/babel-preset-bolt/index.js
+++ b/packages/bolt-config-presets/babel-preset-bolt/index.js
@@ -1,7 +1,8 @@
-const preset = function(api, opts = {}) {
+const preset = function (api, opts = {}) {
   return {
     presets: [
-      ['env', {
+      '@babel/preset-stage-3',
+      ['@babel/preset-env', {
         targets: {
           node: 'current',
           browsers: [
@@ -20,23 +21,20 @@ const preset = function(api, opts = {}) {
  *
  * 2. Allows us to dynamically import JS via Webpack. ex. import('button.standalone.js')
  */
-      'transform-decorators-legacy', // ex. @define
+      '@babel/plugin-syntax-decorators', // ex. @define
+      '@babel/plugin-proposal-decorators',
 
-      'transform-export-extensions', // ex. `export Communications from './icons/communications';` - used in @bolt/components-icons  
 
-      'transform-class-properties', // ex. class { handleThing = () => { } }
-
-      'transform-custom-element-classes', /* [1] */
-
-      'transform-es2015-classes', /* [1] */
-
-      'syntax-dynamic-import', /* [2] */
 
       // critical for preact rendering
       [
-        'transform-react-jsx',
+        '@babel/plugin-transform-react-jsx',
         {
-          pragma: 'h'
+          pragma: 'h',
+          pragmaFrag: "\"span\"",
+          // pragmaFrag: "h",
+          throwIfNamespace: false,
+          useBuiltIns: false
         }
       ],
 
@@ -50,21 +48,10 @@ const preset = function(api, opts = {}) {
         }
       ],
 
-      // The following two plugins use Object.assign directly, instead of Babel's
-      // extends helper. Note that this assumes `Object.assign` is available.
-      // { ...todo, completed: true }
-      [
-        'transform-object-assign',
-        {
-          async: true
-        }
-      ],
 
       [
-        'transform-object-rest-spread',
-        {
-          useBuiltIns: true
-        }
+        '@babel/plugin-proposal-class-properties',
+        { loose: false }
       ],
 
       // @TODO: only include this when being run on a NODE environment

--- a/packages/bolt-config-presets/babel-preset-bolt/package.json
+++ b/packages/bolt-config-presets/babel-preset-bolt/package.json
@@ -13,22 +13,18 @@
     ]
   },
   "dependencies": {
-    "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-jsx-pragmatic": "^1.0.2",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-plugin-transform-async-to-generator": "^6.24.1",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-custom-element-classes": "^0.1.0",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-es2015-classes": "^6.24.1",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-    "babel-plugin-transform-es2015-parameters": "^6.24.1",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-assign": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-plugin-transform-regenerator": "^6.26.0",
-    "babel-preset-env": "^1.6.1"
+    "@babel/plugin-syntax-jsx": "^7.0.0-beta.36",
+    "@babel/core": "^7.0.0-beta.36",
+    "@babel/plugin-syntax-decorators": "^7.0.0-beta.36",
+    "@babel/plugin-proposal-decorators": "^7.0.0-beta.36",
+    "@babel/plugin-transform-object-assign": "^7.0.0-beta.36",
+    "@babel/plugin-transform-react-jsx": "^7.0.0-beta.36",
+    "@babel/preset-env": "^v7.0.0-beta.36",
+    "@babel/preset-stage-3": "^v7.0.0-beta.36",
+    "@babel/plugin-transform-classes": "^v7.0.0-beta.36",
+    "@babel/plugin-syntax-class-properties": "^7.0.0-beta.36",
+    "@babel/plugin-proposal-class-properties": "^7.0.0-beta.36"
   },
   "keywords": [
     "babel",


### PR DESCRIPTION
- Update Babel dependencies to use the latest versions -- needed in order to use [newer fragment syntax](https://github.com/babel/babel/pull/6552) Preact has been supporting based on [recent React updates](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html)
- Update Webpack babel loader version to also use this latest version to fix Webpack errors otherwise (under the hood would be using the older version of Babel)
- Upgrade babel configuration based on the new package names (namely the babel namespace getting added to npm packages)
- Remove plugins no longer needed after adding the babel preset stage 3 package (ie. pre-configured to wire up a bunch of these) to simplify our own config

CC @EvanLovely 