### PR TITLE
Add Video Player Event Hooks + Integration Example

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -126,6 +126,7 @@ plugins:
           - src/_patterns/02-components/bolt-unordered-list/src
           - src/_patterns/02-components/bolt-video/demo
           - src/_patterns/02-components/bolt-video/src
+          - src/_patterns/02-components/brightcove-player/demo
           - src/_patterns/02-components/brightcove-player/src
           - src/_patterns/03-templates/default
           - src/_patterns/04-pages/bolt-homepage

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
 				"fs-extra": "4.0.2",
 				"gulp": "github:gulpjs/gulp#71c094a51c7972d26f557899ddecab0210ef3776",
 				"gulp-exec": "2.1.3",
-				"gulp-notify": "3.0.0",
+				"gulp-notify": "3.1.0",
 				"gulp-plumber": "1.1.0",
-				"gulp-shell": "0.6.3",
+				"gulp-shell": "0.6.5",
 				"gulp-util": "3.0.8",
 				"js-yaml": "3.9.1",
 				"merge": "1.2.0",
@@ -1054,6 +1054,21 @@
 				}
 			}
 		},
+		"acorn-globals": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+			"integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+			"requires": {
+				"acorn": "2.7.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+					"integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+				}
+			}
+		},
 		"acorn-jsx": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
@@ -1166,6 +1181,14 @@
 				"ansi-wrap": "0.1.0"
 			}
 		},
+		"ansi-cyan": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
 		"ansi-escape-sequences": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
@@ -1179,10 +1202,26 @@
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
 			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
 		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
 		"ansi-html": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
 			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+		},
+		"ansi-red": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -1554,9 +1593,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -1587,9 +1626,9 @@
 			"integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k="
 		},
 		"async": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -1797,17 +1836,6 @@
 						"snapdragon-node": "2.1.1",
 						"split-string": "3.1.0",
 						"to-regex": "3.0.1"
-					}
-				},
-				"enhanced-resolve": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
-					"integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"memory-fs": "0.4.1",
-						"object-assign": "4.1.1",
-						"tapable": "0.2.8"
 					}
 				},
 				"expand-brackets": {
@@ -3854,7 +3882,7 @@
 				"deep-equal": "1.0.1",
 				"dns-equal": "1.0.0",
 				"dns-txt": "2.0.2",
-				"multicast-dns": "6.1.1",
+				"multicast-dns": "6.2.1",
 				"multicast-dns-service-types": "1.1.0"
 			},
 			"dependencies": {
@@ -4003,14 +4031,15 @@
 			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
 		},
 		"browser-sync": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.21.0.tgz",
-			"integrity": "sha1-kc3jqEUvIvNV6+cXyhs8Hb+coJY=",
+			"version": "2.23.3",
+			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.23.3.tgz",
+			"integrity": "sha512-80n+JYiiwESY+FAqg8LSN8xgz8+aE3zyc5zmKBEbotP/kN8uzOtsvw+jzsfUrKF+TBrWoiPMyXhHD4BB/czpqQ==",
 			"requires": {
 				"browser-sync-ui": "1.0.1",
 				"bs-recipes": "1.3.4",
 				"chokidar": "1.7.0",
 				"connect": "3.5.0",
+				"connect-history-api-fallback": "1.5.0",
 				"dev-ip": "1.0.1",
 				"easy-extender": "2.3.2",
 				"eazy-logger": "3.0.2",
@@ -4031,7 +4060,6 @@
 				"serve-static": "1.12.2",
 				"server-destroy": "1.0.1",
 				"socket.io": "2.0.4",
-				"socket.io-client": "1.6.0",
 				"ua-parser-js": "0.7.12",
 				"yargs": "6.4.0"
 			},
@@ -4049,15 +4077,6 @@
 						"graceful-fs": "4.1.11",
 						"jsonfile": "3.0.1",
 						"universalify": "0.1.0"
-					}
-				},
-				"opn": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-					"requires": {
-						"object-assign": "4.1.1",
-						"pinkie-promise": "2.0.1"
 					}
 				},
 				"qs": {
@@ -4116,54 +4135,11 @@
 			"integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
 			"requires": {
 				"async-each-series": "0.1.1",
-				"connect-history-api-fallback": "1.3.0",
+				"connect-history-api-fallback": "1.5.0",
 				"immutable": "3.8.1",
 				"server-destroy": "1.0.1",
 				"socket.io-client": "2.0.4",
 				"stream-throttle": "0.1.3"
-			},
-			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-				},
-				"socket.io-client": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-					"integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
-					"requires": {
-						"backo2": "1.0.2",
-						"base64-arraybuffer": "0.1.5",
-						"component-bind": "1.0.0",
-						"component-emitter": "1.2.1",
-						"debug": "2.6.8",
-						"engine.io-client": "3.1.4",
-						"has-cors": "1.1.0",
-						"indexof": "0.0.1",
-						"object-component": "0.0.3",
-						"parseqs": "0.0.5",
-						"parseuri": "0.0.5",
-						"socket.io-parser": "3.1.2",
-						"to-array": "0.1.4"
-					}
-				},
-				"socket.io-parser": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
-					"integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
-					"requires": {
-						"component-emitter": "1.2.1",
-						"debug": "2.6.8",
-						"has-binary2": "1.0.2",
-						"isarray": "2.0.1"
-					}
-				}
 			}
 		},
 		"browserify-aes": {
@@ -4223,11 +4199,11 @@
 			}
 		},
 		"browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
-				"pako": "0.2.9"
+				"pako": "1.0.6"
 			}
 		},
 		"browserslist": {
@@ -4270,44 +4246,6 @@
 				"dom-compare-temp": "0.1.0",
 				"jsdom": "6.5.1",
 				"request": "2.81.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-					"integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
-				},
-				"acorn-globals": {
-					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-					"integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
-					"requires": {
-						"acorn": "2.7.0"
-					}
-				},
-				"jsdom": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-6.5.1.tgz",
-					"integrity": "sha1-tgZNanZRCBr0HVdu3Fa8UeABIsA=",
-					"requires": {
-						"acorn": "2.7.0",
-						"acorn-globals": "1.0.9",
-						"browser-request": "0.3.3",
-						"cssom": "0.3.2",
-						"cssstyle": "0.2.37",
-						"escodegen": "1.9.0",
-						"htmlparser2": "3.9.2",
-						"nwmatcher": "1.4.3",
-						"parse5": "1.5.1",
-						"request": "2.81.0",
-						"symbol-tree": "3.2.2",
-						"tough-cookie": "2.3.2",
-						"whatwg-url-compat": "0.6.5",
-						"xml-name-validator": "2.0.1",
-						"xmlhttprequest": "1.8.0",
-						"xtend": "4.0.1"
-					}
-				}
 			}
 		},
 		"bs-recipes": {
@@ -5884,7 +5822,7 @@
 			"requires": {
 				"debug": "2.2.0",
 				"finalhandler": "0.5.0",
-				"parseurl": "1.3.1",
+				"parseurl": "1.3.2",
 				"utils-merge": "1.0.0"
 			},
 			"dependencies": {
@@ -5904,9 +5842,9 @@
 			}
 		},
 		"connect-history-api-fallback": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
