### PR TITLE
Add custom brightcove metadata

### DIFF
--- a/src/_patterns/02-components/brightcove-player/src/brightcove-meta.scss
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-meta.scss
@@ -1,0 +1,16 @@
+$bolt-export-data: false !global;
+
+@import '@bolt/settings-all';
+@import '@bolt/tools-all';
+
+.brightcove-meta__wrapper {
+  @include bolt-padding(medium, squished);
+  @include bolt-font-size(xsmall);
+
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(bolt-color(indigo), 0.8);
+  color: bolt-color(white);
+}

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.scss
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.scss
@@ -12,6 +12,19 @@ brightcove-player {
   }
 }
 
+bolt-video {
+  // Hide the metadata (which covers the controls) if the user is either
+  //   a) watching the video
+  //   b) potentially interacting with the video
+  &:hover,
+  &.is-playing,
+  &:hover.is-paused {
+    brightcove-meta {
+      display: none;
+    }
+  }
+}
+
 
 .video-js {
   // @supports (--custom:property) {

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
@@ -134,9 +134,6 @@ class BrightcoveVideo extends withComponent(withPreact()) {
   //   console.log(state);
   // }
 
-  _setDuration(time){
-    this.querySelector('brightcove-meta').setAttribute('duration', time);
-  }
 
   _setVideoDimensions(width, height) {
     this.srcWidth = width;
@@ -154,7 +151,6 @@ class BrightcoveVideo extends withComponent(withPreact()) {
       const width = player.mediainfo.sources[1].width;
       const height = player.mediainfo.sources[1].height;
 
-      elem._setDuration(duration);
       elem._setVideoDimensions(width, height);
       elem._calculateIdealVideoSize();
     });
@@ -416,7 +412,6 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     // this.setState({ duration: BrightcoveVideo.getDurationMs(player) });
 
     this.state.duration = duration;
-    this._setDuration(duration);
   }
 
   onEnded() {

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
@@ -13,6 +13,23 @@ import {
 
 let index = 0;
 
+
+@define
+class BrightcoveMeta extends withComponent(withPreact()) {
+  static is = 'brightcove-meta'
+
+  static props = {
+    duration: props.string
+  }
+
+  render() {
+    return (
+      <div>Duration: {this.duration}</div>
+    );
+  }
+}
+
+
 @define
 class BrightcoveVideo extends withComponent(withPreact()) {
   static is = 'brightcove-player';
@@ -112,13 +129,13 @@ class BrightcoveVideo extends withComponent(withPreact()) {
 
   // Called to check whether or not the component should call
   // updated(), much like React's shouldComponentUpdate().
-  // updating(props, state) { 
+  // updating(props, state) {
   //   console.log(props);
   //   console.log(state);
   // }
 
   _setDuration(time){
-    this.duration = time;
+    this.querySelector('brightcove-meta').setAttribute('duration', time);
   }
 
   _setVideoDimensions(width, height) {
@@ -137,7 +154,7 @@ class BrightcoveVideo extends withComponent(withPreact()) {
       const width = player.mediainfo.sources[1].width;
       const height = player.mediainfo.sources[1].height;
 
-      elem._setDuration();
+      elem._setDuration(duration);
       elem._setVideoDimensions(width, height);
       elem._calculateIdealVideoSize();
     });
@@ -399,6 +416,7 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     // this.setState({ duration: BrightcoveVideo.getDurationMs(player) });
 
     this.state.duration = duration;
+    this._setDuration(duration);
   }
 
   onEnded() {
@@ -545,21 +563,24 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     // Added a wrapping div as brightcove adds siblings to the video tag
 
     return(
-      <video
-        id={this.state.id}
-        {...(this.props.poster ? { poster: this.props.poster.uri } : {}) }
-        data-embed="default"
-        data-video-id={this.props.videoId}
-        data-account={this.props.accountId}
-        data-player={this.props.playerId}
-        // playIcon={playIconEmoji()}
-        // following 'autoplay' can not expected to always work on web
-        // see: https://docs.brightcove.com/en/player/brightcove-player/guides/in-page-embed-player-implementation.html
-        autoPlay={this.props.autoplay}
-        data-application-id
-        className="video-js"
-        controls
-      />
+      <div>
+        <video
+          id={this.state.id}
+          {...(this.props.poster ? { poster: this.props.poster.uri } : {}) }
+          data-embed="default"
+          data-video-id={this.props.videoId}
+          data-account={this.props.accountId}
+          data-player={this.props.playerId}
+          // playIcon={playIconEmoji()}
+          // following 'autoplay' can not expected to always work on web
+          // see: https://docs.brightcove.com/en/player/brightcove-player/guides/in-page-embed-player-implementation.html
+          autoPlay={this.props.autoplay}
+          data-application-id
+          className="video-js"
+          controls
+        />
+        <brightcove-meta />
+      </div>
     );
   }
 }

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
@@ -13,18 +13,31 @@ import {
 
 let index = 0;
 
+import metaStyles from './brightcove-meta.scss';
 
 @define
 class BrightcoveMeta extends withComponent(withPreact()) {
-  static is = 'brightcove-meta'
+  static is = 'brightcove-meta';
 
   static props = {
-    duration: props.string
-  }
+    duration: props.string,
+    title: props.string
+  };
 
   render() {
+    const separator = this.title && this.duration ? ' | ' : '';
+
+    // 'reveal' allows the metadata to be hidden.
+    // All of its logic is contained here in render(), but it could be updated to be a property that is set
+    // externally (such as when the video has finished fully loading).
+    const reveal =  Boolean(this.title || this.duration);
     return (
-      <div>Duration: {this.duration}</div>
+      <div>
+        <style>{metaStyles[0][1]}</style>
+        {reveal ? (
+          <div class="brightcove-meta__wrapper">{this.title}{separator}{this.duration}</div>
+        ) : null}
+      </div>
     );
   }
 }

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
@@ -147,6 +147,21 @@ class BrightcoveVideo extends withComponent(withPreact()) {
   //   console.log(state);
   // }
 
+  _setMetaTitle(title) {
+    this.querySelector('brightcove-meta').setAttribute('title', title);
+  }
+
+  _setMetaDuration(seconds) {
+    const durationFormatted = BrightcoveVideo._formatDuration(seconds);
+    this.querySelector('brightcove-meta').setAttribute('duration', durationFormatted);
+  }
+
+  static _formatDuration(seconds) {
+    const mm = Math.floor(seconds / 60) || 0;
+    const ss = ('0' + Math.floor(seconds % 60)).slice(-2);
+
+    return mm + ':' + ss;
+  }
 
   _setVideoDimensions(width, height) {
     this.srcWidth = width;
@@ -161,9 +176,12 @@ class BrightcoveVideo extends withComponent(withPreact()) {
 
     player.on("loadedmetadata", function () {
       const duration = player.mediainfo.duration;
+      const title = player.mediainfo.name;
       const width = player.mediainfo.sources[1].width;
       const height = player.mediainfo.sources[1].height;
 
+      elem._setMetaTitle(title);
+      elem._setMetaDuration(duration);
       elem._setVideoDimensions(width, height);
       elem._calculateIdealVideoSize();
     });


### PR DESCRIPTION
Resolves [BK-124](http://vjira2:8080/browse/BK-124)

Notes:
- The metadata band appears before the embedded video expands to its full size, which seems less than ideal.  I couldn't find an appropriate place that would know when the video has been resized so that I could trigger display of the metadata from there.
- This is has not been thoroughly tested in context (i.e. on a real page, with multiple videos on a single page, etc).  I'm unsure of the best way to do that.
- Should metadata be hidden for background videos?  It is not in this PR.
  