-			"integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
 		},
 		"connect-pause": {
 			"version": "0.1.0",
@@ -6603,9 +6541,9 @@
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -6616,7 +6554,8 @@
 				"inherits": "2.0.3",
 				"pbkdf2": "3.0.14",
 				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"randombytes": "2.0.5",
+				"randomfill": "1.0.3"
 			}
 		},
 		"crypto-random-string": {
@@ -6782,7 +6721,7 @@
 			"integrity": "sha512-E7CzbC0I4uAs2dI8mPCVe+K37xuja5kjIugOotpwICFL7vzhmFMAPHvS/MF9gFrmv8DDUANsxrgyT/I3OLukcw==",
 			"requires": {
 				"change-case": "3.0.1",
-				"postcss": "6.0.14"
+				"postcss": "6.0.15"
 			},
 			"dependencies": {
 				"chalk": {
@@ -6793,16 +6732,26 @@
 						"ansi-styles": "3.1.0",
 						"escape-string-regexp": "1.0.5",
 						"supports-color": "4.5.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "4.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+							"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+							"requires": {
+								"has-flag": "2.0.0"
+							}
+						}
 					}
 				},
 				"postcss": {
-					"version": "6.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-					"integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+					"version": "6.0.15",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+					"integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
 					"requires": {
 						"chalk": "2.3.0",
 						"source-map": "0.6.1",
-						"supports-color": "4.5.0"
+						"supports-color": "5.1.0"
 					}
 				},
 				"source-map": {
@@ -6811,9 +6760,9 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+					"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -6900,7 +6849,7 @@
 			"resolved": "https://registry.npmjs.org/css-selector-extract/-/css-selector-extract-3.3.6.tgz",
 			"integrity": "sha512-bBI8ZJKKyR9iHvxXb4t3E6WTMkis94eINopVg7y2FmmMjLXUVduD7mPEcADi4i9FX4wOypFMFpySX+0keuefxg==",
 			"requires": {
-				"postcss": "6.0.14"
+				"postcss": "6.0.15"
 			},
 			"dependencies": {
 				"chalk": {
@@ -6911,16 +6860,26 @@
 						"ansi-styles": "3.1.0",
 						"escape-string-regexp": "1.0.5",
 						"supports-color": "4.5.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "4.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+							"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+							"requires": {
+								"has-flag": "2.0.0"
+							}
+						}
 					}
 				},
 				"postcss": {
-					"version": "6.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-					"integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+					"version": "6.0.15",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+					"integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
 					"requires": {
 						"chalk": "2.3.0",
 						"source-map": "0.6.1",
-						"supports-color": "4.5.0"
+						"supports-color": "5.1.0"
 					}
 				},
 				"source-map": {
@@ -6929,9 +6888,9 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+					"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -7277,6 +7236,11 @@
 					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
+		},
+		"dasherize": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
+			"integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
 		},
 		"date-fns": {
 			"version": "1.29.0",
@@ -7634,14 +7598,14 @@
 			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
 			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
 			"requires": {
-				"acorn": "5.2.1",
+				"acorn": "5.3.0",
 				"defined": "1.0.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-					"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+					"integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
 				}
 			}
 		},
@@ -8444,7 +8408,7 @@
 				"base64id": "1.0.0",
 				"cookie": "0.3.1",
 				"debug": "2.6.9",
-				"engine.io-parser": "2.1.1",
+				"engine.io-parser": "2.1.2",
 				"uws": "0.14.5",
 				"ws": "3.3.3"
 			},
@@ -8467,7 +8431,7 @@
 				"component-emitter": "1.2.1",
 				"component-inherit": "0.0.3",
 				"debug": "2.6.9",
-				"engine.io-parser": "2.1.1",
+				"engine.io-parser": "2.1.2",
 				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
 				"parseqs": "0.0.5",
@@ -8498,15 +8462,22 @@
 			}
 		},
 		"engine.io-parser": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.1.tgz",
-			"integrity": "sha1-4Ps/DgRi9/WLt3waUun1p+JuRmg=",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+			"integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
 			"requires": {
 				"after": "0.8.2",
-				"arraybuffer.slice": "0.0.6",
+				"arraybuffer.slice": "0.0.7",
 				"base64-arraybuffer": "0.1.5",
 				"blob": "0.0.4",
 				"has-binary2": "1.0.2"
+			},
+			"dependencies": {
+				"arraybuffer.slice": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+					"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+				}
 			}
 		},
 		"enhance-visitors": {
@@ -8518,9 +8489,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
+			"integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"memory-fs": "0.4.1",
@@ -8534,11 +8505,11 @@
 			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
 		},
 		"errno": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+			"integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
 			"requires": {
-				"prr": "0.0.0"
+				"prr": "1.0.1"
 			}
 		},
 		"error-ex": {
@@ -9377,6 +9348,11 @@
 						"unpipe": "1.0.0"
 					}
 				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				},
 				"mime-db": {
 					"version": "1.30.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
@@ -9390,15 +9366,30 @@
 						"mime-db": "1.30.0"
 					}
 				},
-				"parseurl": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-					"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-				},
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
 					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"send": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+					"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "1.1.1",
+						"destroy": "1.0.4",
+						"encodeurl": "1.0.1",
+						"escape-html": "1.0.3",
+						"etag": "1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "1.6.2",
+						"mime": "1.4.1",
+						"ms": "2.0.0",
+						"on-finished": "2.3.0",
+						"range-parser": "1.2.0",
+						"statuses": "1.3.1"
+					}
 				},
 				"serve-static": {
 					"version": "1.13.1",
@@ -10882,14 +10873,14 @@
 			}
 		},
 		"gm": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/gm/-/gm-1.23.0.tgz",
-			"integrity": "sha1-gKL+nL8TFRUCSEZERlhGEmn1JmE=",
+			"version": "1.23.1",
+			"resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
+			"integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
 			"requires": {
 				"array-parallel": "0.1.3",
 				"array-series": "0.1.5",
 				"cross-spawn": "4.0.2",
-				"debug": "2.2.0"
+				"debug": "3.1.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -10902,17 +10893,12 @@
 					}
 				},
 				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
-						"ms": "0.7.1"
+						"ms": "2.0.0"
 					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
 				}
 			}
 		},
@@ -11241,19 +11227,35 @@
 			}
 		},
 		"gulp-changed": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-3.1.1.tgz",
-			"integrity": "sha512-Msl9tBv7URgh1mjNUlMzy58KngNzqCShklkQ6CjBx4YqzPfIKnvX12V7auocDTyT1Ef/HtWlSD3AyjRDyS8h+g==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-3.2.0.tgz",
+			"integrity": "sha1-zumGbZSeCRh1IlI9bGVWX24yvXw=",
 			"requires": {
-				"gulp-util": "3.0.8",
+				"make-dir": "1.1.0",
 				"pify": "3.0.0",
-				"through2": "2.0.3"
+				"plugin-error": "0.1.2",
+				"replace-ext": "1.0.0",
+				"through2": "2.0.3",
+				"touch": "3.1.0"
 			},
 			"dependencies": {
+				"make-dir": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+					"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"replace-ext": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 				}
 			}
 		},
@@ -11266,37 +11268,15 @@
 			}
 		},
 		"gulp-cheerio": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/gulp-cheerio/-/gulp-cheerio-0.6.2.tgz",
-			"integrity": "sha1-dQYzkVFvx5KXS+w8EFGdfJKB6SE=",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/gulp-cheerio/-/gulp-cheerio-0.6.3.tgz",
+			"integrity": "sha512-ZuRAq48qT9u2E8QUz1pHQZOq9500tQojOfGXzAER91CGYf8a3U5+fHuLWk5wvJ0iwrriaApg5Honvt3r5XMcNg==",
 			"requires": {
 				"cheerio": "0.22.0",
-				"gulp-util": "2.2.20",
+				"plugin-error": "0.1.2",
 				"through2": "0.6.5"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-				},
-				"ansi-styles": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-					"integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-				},
-				"chalk": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-					"requires": {
-						"ansi-styles": "1.1.0",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "0.1.0",
-						"strip-ansi": "0.3.0",
-						"supports-color": "0.2.0"
-					}
-				},
 				"cheerio": {
 					"version": "0.22.0",
 					"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
@@ -11320,113 +11300,15 @@
 						"lodash.some": "4.6.0"
 					}
 				},
-				"gulp-util": {
-					"version": "2.2.20",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-					"integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-					"requires": {
-						"chalk": "0.5.1",
-						"dateformat": "1.0.12",
-						"lodash._reinterpolate": "2.4.1",
-						"lodash.template": "2.4.1",
-						"minimist": "0.2.0",
-						"multipipe": "0.1.2",
-						"through2": "0.5.1",
-						"vinyl": "0.2.3"
-					},
-					"dependencies": {
-						"through2": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-							"integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-							"requires": {
-								"readable-stream": "1.0.34",
-								"xtend": "3.0.0"
-							}
-						}
-					}
-				},
-				"has-ansi": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-					"requires": {
-						"ansi-regex": "0.2.1"
-					}
-				},
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
-				"lodash._reinterpolate": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-					"integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
-				},
 				"lodash.defaults": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
 					"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-				},
-				"lodash.escape": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-					"integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-					"requires": {
-						"lodash._escapehtmlchar": "2.4.1",
-						"lodash._reunescapedhtml": "2.4.1",
-						"lodash.keys": "2.4.1"
-					}
-				},
-				"lodash.keys": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-					"requires": {
-						"lodash._isnative": "2.4.1",
-						"lodash._shimkeys": "2.4.1",
-						"lodash.isobject": "2.4.1"
-					}
-				},
-				"lodash.template": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-					"integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-					"requires": {
-						"lodash._escapestringchar": "2.4.1",
-						"lodash._reinterpolate": "2.4.1",
-						"lodash.defaults": "2.4.1",
-						"lodash.escape": "2.4.1",
-						"lodash.keys": "2.4.1",
-						"lodash.templatesettings": "2.4.1",
-						"lodash.values": "2.4.1"
-					},
-					"dependencies": {
-						"lodash.defaults": {
-							"version": "2.4.1",
-							"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-							"integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-							"requires": {
-								"lodash._objecttypes": "2.4.1",
-								"lodash.keys": "2.4.1"
-							}
-						}
-					}
-				},
-				"lodash.templatesettings": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-					"integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-					"requires": {
-						"lodash._reinterpolate": "2.4.1",
-						"lodash.escape": "2.4.1"
-					}
-				},
-				"minimist": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-					"integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
@@ -11444,19 +11326,6 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
-				"strip-ansi": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-					"requires": {
-						"ansi-regex": "0.2.1"
-					}
-				},
-				"supports-color": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-					"integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
@@ -11464,37 +11333,17 @@
 					"requires": {
 						"readable-stream": "1.0.34",
 						"xtend": "4.0.1"
-					},
-					"dependencies": {
-						"xtend": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-							"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-						}
 					}
-				},
-				"vinyl": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-					"integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-					"requires": {
-						"clone-stats": "0.0.1"
-					}
-				},
-				"xtend": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
 				}
 			}
 		},
 		"gulp-clean-css": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.9.0.tgz",
-			"integrity": "sha512-CsqaSO2ZTMQI/WwbWloZWBudhsRMKgxBthzxt4bbcbWrjOY4pRFziyK9IH6YbTpaWAPKEwWpopPkpiAEoDofxw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.9.2.tgz",
+			"integrity": "sha512-NaBtCOmhk2FP1D1pgv5jEvZaKr+6FZHvEgsl1iPGmTpyUOWpECR3Mzdciwo+hEWwtlnkZSueoAf74YCMtar48A==",
 			"requires": {
 				"clean-css": "4.1.9",
-				"gulp-util": "3.0.8",
+				"plugin-error": "0.1.2",
 				"through2": "2.0.3",
 				"vinyl-sourcemaps-apply": "0.2.1"
 			}
@@ -11604,39 +11453,37 @@
 			}
 		},
 		"gulp-debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-3.1.0.tgz",
-			"integrity": "sha1-TakVaLVJFb6ANpbKqsEMiVssCnE=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-3.2.0.tgz",
+			"integrity": "sha512-2LZzP+ydczqz1rhqq/NYxvVvYTmOa0IgBl2B1sQTdkQgku9ayOUM/KHuGPjF4QA5aO1VcG+Sskw7iCcRUqHKkA==",
 			"requires": {
-				"chalk": "1.1.3",
-				"gulp-util": "3.0.8",
+				"chalk": "2.3.0",
+				"fancy-log": "1.3.2",
 				"plur": "2.1.2",
 				"stringify-object": "3.2.1",
 				"through2": "2.0.3",
 				"tildify": "1.2.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
 				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"requires": {
-						"ansi-styles": "2.2.1",
+						"ansi-styles": "3.1.0",
 						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"supports-color": "4.2.0"
 					}
 				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				"fancy-log": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+					"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+					"requires": {
+						"ansi-gray": "0.1.1",
+						"color-support": "1.1.3",
+						"time-stamp": "1.1.0"
+					}
 				}
 			}
 		},
@@ -11949,12 +11796,12 @@
 			}
 		},
 		"gulp-filter": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.1.tgz",
-			"integrity": "sha512-5olRzAhFdXB2klCu1lnazP65aO9YdA/5WfC9VdInIc8PrUeDIoZfaA3Edb0yUBGhVdHv4eHKL9Fg5tUoEJ9z5A==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
+			"integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
 			"requires": {
-				"gulp-util": "3.0.8",
 				"multimatch": "2.1.0",
+				"plugin-error": "0.1.2",
 				"streamfilter": "1.0.7"
 			}
 		},
@@ -12015,25 +11862,39 @@
 			}
 		},
 		"gulp-newer": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.3.0.tgz",
-			"integrity": "sha1-1Q7Ky7gi7aSStXMkpshaB/2aVcE=",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gulp-newer/-/gulp-newer-1.4.0.tgz",
+			"integrity": "sha512-h79fGO55S/P9eAADbLAP9aTtVYpLSR1ONj08VPaSdVVNVYhTS8p1CO1TW7kEMu+hC+sytmCqcUr5LesvZEtDoQ==",
 			"requires": {
 				"glob": "7.1.2",
-				"gulp-util": "3.0.8",
-				"kew": "0.7.0"
+				"kew": "0.7.0",
+				"plugin-error": "0.1.2"
 			}
 		},
 		"gulp-notify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.0.0.tgz",
-			"integrity": "sha1-oEuK+azb5OY8hFZ4zgw9MGlMWaM=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.1.0.tgz",
+			"integrity": "sha512-DmGfTdno/KWPMHfVQVM2/3LJQyUKvxgmL1xYS72eqxDw/v9MUv5Wg+PALunptIry4ZVEZOF56KYj3I8s2N0W3Q==",
 			"requires": {
-				"gulp-util": "3.0.8",
+				"ansi-colors": "1.0.1",
+				"fancy-log": "1.3.2",
 				"lodash.template": "4.4.0",
 				"node-notifier": "5.1.2",
 				"node.extend": "1.1.6",
+				"plugin-error": "0.1.2",
 				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"fancy-log": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+					"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+					"requires": {
+						"ansi-gray": "0.1.1",
+						"color-support": "1.1.3",
+						"time-stamp": "1.1.0"
+					}
+				}
 			}
 		},
 		"gulp-plumber": {
@@ -12046,14 +11907,27 @@
 			}
 		},
 		"gulp-postcss": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.0.tgz",
-			"integrity": "sha1-z7YqGfqUf4vmfOnsronOuVnwz5M=",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.1.tgz",
+			"integrity": "sha1-Pxw22xGXFAw5nCUt3/M5EpY445U=",
 			"requires": {
-				"gulp-util": "3.0.8",
+				"fancy-log": "1.3.2",
+				"plugin-error": "0.1.2",
 				"postcss": "6.0.13",
 				"postcss-load-config": "1.2.0",
 				"vinyl-sourcemaps-apply": "0.2.1"
+			},
+			"dependencies": {
+				"fancy-log": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+					"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+					"requires": {
+						"ansi-gray": "0.1.1",
+						"color-support": "1.1.3",
+						"time-stamp": "1.1.0"
+					}
+				}
 			}
 		},
 		"gulp-remember": {
@@ -12144,14 +12018,39 @@
 			}
 		},
 		"gulp-shell": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.6.3.tgz",
-			"integrity": "sha1-Lqpu3/+ovf96jwufmFKHbzMzHGs=",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.6.5.tgz",
+			"integrity": "sha512-f3m1WcS0o2B72/PGj1Jbv9zYR9rynBh/EQJv64n01xQUo7j7anols0eww9GG/WtDTzGVQLrupVDYkifRFnj5Zg==",
 			"requires": {
-				"async": "2.5.0",
-				"gulp-util": "3.0.8",
+				"async": "2.6.0",
+				"chalk": "2.3.0",
+				"fancy-log": "1.3.2",
 				"lodash": "4.17.4",
+				"lodash.template": "4.4.0",
+				"plugin-error": "0.1.2",
 				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"requires": {
+						"ansi-styles": "3.1.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.2.0"
+					}
+				},
+				"fancy-log": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+					"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+					"requires": {
+						"ansi-gray": "0.1.1",
+						"color-support": "1.1.3",
+						"time-stamp": "1.1.0"
+					}
+				}
 			}
 		},
 		"gulp-size": {
@@ -12201,9 +12100,9 @@
 			}
 		},
 		"gulp-sourcemaps": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.2.tgz",
-			"integrity": "sha1-T0HHKzWn6ga2ZtLj9XkX4sDnHE4=",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.3.tgz",
+			"integrity": "sha1-EbAz91n5CeCl8Vt730esKcxU76Q=",
 			"requires": {
 				"@gulp-sourcemaps/identity-map": "1.0.1",
 				"@gulp-sourcemaps/map-sources": "1.0.0",
@@ -12475,12 +12374,14 @@
 			}
 		},
 		"gulp-svgstore": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.1.0.tgz",
-			"integrity": "sha1-BLIDrA4T+O1tv8lA0lllxOJFZnY=",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.1.1.tgz",
+			"integrity": "sha1-f6ivAFwjuwM4+fNlpgEMhmUfE9A=",
 			"requires": {
 				"cheerio": "0.22.0",
-				"gulp-util": "3.0.8"
+				"fancy-log": "1.3.2",
+				"plugin-error": "0.1.2",
+				"vinyl": "2.1.0"
 			},
 			"dependencies": {
 				"cheerio": {
@@ -12506,10 +12407,48 @@
 						"lodash.some": "4.6.0"
 					}
 				},
+				"clone": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+					"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+				},
+				"fancy-log": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+					"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+					"requires": {
+						"ansi-gray": "0.1.1",
+						"color-support": "1.1.3",
+						"time-stamp": "1.1.0"
+					}
+				},
 				"lodash.defaults": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
 					"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+				},
+				"replace-ext": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+				},
+				"vinyl": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+					"requires": {
+						"clone": "2.1.1",
+						"clone-buffer": "1.0.0",
+						"clone-stats": "1.0.0",
+						"cloneable-readable": "1.0.0",
+						"remove-trailing-separator": "1.0.2",
+						"replace-ext": "1.0.0"
+					}
 				}
 			}
 		},
@@ -13032,7 +12971,7 @@
 				"ncname": "1.0.0",
 				"param-case": "2.1.1",
 				"relateurl": "0.2.7",
-				"uglify-js": "3.3.2"
+				"uglify-js": "3.3.4"
 			},
 			"dependencies": {
 				"commander": {
@@ -13046,9 +12985,9 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"uglify-js": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.2.tgz",
-					"integrity": "sha512-uZp2gduFfZDDfx0iIAmfKgRTANCooWcFjnFmJ2n8x/+RpBNk97lac1HU5wvZxWZCBbwHmTFDpWAsEhKnQpsM2A==",
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.4.tgz",
+					"integrity": "sha512-hfIwuAQI5dlXP30UtdmWoYF9k+ypVqBXIdmd6ZKBiaNHHvA8ty7ZloMe3+7S5AEKVkxHbjByl4DfRHQ7QpZquw==",
 					"requires": {
 						"commander": "2.12.2",
 						"source-map": "0.6.1"
@@ -13172,9 +13111,9 @@
 			}
 		},
 		"https-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"https-proxy-agent": {
 			"version": "1.0.0",
@@ -14528,6 +14467,36 @@
 			"resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.2.tgz",
 			"integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo="
 		},
+		"jsdom": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-6.5.1.tgz",
+			"integrity": "sha1-tgZNanZRCBr0HVdu3Fa8UeABIsA=",
+			"requires": {
+				"acorn": "2.7.0",
+				"acorn-globals": "1.0.9",
+				"browser-request": "0.3.3",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"escodegen": "1.9.0",
+				"htmlparser2": "3.9.2",
+				"nwmatcher": "1.4.3",
+				"parse5": "1.5.1",
+				"request": "2.81.0",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.2",
+				"whatwg-url-compat": "0.6.5",
+				"xml-name-validator": "2.0.1",
+				"xmlhttprequest": "1.8.0",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+					"integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+				}
+			}
+		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -14709,11 +14678,6 @@
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"leven": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-					"integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
 				},
 				"lodash": {
 					"version": "2.4.2",
@@ -16021,6 +15985,11 @@
 				}
 			}
 		},
+		"leven": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+			"integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
+		},
 		"levenshtein-edit-distance": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz",
@@ -16569,28 +16538,10 @@
 				"lodash.isfunction": "2.4.1"
 			}
 		},
-		"lodash._escapehtmlchar": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-			"integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-			"requires": {
-				"lodash._htmlescapes": "2.4.1"
-			}
-		},
-		"lodash._escapestringchar": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-			"integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I="
-		},
 		"lodash._getnative": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
 			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-		},
-		"lodash._htmlescapes": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-			"integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
 		},
 		"lodash._isiterateecall": {
 			"version": "3.0.9",
@@ -16621,27 +16572,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-		},
-		"lodash._reunescapedhtml": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-			"integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
-			"requires": {
-				"lodash._htmlescapes": "2.4.1",
-				"lodash.keys": "2.4.1"
-			},
-			"dependencies": {
-				"lodash.keys": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-					"requires": {
-						"lodash._isnative": "2.4.1",
-						"lodash._shimkeys": "2.4.1",
-						"lodash.isobject": "2.4.1"
-					}
-				}
-			}
 		},
 		"lodash._root": {
 			"version": "3.0.1",
@@ -16946,26 +16876,6 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
 			"integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984="
-		},
-		"lodash.values": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-			"integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-			"requires": {
-				"lodash.keys": "2.4.1"
-			},
-			"dependencies": {
-				"lodash.keys": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-					"requires": {
-						"lodash._isnative": "2.4.1",
-						"lodash._shimkeys": "2.4.1",
-						"lodash.isobject": "2.4.1"
-					}
-				}
-			}
 		},
 		"log-symbols": {
 			"version": "1.0.2",
@@ -17663,7 +17573,7 @@
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"requires": {
-				"errno": "0.1.4",
+				"errno": "0.1.6",
 				"readable-stream": "2.3.3"
 			}
 		},
@@ -18109,9 +18019,9 @@
 			}
 		},
 		"multicast-dns": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
-			"integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.1.tgz",
+			"integrity": "sha512-uV3/ckdsffHx9IrGQrx613mturMdMqQ06WTq+C09NsStJ9iNG6RcUWgPKs1Rfjy+idZT6tfQoXEusGNnEZhT3w==",
 			"requires": {
 				"dns-packet": "1.2.2",
 				"thunky": "0.1.0"
@@ -18428,20 +18338,20 @@
 			}
 		},
 		"node-libs-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"requires": {
 				"assert": "1.4.1",
-				"browserify-zlib": "0.1.4",
+				"browserify-zlib": "0.2.0",
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
+				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
-				"https-browserify": "0.0.1",
-				"os-browserify": "0.2.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
 				"path-browserify": "0.0.0",
 				"process": "0.11.10",
 				"punycode": "1.4.1",
@@ -18449,7 +18359,7 @@
 				"readable-stream": "2.3.3",
 				"stream-browserify": "2.0.1",
 				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
+				"string_decoder": "1.0.3",
 				"timers-browserify": "2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "0.11.0",
@@ -18471,11 +18381,6 @@
 						"ieee754": "1.1.8",
 						"isarray": "1.0.0"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -18488,13 +18393,6 @@
 				"semver": "5.4.1",
 				"shellwords": "0.1.1",
 				"which": "1.2.14"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-				}
 			}
 		},
 		"node-pre-gyp": {
@@ -20232,11 +20130,12 @@
 			"integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
 		},
 		"opn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-			"integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+			"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
 			"requires": {
-				"is-wsl": "1.1.0"
+				"object-assign": "4.1.1",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"optimist": {
@@ -20378,9 +20277,9 @@
 			"integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
 		},
 		"os-browserify": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-family": {
 			"version": "1.0.0",
@@ -20521,9 +20420,9 @@
 			}
 		},
 		"pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
@@ -20548,7 +20447,7 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.1",
+				"asn1.js": "4.9.2",
 				"browserify-aes": "1.1.1",
 				"create-hash": "1.1.3",
 				"evp_bytestokey": "1.0.3",
@@ -20694,9 +20593,9 @@
 			}
 		},
 		"parseurl": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-			"integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
 		"pascal-case": {
 			"version": "2.0.1",
@@ -21088,6 +20987,52 @@
 					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
 					"integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
 					"optional": true
+				}
+			}
+		},
+		"plugin-error": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+			"requires": {
+				"ansi-cyan": "0.1.1",
+				"ansi-red": "0.1.1",
+				"arr-diff": "1.1.0",
+				"arr-union": "2.1.0",
+				"extend-shallow": "1.1.4"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+					"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-slice": "0.2.3"
+					}
+				},
+				"arr-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+					"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+				},
+				"array-slice": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+					"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+				},
+				"extend-shallow": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+					"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+					"requires": {
+						"kind-of": "1.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+					"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
 				}
 			}
 		},
@@ -23442,6 +23387,16 @@
 						"ansi-styles": "3.1.0",
 						"escape-string-regexp": "1.0.5",
 						"supports-color": "4.5.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "4.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+							"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+							"requires": {
+								"has-flag": "2.0.0"
+							}
+						}
 					}
 				},
 				"source-map": {
@@ -23454,25 +23409,25 @@
 					"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
 					"integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
 					"requires": {
-						"postcss": "6.0.14"
+						"postcss": "6.0.15"
 					},
 					"dependencies": {
 						"postcss": {
-							"version": "6.0.14",
-							"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-							"integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+							"version": "6.0.15",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+							"integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
 							"requires": {
 								"chalk": "2.3.0",
 								"source-map": "0.6.1",
-								"supports-color": "4.5.0"
+								"supports-color": "5.1.0"
 							}
 						}
 					}
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+					"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -24988,9 +24943,9 @@
 			}
 		},
 		"prr": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"ps-tree": {
 			"version": "1.1.0",
@@ -25250,6 +25205,15 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"requires": {
+				"randombytes": "2.0.5",
 				"safe-buffer": "5.1.1"
 			}
 		},
@@ -28060,47 +28024,49 @@
 			}
 		},
 		"send": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-			"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
+			"integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
 			"requires": {
-				"debug": "2.6.9",
+				"debug": "2.6.4",
 				"depd": "1.1.1",
 				"destroy": "1.0.4",
 				"encodeurl": "1.0.1",
 				"escape-html": "1.0.3",
 				"etag": "1.8.1",
-				"fresh": "0.5.2",
+				"fresh": "0.5.0",
 				"http-errors": "1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
+				"mime": "1.3.4",
+				"ms": "1.0.0",
 				"on-finished": "2.3.0",
 				"range-parser": "1.2.0",
 				"statuses": "1.3.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "2.6.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "0.7.3"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "0.7.3",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+							"integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+						}
 					}
 				},
-				"etag": {
-					"version": "1.8.1",
-					"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-				},
 				"fresh": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+					"integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
 				},
-				"mime": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				"ms": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
+					"integrity": "sha1-Wa3NIu3FQ/e1OBhi0xOHsfS8lHM="
 				}
 			}
 		},
@@ -28129,7 +28095,7 @@
 				"escape-html": "1.0.3",
 				"http-errors": "1.5.1",
 				"mime-types": "2.1.15",
-				"parseurl": "1.3.1"
+				"parseurl": "1.3.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -28169,55 +28135,8 @@
 			"requires": {
 				"encodeurl": "1.0.1",
 				"escape-html": "1.0.3",
-				"parseurl": "1.3.1",
+				"parseurl": "1.3.2",
 				"send": "0.15.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-					"integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
-					"requires": {
-						"ms": "0.7.3"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "0.7.3",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-							"integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
-						}
-					}
-				},
-				"fresh": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-					"integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
-				},
-				"ms": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
-					"integrity": "sha1-Wa3NIu3FQ/e1OBhi0xOHsfS8lHM="
-				},
-				"send": {
-					"version": "0.15.2",
-					"resolved": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
-					"integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
-					"requires": {
-						"debug": "2.6.4",
-						"depd": "1.1.1",
-						"destroy": "1.0.4",
-						"encodeurl": "1.0.1",
-						"escape-html": "1.0.3",
-						"etag": "1.8.1",
-						"fresh": "0.5.0",
-						"http-errors": "1.6.2",
-						"mime": "1.3.4",
-						"ms": "1.0.0",
-						"on-finished": "2.3.0",
-						"range-parser": "1.2.0",
-						"statuses": "1.3.1"
-					}
-				}
 			}
 		},
 		"server-destroy": {
@@ -28921,26 +28840,6 @@
 					"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
 					"integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
 				},
-				"socket.io-client": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-					"integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
-					"requires": {
-						"backo2": "1.0.2",
-						"base64-arraybuffer": "0.1.5",
-						"component-bind": "1.0.0",
-						"component-emitter": "1.2.1",
-						"debug": "2.6.8",
-						"engine.io-client": "3.1.4",
-						"has-cors": "1.1.0",
-						"indexof": "0.0.1",
-						"object-component": "0.0.3",
-						"parseqs": "0.0.5",
-						"parseuri": "0.0.5",
-						"socket.io-parser": "3.1.2",
-						"to-array": "0.1.4"
-					}
-				},
 				"socket.io-parser": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
@@ -28979,100 +28878,44 @@
 			}
 		},
 		"socket.io-client": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
-			"integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+			"integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
 			"requires": {
 				"backo2": "1.0.2",
+				"base64-arraybuffer": "0.1.5",
 				"component-bind": "1.0.0",
 				"component-emitter": "1.2.1",
-				"debug": "2.3.3",
-				"engine.io-client": "1.8.0",
-				"has-binary": "0.1.7",
+				"debug": "2.6.8",
+				"engine.io-client": "3.1.4",
+				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
 				"object-component": "0.0.3",
+				"parseqs": "0.0.5",
 				"parseuri": "0.0.5",
-				"socket.io-parser": "2.3.1",
+				"socket.io-parser": "3.1.2",
 				"to-array": "0.1.4"
 			},
 			"dependencies": {
-				"after": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-					"integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
-				},
 				"component-emitter": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
 					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 				},
-				"debug": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-					"integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-					"requires": {
-						"ms": "0.7.2"
-					}
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
 				},
-				"engine.io-client": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
-					"integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
+				"socket.io-parser": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
+					"integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
 					"requires": {
 						"component-emitter": "1.2.1",
-						"component-inherit": "0.0.3",
-						"debug": "2.3.3",
-						"engine.io-parser": "1.3.1",
-						"has-cors": "1.1.0",
-						"indexof": "0.0.1",
-						"parsejson": "0.0.3",
-						"parseqs": "0.0.5",
-						"parseuri": "0.0.5",
-						"ws": "1.1.1",
-						"xmlhttprequest-ssl": "1.5.3",
-						"yeast": "0.1.2"
-					}
-				},
-				"engine.io-parser": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
-					"integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
-					"requires": {
-						"after": "0.8.1",
-						"arraybuffer.slice": "0.0.6",
-						"base64-arraybuffer": "0.1.5",
-						"blob": "0.0.4",
-						"has-binary": "0.1.6",
-						"wtf-8": "1.0.0"
-					},
-					"dependencies": {
-						"has-binary": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-							"integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-							"requires": {
-								"isarray": "0.0.1"
-							}
-						}
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"ms": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-				},
-				"ws": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-					"integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-					"requires": {
-						"options": "0.0.6",
-						"ultron": "1.0.2"
+						"debug": "2.6.8",
+						"has-binary2": "1.0.2",
+						"isarray": "2.0.1"
 					}
 				}
 			}
@@ -29134,7 +28977,7 @@
 				"faye-websocket": "0.11.1",
 				"inherits": "2.0.3",
 				"json3": "3.3.2",
-				"url-parse": "1.1.9"
+				"url-parse": "1.2.0"
 			},
 			"dependencies": {
 				"faye-websocket": {
@@ -33370,9 +33213,9 @@
 				"find-cache-dir": "1.0.0",
 				"schema-utils": "0.3.0",
 				"source-map": "0.5.6",
-				"uglify-es": "3.3.2",
+				"uglify-es": "3.3.4",
 				"webpack-sources": "1.0.1",
-				"worker-farm": "1.5.0"
+				"worker-farm": "1.5.2"
 			},
 			"dependencies": {
 				"commander": {
@@ -33381,9 +33224,9 @@
 					"integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
 				},
 				"uglify-es": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.2.tgz",
-					"integrity": "sha512-g7rGvx7YiFROLXKUtFMTw+YpTVV/XXPNvDUQfzwDTcB3vINwLUr3qXnkcPCu8VCIVjxI2EqaZ+sHoAxcYE/98w==",
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.4.tgz",
+					"integrity": "sha512-vDOyDaf7LcABZI5oJt8bin5FD8kYONux5jd8FY6SsV2SfD+MMXaPeGUotysbycSxdu170y5IQ8FvlKzU/TUryw==",
 					"requires": {
 						"commander": "2.12.2",
 						"source-map": "0.6.1"
@@ -33875,9 +33718,9 @@
 			"integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc="
 		},
 		"url-parse": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
-			"integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+			"integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
 			"requires": {
 				"querystringify": "1.0.0",
 				"requires-port": "1.0.0"
@@ -34329,7 +34172,7 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"chokidar": "1.7.0",
 				"graceful-fs": "4.1.11"
 			}
@@ -35207,7 +35050,7 @@
 				"acorn-dynamic-import": "2.0.2",
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
-				"async": "2.5.0",
+				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
 				"escope": "3.6.0",
 				"interpret": "1.0.3",
@@ -35217,7 +35060,7 @@
 				"loader-utils": "1.1.0",
 				"memory-fs": "0.4.1",
 				"mkdirp": "0.5.1",
-				"node-libs-browser": "2.0.0",
+				"node-libs-browser": "2.1.0",
 				"source-map": "0.5.6",
 				"supports-color": "4.5.0",
 				"tapable": "0.2.8",
@@ -35242,6 +35085,17 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
 					"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+				},
+				"enhanced-resolve": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+					"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"memory-fs": "0.4.1",
+						"object-assign": "4.1.1",
+						"tapable": "0.2.8"
+					}
 				},
 				"supports-color": {
 					"version": "4.5.0",
@@ -35273,17 +35127,22 @@
 			}
 		},
 		"webpack-dev-middleware": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
-			"integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+			"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
 			"requires": {
 				"memory-fs": "0.4.1",
-				"mime": "1.3.4",
+				"mime": "1.6.0",
 				"path-is-absolute": "1.0.1",
 				"range-parser": "1.2.0",
 				"time-stamp": "2.0.0"
 			},
 			"dependencies": {
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+				},
 				"time-stamp": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
@@ -35301,7 +35160,7 @@
 				"bonjour": "3.5.0",
 				"chokidar": "1.7.0",
 				"compression": "1.7.0",
-				"connect-history-api-fallback": "1.3.0",
+				"connect-history-api-fallback": "1.5.0",
 				"debug": "3.1.0",
 				"del": "3.0.0",
 				"express": "4.16.2",
@@ -35321,7 +35180,7 @@
 				"spdy": "3.4.7",
 				"strip-ansi": "3.0.1",
 				"supports-color": "4.5.0",
-				"webpack-dev-middleware": "1.12.0",
+				"webpack-dev-middleware": "1.12.2",
 				"yargs": "6.6.0"
 			},
 			"dependencies": {
@@ -35336,6 +35195,14 @@
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
 						"ms": "2.0.0"
+					}
+				},
+				"opn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+					"integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+					"requires": {
+						"is-wsl": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -35431,13 +35298,13 @@
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
 			"requires": {
 				"http-parser-js": "0.4.9",
-				"websocket-extensions": "0.1.2"
+				"websocket-extensions": "0.1.3"
 			}
 		},
 		"websocket-extensions": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
-			"integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0="
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
 		},
 		"whatwg-url-compat": {
 			"version": "0.6.5",
@@ -35614,11 +35481,11 @@
 			}
 		},
 		"worker-farm": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
-			"integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+			"integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
 			"requires": {
-				"errno": "0.1.4",
+				"errno": "0.1.6",
 				"xtend": "4.0.1"
 			}
 		},

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
@@ -48,7 +48,6 @@ export class BoltRatio extends withComponent(withPreact()) {
       this.style.paddingTop = (100 * h / w) + "%";
       this.style.removeProperty('--aspect-ratio-height');
       this.style.removeProperty('--aspect-ratio-width');
-      this.querySelector('img').classList.add('o-bolt-ratio__inner');
     }
   }
 
@@ -87,6 +86,14 @@ export class BoltRatio extends withComponent(withPreact()) {
         this.shadyPrepared = true;
       }
       ShadyCSS.styleElement(this);
+
+      // Auto-add class for fallback styles
+      var childNodes = this.childNodes;
+      for (var i = 0; i < childNodes.length; i++) {
+        if (childNodes[i].nodeType !== 3) { // nodeType 3 is a text node
+          childNodes[i].classList.add('o-bolt-ratio__inner');
+        }
+      }
 
     /** @TODO: determine if this logic below is required. This <style> node cleanup was
      *  included in original example (mentioned above) so keeping around for now.

--- a/src/_patterns/02-components/bolt-video/src/_videojs-enhancements.scss
+++ b/src/_patterns/02-components/bolt-video/src/_videojs-enhancements.scss
@@ -24,23 +24,18 @@
   }
 
   .vjs-icon-placeholder {
-    display: flex;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
+    display: block;
+    position: relative;
+    align-self: center;
+    line-height: 1; // Fixes vertical alignment issues w/ the icon in IE11 and Chrome
   }
 
   .vjs-icon-placeholder:before {
     color: bolt-color(blue);
+    display: block;
     position: relative;
     height: auto;
     width: auto;
-    line-height: 1;
     pointer-events: none; // prevent clicks from sticking
   }
 }

--- a/src/_patterns/02-components/bolt-video/src/video.twig
+++ b/src/_patterns/02-components/bolt-video/src/video.twig
@@ -55,14 +55,11 @@
 {% endset %}
 
 {% if ratio == true %}
-  {% embed "@bolt/ratio.twig" with {
+  {% include "@bolt/ratio.twig" with {
     aspectRatioHeight: aspectRatioHeight ?? 9,
-    aspectRatioWidth: aspectRatioWidth ?? 16
-  } %}
-    {% block ratio_content %}
-      {{ videoTag }}
-    {% endblock %}
-  {% endembed %}
+    aspectRatioWidth: aspectRatioWidth ?? 16,
+    children: videoTag
+  } only %}
 {% else %}
   {{ videoTag }}
 {% endif %}

--- a/src/_patterns/02-components/brightcove-player/demo/brightcove-player--inline-script.twig
+++ b/src/_patterns/02-components/brightcove-player/demo/brightcove-player--inline-script.twig
@@ -32,20 +32,22 @@
         pegaPlayer.emailSocialShare();
 
 
-        if (pegaPlayer.controlBar.playbackRateMenuButton) {
-          // Update the existing playback rate menu button in the control bar
-          var playbackControl = pegaPlayer.controlBar.playbackRateMenuButton;
-          playbackControl.removeChild(playbackControl.menu);
-          playbackControl.options_.playbackRates = options.playbackRates;
-          playbackControl.addChild(playbackControl.createMenu());
-          playbackControl.updateLabel();
-          playbackControl.updateVisibility();
-        } else {
-          // Add the playback rate menu button to the control bar
-          pegaPlayer.controlBar.playbackRateMenuButton = pegaPlayer.controlBar.addChild('PlaybackRateMenuButton', {
-            playbackRates: options.playbackRates
-          });
-          pegaPlayer.controlBar.playbackRateMenuButton.updateVisibility();
+        if (Array.isArray(options.playbackRates)) {
+          if (pegaPlayer.controlBar.playbackRateMenuButton) {
+            // Update the existing playback rate menu button in the control bar
+            var playbackControl = pegaPlayer.controlBar.playbackRateMenuButton;
+            playbackControl.removeChild(playbackControl.menu);
+            playbackControl.options_.playbackRates = options.playbackRates;
+            playbackControl.addChild(playbackControl.createMenu());
+            playbackControl.updateLabel();
+            playbackControl.updateVisibility();
+          } else {
+            // Add the playback rate menu button to the control bar
+            pegaPlayer.controlBar.playbackRateMenuButton = pegaPlayer.controlBar.addChild('PlaybackRateMenuButton', {
+              playbackRates: options.playbackRates
+            });
+            pegaPlayer.controlBar.playbackRateMenuButton.updateVisibility();
+          }
         }
       });
     });

--- a/src/_patterns/02-components/brightcove-player/demo/brightcove-player--inline-script.twig
+++ b/src/_patterns/02-components/brightcove-player/demo/brightcove-player--inline-script.twig
@@ -1,0 +1,66 @@
+<script type="text/javascript">
+  <!-- https://fokkezb.nl/2016/04/14/how-to-wait-for-a-javascript-variable-to-be-defined/ -->
+  <!-- https://github.com/OwenMelbz/whendefined -->
+  (function(){window.whenDefined=function(a,b,c){a[b]?c():Object.defineProperty(a,b,{configurable:!0,enumerable:!0,writeable:!0,get:function(){return this["_"+b]},set:function(a){this["_"+b]=a,c()}})}}).call(this);
+
+
+  function pegaCustomInitVideo(elem){
+
+    whenDefined(window, 'bc', function() {
+      var id = elem.state.id;
+
+      videojs(id).ready(function(){
+        var pegaPlayer = this;
+
+        var options = {
+          "playbackRates": [1, 1.3, 1.5, 2]
+        }
+
+        pegaPlayer.social({
+          "url": "https://local.d8.pega.com/insights/resources/intelligent-virtual-assistant-email",
+          "displayAfterVideo": true,
+          "services": {
+            "facebook": true,
+            "google": false,
+            "twitter": true,
+            "linkedin": true,
+            "pinterest": false,
+            "tumblr": false
+          }
+        });
+
+        pegaPlayer.emailSocialShare();
+
+
+        if (pegaPlayer.controlBar.playbackRateMenuButton) {
+          // Update the existing playback rate menu button in the control bar
+          var playbackControl = pegaPlayer.controlBar.playbackRateMenuButton;
+          playbackControl.removeChild(playbackControl.menu);
+          playbackControl.options_.playbackRates = options.playbackRates;
+          playbackControl.addChild(playbackControl.createMenu());
+          playbackControl.updateLabel();
+          playbackControl.updateVisibility();
+        } else {
+          // Add the playback rate menu button to the control bar
+          pegaPlayer.controlBar.playbackRateMenuButton = pegaPlayer.controlBar.addChild('PlaybackRateMenuButton', {
+            playbackRates: options.playbackRates
+          });
+          pegaPlayer.controlBar.playbackRateMenuButton.updateVisibility();
+        }
+      });
+    });
+  }
+
+</script>
+
+{% include "@bolt/video.twig" with {
+  "videoId": "5609376179001",
+  "accountId": "1900410236",
+  "playerId": "r1CAdLzTW",
+  "attributes": {
+    "on-init": "pegaCustomInitVideo",
+    "data-email-subject": "Pega - Intelligent Virtual Assistant for Email",
+    "data-email-body": "Check out this video from Pega",
+    "data-email-videourl": "https://local.d8.pega.com/insights/resources/intelligent-virtual-assistant-email"
+  }
+} only %}

--- a/src/_patterns/02-components/brightcove-player/package.json
+++ b/src/_patterns/02-components/brightcove-player/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "@bolt/core": "^0.9.0-rc.1",
     "@bolt/settings-all": "^0.9.0-rc.1",
-    "@bolt/tools-all": "^0.9.0-rc.1"
+    "@bolt/tools-all": "^0.9.0-rc.1",
+    "dasherize": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
@@ -11,6 +11,8 @@ import {
   spacingSizes
 } from '@bolt/core';
 
+import dasherize from 'dasherize';
+
 let index = 0;
 
 @define
@@ -23,6 +25,7 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     playerId: props.string,
     poster: props.object,
     isBackgroundVideo: props.boolean,
+    onInit: props.string,
     // onError: null,
     // onPlay: null,
     // onPause: null,
@@ -112,7 +115,7 @@ class BrightcoveVideo extends withComponent(withPreact()) {
 
   // Called to check whether or not the component should call
   // updated(), much like React's shouldComponentUpdate().
-  // updating(props, state) { 
+  // updating(props, state) {
   //   console.log(props);
   //   console.log(state);
   // }
@@ -251,9 +254,15 @@ class BrightcoveVideo extends withComponent(withPreact()) {
       BrightcoveVideo.appendScript(s);
     }
 
-    // console.log('init');
 
-    this.init();
+    // If onInit event exists on element, run that instead of auto initializing
+    if (this.props.onInit) {
+      if (window[this.props.onInit]){
+        window[this.props.onInit](this);
+      }
+    } else {
+      this.init();
+    }
 
 
     window.addEventListener('optimizedResize', this._onWindowResize);
@@ -544,8 +553,21 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     /* eslint jsx-a11y/media-has-caption: "off" */
     // Added a wrapping div as brightcove adds siblings to the video tag
 
+    // Loop through any extra (unknown) data attributes on the main element; copy over to the <video> tag being rendered
+    function datasetToObject(elem) {
+      var data = {};
+      [].forEach.call(elem.attributes, function (attr) {
+        if (/^data-/.test(attr.name)) {
+          data[dasherize(attr.name)] = attr.value;
+        }
+      });
+      return data;
+    }
+    const dataAttributes = datasetToObject(this);
+
     return(
       <video
+        {...dataAttributes}
         id={this.state.id}
         {...(this.props.poster ? { poster: this.props.poster.uri } : {}) }
         data-embed="default"


### PR DESCRIPTION
- Add integration example of adding extra plugins to vanilla Bolt Video component (via inline JS script) using the new `onInit` property
- Fix issue with ratio object IE11 workaround
- Fix video player icon alignment in IE11
- Fixing issue with the ratio object getting extra Twig attributes when including in the video player 
- Adding solution to allow data attributes added to the video player (via `attributes`) to trickle down to the internal `<video>` tag that gets rendered

CC @christophersmith262 @krlucas @remydenton 