### PR TITLE
Video player Updates Per UAT Feedback

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -134,6 +134,7 @@ plugins:
           - src/_patterns/04-pages/d8-homepage
           - src/_patterns/04-pages/d8-product-landing
           - src/_patterns/04-pages/d8-resource-details
+          - src/_patterns/04-pages
     roots: {}
 ishMinimum: '240'
 ishMaximum: '2600'

--- a/packages/bolt-core/utils/renderer-preact.js
+++ b/packages/bolt-core/utils/renderer-preact.js
@@ -38,11 +38,5 @@ export function withPreact(Base = HTMLElement){
     //   this.rendered && this.rendered();
     // }
 
-    disconnectedCallback() {
-      super.disconnectedCallback && super.disconnectedCallback();
-      // Preact hack https://github.com/developit/preact/issues/53
-      const Nothing = () => null;
-      this._preactDom = render(<Nothing />, this._renderRoot, this._preactDom);
-    }
   }
 };

--- a/src/_patterns/02-components/bolt-background/src/background.scss
+++ b/src/_patterns/02-components/bolt-background/src/background.scss
@@ -75,7 +75,7 @@ $bolt-bg-shape-offset-side-large: $bolt-bg-shape-offset-bottom-large * 1.2;
 
 .c-bolt-background__video {
   z-index: 10;
-  transition: all 0.4s ease;
+  transition: opacity 0.4s ease, min-height 0.4s ease, max-height 0.4s ease;
   top: 0;
   right: 0;
   bottom: 0;

--- a/src/_patterns/02-components/bolt-button/src/button.scss
+++ b/src/_patterns/02-components/bolt-button/src/button.scss
@@ -484,6 +484,7 @@ bolt-button {
   font-size: inherit;
   font-family: inherit;
   cursor: inherit;
+  color: inherit; // fix for black text browser default
   outline: 0;
   padding: 0;
   display: inline-flex; // vertical alignment w/ icon only button

--- a/src/_patterns/02-components/bolt-video/demo/video--hide-meta.twig
+++ b/src/_patterns/02-components/bolt-video/demo/video--hide-meta.twig
@@ -1,0 +1,6 @@
+{% include "@bolt/video.twig" with {
+  "videoId": "5609376179001",
+  "accountId": "1900410236",
+  "playerId": "r1CAdLzTW",
+  "showMeta": false
+} only %}

--- a/src/_patterns/02-components/bolt-video/demo/video--show-meta.twig
+++ b/src/_patterns/02-components/bolt-video/demo/video--show-meta.twig
@@ -1,0 +1,6 @@
+{% include "@bolt/video.twig" with {
+  "videoId": "5609376179001",
+  "accountId": "1900410236",
+  "playerId": "r1CAdLzTW",
+  "showMeta": true
+} only %}

--- a/src/_patterns/02-components/bolt-video/src/_video.scss
+++ b/src/_patterns/02-components/bolt-video/src/_video.scss
@@ -3,6 +3,8 @@
 
 @import 'videojs-enhancements';
 
+// Same as max-width of wrapper container
+$bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
 
 .c-bolt-video {
   position: absolute;
@@ -18,6 +20,17 @@
   position: relative;
   width: 100%;
   pointer-events: none;
+  max-width: $bolt-video-wrapper--max-width;
+  margin: 0 auto;
+  transition: opacity 0.4s ease, visibility 0.1s ease;
+  opacity: 0;
+  visibility: hidden;
+
+  .is-expanded & {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
 }
 
 .c-bolt-video__video-element {

--- a/src/_patterns/02-components/bolt-video/src/_videojs-enhancements.scss
+++ b/src/_patterns/02-components/bolt-video/src/_videojs-enhancements.scss
@@ -9,6 +9,10 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.video-js .vjs-poster {
+  background-color: transparent;
+}
+
 .video-js .vjs-big-play-button.vjs-big-play-button {
   @include bolt-button-secondary;
   margin-top: auto;

--- a/src/_patterns/02-components/bolt-video/src/video.twig
+++ b/src/_patterns/02-components/bolt-video/src/video.twig
@@ -21,37 +21,6 @@
 
 {% set videoTag %}
   {% include "@bolt/_video-tag.twig" %}
-  <div class="c-bolt-video__wrapper">
-    {% embed "@bolt/wrapper.twig" with {
-      attributes: {
-        class: [
-          "u-bolt-padding-left-none",
-          "u-bolt-padding-right-none"
-        ]
-      }
-    } %}
-      {% block wrapper_content %}
-        <div class="c-bolt-video__close-button">
-          {% include "@bolt/button.twig" with {
-            text: "Close video",
-            tag: "button",
-            size: "xsmall",
-            style: "secondary",
-            iconOnly: true,
-            rounded: true,
-            icon: {
-              name: "close",
-              size: "small"
-            },
-            attributes: {
-              "on-click": "close",
-              "on-click-target": videoUuid
-            }
-          } only %}
-        </div>
-      {% endblock %}
-    {% endembed %}
-  </div>
 {% endset %}
 
 {% if ratio == true %}

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-meta.scss
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-meta.scss
@@ -3,6 +3,13 @@ $bolt-export-data: false !global;
 @import '@bolt/settings-all';
 @import '@bolt/tools-all';
 
+// Same as max-width of wrapper container
+$bolt-video-meta--max-width: bolt-breakpoint(xxlarge);
+
+.c-brightcove-meta {
+  max-width: $bolt-video-meta--max-width;
+}
+
 .c-brightcove-meta__wrapper {
   @include bolt-padding(medium, squished);
   @include bolt-font-size(xsmall);

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.scss
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.scss
@@ -33,6 +33,12 @@ bolt-video {
 
 
 .c-brightcove-video {
+
+  .video-js {
+    width: 100%;
+    height: 100%;
+  }
+
   .c-bolt-background__video & {
     position: relative;
     display: block;
@@ -45,6 +51,8 @@ bolt-video {
 }
 
 .video-js {
+  width: 100%;
+  height: 100%;
   // @supports (--custom:property) {
   //   padding-top: calc( var(--aspect-ratio-height, 1) / var(--aspect-ratio-width, 1) * 100%);
   // }

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.scss
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.scss
@@ -6,10 +6,14 @@ brightcove-player {
   // --aspect-ratio-height: 16;
   // --aspect-ratio-width: 9;
   // padding-top: calc( var(--aspect-ratio-height, 1) / var(--aspect-ratio-width, 1) * 100%);
-  
+
   &.is-playing {
     opacity: 1;
   }
+}
+
+.c-brightcove-video__inner {
+  margin: 0 auto;
 }
 
 bolt-video {
@@ -26,12 +30,28 @@ bolt-video {
 }
 
 
+
+
+.c-brightcove-video {
+  .c-bolt-background__video & {
+    position: relative;
+    display: block;
+    width: 100vw;
+    max-width: 100vh;
+    height: calc(100vw * (9/16));
+    max-height: calc(100vh * (9/16));
+    margin: 0 auto;
+  }
+}
+
 .video-js {
   // @supports (--custom:property) {
   //   padding-top: calc( var(--aspect-ratio-height, 1) / var(--aspect-ratio-width, 1) * 100%);
   // }
-  min-height: 100%;
-  min-width: 100%;
+
+  .c-bolt-background__video & {
+    height: 100%;
+  }
 }
 
 // .c-bolt-background-video {

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
@@ -34,7 +34,7 @@ class BrightcoveMeta extends withComponent(withPreact()) {
     // externally (such as when the video has finished fully loading).
     const reveal =  Boolean(this.title || this.duration);
     return (
-      <div>
+      <div class="c-brightcove-meta">
         <style>{metaStyles[0][1]}</style>
         {reveal ? (
           <div class="c-brightcove-meta__wrapper">{this.title}{separator}{this.duration}</div>
@@ -56,6 +56,8 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     poster: props.object,
     isBackgroundVideo: props.boolean,
     onInit: props.string,
+    showMeta: props.boolean,
+    closeButtonText: props.string,
     // onError: null,
     // onPlay: null,
     // onPause: null,
@@ -78,6 +80,9 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     // this.onProgress = this.onProgress.bind(this);
     this.onDurationChange = this.onDurationChange.bind(this);
     this.onSeeked = this.onSeeked.bind(this);
+
+    // This binding is necessary to make `this` work in the callback
+    this.handleClose = this.handleClose.bind(this);
 
     // BrightcoveVideo.globalErrors.forEach(this.props.onError);
 
@@ -152,12 +157,16 @@ class BrightcoveVideo extends withComponent(withPreact()) {
   // }
 
   _setMetaTitle(title) {
-    this.querySelector('brightcove-meta').setAttribute('title', title);
+    if (this.props.showMeta){
+      this.querySelector('brightcove-meta').setAttribute('title', title);
+    }
   }
 
   _setMetaDuration(seconds) {
-    const durationFormatted = BrightcoveVideo._formatDuration(seconds);
-    this.querySelector('brightcove-meta').setAttribute('duration', durationFormatted);
+    if (this.props.showMeta) {
+      const durationFormatted = BrightcoveVideo._formatDuration(seconds);
+      this.querySelector('brightcove-meta').setAttribute('duration', durationFormatted);
+    }
   }
 
   static _formatDuration(seconds) {
@@ -250,6 +259,9 @@ class BrightcoveVideo extends withComponent(withPreact()) {
   //   return this.props.isBackgroundVideo;
   // }
 
+  handleClose() {
+    this.close();
+  }
 
   connectedCallback() {
     this.state = {
@@ -644,25 +656,44 @@ class BrightcoveVideo extends withComponent(withPreact()) {
     }
     const dataAttributes = datasetToObject(this);
 
+    let closeButtonText = null;
+    if (this.props.closeButtonText) {
+      closeButtonText = this.props.closeButtonText;
+    } else {
+      closeButtonText = 'Close video';
+    }
+
     return(
-      <span>
-        <video
-        {...dataAttributes}
-        id={this.state.id}
-        {...(this.props.poster ? { poster: this.props.poster.uri } : {}) }
-        data-embed="default"
-        data-video-id={this.props.videoId}
-        data-account={this.props.accountId}
-        data-player={this.props.playerId}
-        // playIcon={playIconEmoji()}
-        // following 'autoplay' can not expected to always work on web
-        // see: https://docs.brightcove.com/en/player/brightcove-player/guides/in-page-embed-player-implementation.html
-        autoPlay={this.props.autoplay}
-        data-application-id
-        className="video-js"
-        controls
-        />
-        <brightcove-meta />
+      <span class="c-brightcove-video">
+          <video
+            {...dataAttributes}
+            id={this.state.id}
+            {...(this.props.poster ? { poster: this.props.poster.uri } : {}) }
+            data-embed="default"
+            data-video-id={this.props.videoId}
+            data-account={this.props.accountId}
+            data-player={this.props.playerId}
+            // playIcon={playIconEmoji()}
+            // following 'autoplay' can not expected to always work on web
+            // see: https://docs.brightcove.com/en/player/brightcove-player/guides/in-page-embed-player-implementation.html
+            autoPlay={this.props.autoplay}
+            data-application-id
+            className="video-js"
+            controls
+          />
+          {this.props.showMeta &&
+            <brightcove-meta />
+          }
+        <div class="c-bolt-video__close-button">
+          <bolt-button size="xsmall" color="secondary" rounded="true" icon-only="true" onClick={this.handleClose}>
+            <button class="c-bolt-button__button">
+              <span class="c-bolt-button__item c-bolt-button__item-text u-bolt-visuallyhidden">{closeButtonText}</span>
+              <span class="c-bolt-button__icon u-bolt-margin-left-none ">
+                <bolt-icon name="close" size="small"></bolt-icon>
+              </span>
+            </button>
+          </bolt-button>
+        </div>
       </span>
     );
   }

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.twig
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.twig
@@ -1,11 +1,18 @@
 {% set attributes = create_attribute(attributes | default({})) %}
 
+{# force HTML5 Only Rendering #}
+{% set attributes = attributes.setAttribute("data-setup", "{&quot;techOrder&quot;: [&quot;Html5&quot;]}") %}
+
 {% if videoId %}
   {% set attributes = attributes.setAttribute("video-id", videoId) %}
 {% endif %}
 
 {% if accountId %}
   {% set attributes = attributes.setAttribute("account-id", accountId) %}
+{% endif %}
+
+{% if showMeta %}
+  {% set attributes = attributes.setAttribute("show-meta", showMeta) %}
 {% endif %}
 
 {% if playerId %}

--- a/src/_patterns/04-pages/d8-homepage/d8-homepage-video-band.twig
+++ b/src/_patterns/04-pages/d8-homepage/d8-homepage-video-band.twig
@@ -150,9 +150,9 @@
 
 {% set videoUuid1 = "js-bolt-video-uuid--1" %}
 
-{% embed "@bolt/band.twig" with {
-  theme: "dark",
-  size: "medium",
+{% embed "@bolt/band--collection.twig" with {
+  "theme": "dark",
+  "size": "medium",
   background: {
     "opacity": "heavy",
     "fill": "color",
@@ -174,32 +174,94 @@
         "videoUuid": videoUuid1
       }
     ]
-  }
-} %}
-  {% block band_content %}
-    {% include "@bolt/headline.twig" with {
-      text: "What's Trending",
-      size: "xlarge",
-      tag: "h3"
-    } only %}
-    {% include "@bolt/button.twig" with {
-      text: "Toggle video",
-      tag: "button",
-      attributes: {
-        "on-click": "toggle",
-        "on-click-target": videoUuid1
-      }
-    } only %}
-    {{ parent() }}
-  {% endblock band_content %}
-{% endembed %}
-
-
-
-{% embed "@bolt/band--collection.twig" with {
-  "theme": "light",
-  "size": "medium",
+  },
   "contentItems": [
+    {
+      "pattern": "card",
+      "contentItems": [
+        {
+          "pattern": "image",
+          "src": "/images/placeholders/1200x660.jpg"
+        },
+        {
+          "pattern": "headline",
+          "text": "2017 Forrester Wave Report",
+          "size": "large",
+          "tag": "h3"
+        },
+        {
+          "pattern": "text",
+          "text": "Pega cited as a Leader in The Forrester Wave™: Digital Process Automation Software, Q3 2017."
+        },
+        {
+          "pattern": "button",
+          "width": "full",
+          "text": "Get the report",
+          "style": "text"
+        }
+      ]
+    },
+    {
+      "pattern": "card",
+      "image": {
+        "src": "/images/sample/anthem-video.jpg"
+      },
+      "teaser": {
+        "eyebrow": {
+          text: "Article"
+        },
+        "headlines": [
+          {
+            "type": "headline",
+            "text": "Headline #2",
+            "size": "large"
+          }
+        ],
+        "content": "Simplify and automate to reduce costs and improve agility.",
+        "buttons": [
+          {
+            "text": "Learn More",
+            "style": "secondary",
+            "url": "www.google.com/pega7",
+            "width": "full"
+          },
+          {
+            "text": "About Pega",
+            "style": "secondary",
+            "url": "www.google.com/pega7",
+            "width": "full"
+          }
+        ]
+      }
+    },
+    {
+      "pattern": "card",
+      "contentItems": [
+        {
+          "pattern": "image",
+          "src": "/images/sample/artificial-intelligence-image.jpg"
+        },
+        {
+          "pattern": "teaser",
+          "headlines": [
+            {
+              "type": "headline",
+              "text": "Headline #3",
+              "size": "large"
+            }
+          ],
+          "content": "Simplify and automate to reduce costs and improve agility.",
+          "buttons": [
+            {
+              "text": "Learn More About Pega 7",
+              "style": "text",
+              "url": "www.google.com/pega7",
+              "width": "full"
+            }
+          ]
+        }
+      ]
+    },
     {
       "pattern": "card",
       "contentItems": [
@@ -294,6 +356,18 @@
       size: "xlarge",
       tag: "h3"
     } only %}
+
+    {% include "@bolt/button.twig" with {
+      text: "Toggle video",
+      tag: "button",
+      attributes: {
+        "on-click": "toggle",
+        "on-click-target": videoUuid1
+      }
+    } only %}
+
+    <br><br><br>
+
     {{ parent() }}
   {% endblock band_content %}
 {% endembed %}

--- a/src/_patterns/04-pages/tall-video-band-poc.twig
+++ b/src/_patterns/04-pages/tall-video-band-poc.twig
@@ -1,0 +1,204 @@
+<bolt-band size="medium" theme="xlight" bolt-component id="p-4209730f-b40b-4b24-9c9a-724f9eb744a1" class="c-bolt-band c-bolt-band--medium c-bolt-band--full t-bolt-xlight">
+
+    <bolt-wrapper size="xxlarge" full="true" bolt-object>
+        <div class="o-bolt-wrapper o-bolt-wrapper--xxlarge o-bolt-wrapper--full">
+
+            <bolt-background bolt-component>
+                <div class="c-bolt-background">
+                    <div class="c-bolt-background__item">
+                      <bolt-video class="js-55dd446c-c6f5-470d-a8be-b0986edf0cb1 js-bolt-video-uuid--1618045232 c-bolt-background__video" on-init="initBrightcovePlugins" data-setup="{&quot;techOrder&quot;: [&quot;Html5&quot;]}" video-id="5609376179001" account-id="1900410236"
+                            player-id="r1CAdLzTW" is-background-video></bolt-video>
+                    </div>
+                </div>
+            </bolt-background>
+            <div class="c-bolt-band__content">
+
+                <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--large o-bolt-grid--matrix">
+
+                    <div class="o-bolt-grid__cell u-bolt-width-1/1 u-bolt-width-1/2@small">
+
+                        <bolt-device-viewer id="p-7d6338ba-cfe6-479e-9512-793d0abf3e48" class="c-bolt-iphone8-viewer c-bolt-device-viewer marvel-device c-bolt-iphone8-viewer--black c-bolt-iphone8-viewer--portrait">
+                            <div class="c-bolt-device-viewer__inner c-bolt-iphone8-viewer__inner">
+                                <div class="c-bolt-iphone8-viewer__top-bar"></div>
+                                <div class="c-bolt-iphone8-viewer__bottom-bar"></div>
+                                <div class="c-bolt-iphone8-viewer__sensor"></div>
+                                <div class="c-bolt-iphone8-viewer__sleep"></div>
+                                <div class="c-bolt-iphone8-viewer__volume"></div>
+                                <div class="c-bolt-device-viewer__camera c-bolt-iphone8-viewer__camera"></div>
+                                <div class="c-bolt-iphone8-viewer__speaker"></div>
+                                <div class="c-bolt-device-viewer__home c-bolt-iphone8-viewer__home"></div>
+
+                                <div class="c-bolt-device-viewer__screen c-bolt-iphone8-viewer__screen">
+                                    <bolt-image-zoom>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--top-left"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--top-center"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--top-right"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--middle-left"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--middle-center"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--middle-right"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--bottom-left"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--bottom-center"></span>
+                                        <span class="c-bolt-image-zoom__tilt c-bolt-image-zoom__tilt--bottom-right"></span>
+
+                                        <bolt-image>
+
+                                            <bolt-ratio class="c-bolt-image o-bolt-ratio" aspect-ratio-height="2162" aspect-ratio-width="2880" style="--aspect-ratio-height: 2162; --aspect-ratio-width: 2880;">
+
+                                                <img class="c-bolt-image__img js-lazyload is-lazyloading" data-zoom="https://demo1.d8.pega.com/sites/default/files/styles/2560/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=aHLDcbgY" data-srcset="https://demo1.d8.pega.com/sites/default/files/styles/50/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=4qyQ3iR8 50w, https://demo1.d8.pega.com/sites/default/files/styles/100/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=GprgqOJb 100w, https://demo1.d8.pega.com/sites/default/files/styles/200/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=BUfpoyo9 200w, https://demo1.d8.pega.com/sites/default/files/styles/320/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=8x93Q8-j 320w, https://demo1.d8.pega.com/sites/default/files/styles/480/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=3nu5m8J6 480w, https://demo1.d8.pega.com/sites/default/files/styles/640/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=uhM5NTPA 640w, https://demo1.d8.pega.com/sites/default/files/styles/1024/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=Ru9xB74O 1024w, https://demo1.d8.pega.com/sites/default/files/styles/1366/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=1Y9QShfY 1366w, https://demo1.d8.pega.com/sites/default/files/styles/1536/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=AmRuj7jZ 1536w, https://demo1.d8.pega.com/sites/default/files/styles/1920/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=QjYx0ECN 1920w, https://demo1.d8.pega.com/sites/default/files/styles/2560/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=aHLDcbgY 2560w"
+                                                    srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-sizes="(min-width: 600px) 150vw, 100vw">
+                                                <noscript>
+                                                    <img class="c-bolt-image__img" data-zoom="https://demo1.d8.pega.com/sites/default/files/styles/2560/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=aHLDcbgY" data-srcset="https://demo1.d8.pega.com/sites/default/files/styles/50/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=4qyQ3iR8 50w, https://demo1.d8.pega.com/sites/default/files/styles/100/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=GprgqOJb 100w, https://demo1.d8.pega.com/sites/default/files/styles/200/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=BUfpoyo9 200w, https://demo1.d8.pega.com/sites/default/files/styles/320/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=8x93Q8-j 320w, https://demo1.d8.pega.com/sites/default/files/styles/480/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=3nu5m8J6 480w, https://demo1.d8.pega.com/sites/default/files/styles/640/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=uhM5NTPA 640w, https://demo1.d8.pega.com/sites/default/files/styles/1024/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=Ru9xB74O 1024w, https://demo1.d8.pega.com/sites/default/files/styles/1366/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=1Y9QShfY 1366w, https://demo1.d8.pega.com/sites/default/files/styles/1536/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=AmRuj7jZ 1536w, https://demo1.d8.pega.com/sites/default/files/styles/1920/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=QjYx0ECN 1920w, https://demo1.d8.pega.com/sites/default/files/styles/2560/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=aHLDcbgY 2560w"
+                                                        srcset="https://demo1.d8.pega.com/sites/default/files/styles/50/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=4qyQ3iR8 50w, https://demo1.d8.pega.com/sites/default/files/styles/100/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=GprgqOJb 100w, https://demo1.d8.pega.com/sites/default/files/styles/200/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=BUfpoyo9 200w, https://demo1.d8.pega.com/sites/default/files/styles/320/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=8x93Q8-j 320w, https://demo1.d8.pega.com/sites/default/files/styles/480/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=3nu5m8J6 480w, https://demo1.d8.pega.com/sites/default/files/styles/640/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=uhM5NTPA 640w, https://demo1.d8.pega.com/sites/default/files/styles/1024/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=Ru9xB74O 1024w, https://demo1.d8.pega.com/sites/default/files/styles/1366/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=1Y9QShfY 1366w, https://demo1.d8.pega.com/sites/default/files/styles/1536/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=AmRuj7jZ 1536w, https://demo1.d8.pega.com/sites/default/files/styles/1920/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=QjYx0ECN 1920w, https://demo1.d8.pega.com/sites/default/files/styles/2560/public/media/images/2017-12/product-device-screenshot--tablet-2880.jpg?itok=aHLDcbgY 2560w"
+                                                        data-sizes="(min-width: 600px) 150vw, 100vw">
+                                                </noscript>
+
+                                            </bolt-ratio>
+                                        </bolt-image>
+
+                                        <div class="c-bolt-image-zoom__overlay">
+                                            <!-- Icon JS + twig integration -->
+
+                                            <bolt-icon class="c-bolt-image-zoom__overlay-icon" name="search" background="circle" size="xlarge"></bolt-icon>
+                                        </div>
+                                    </bolt-image-zoom>
+                                </div>
+                            </div>
+                        </bolt-device-viewer>
+
+                    </div>
+
+                    <div class="o-bolt-grid__cell u-bolt-width-1/1 u-bolt-width-1/2@small">
+
+                        <bolt-teaser>
+
+                            <h3 class="c-bolt-headline--left c-bolt-headline c-bolt-headline--bold c-bolt-headline--xxxlarge" id="p-146e7b3a-d4fa-4cc4-9fe1-fd15c95aff76">
+                                <span class="c-bolt-headline__text">
+                                    Intelligent
+                                </span>
+
+                            </h3>
+
+                            <p>A single unified platform with everything you need to build or modify enterprise apps fast. Capgemini found that the pega 7 enterprise application development platform is 6.4x faster to build and 8x faster to change than conventional
+                                software development.</p>
+
+                            <bolt-button-group bolt-component>
+                                <ul class="c-bolt-button-group">
+                                    <li class="c-bolt-button-group__item">
+
+                                        <bolt-button size="medium" color="primary" on-click="toggle" on-click-target="js-55dd446c-c6f5-470d-a8be-b0986edf0cb1" id="p-e827c1fa-b53c-44fa-9cd4-8e900167d05d">
+                                            <div on-click="toggle" on-click-target="js-55dd446c-c6f5-470d-a8be-b0986edf0cb1" id="p-e827c1fa-b53c-44fa-9cd4-8e900167d05d" class="c-bolt-button c-bolt-button--primary c-bolt-button--item-align-center">
+                                                <button class="c-bolt-button__button">
+                                                    <span class="c-bolt-button__item c-bolt-button__item-text ">Play Video</span>
+
+                                                </button>
+                                            </div>
+                                        </bolt-button>
+                                    </li>
+                                    <li class="c-bolt-button-group__item">
+
+                                        <bolt-button size="medium" color="secondary" id="p-3748d04e-4b27-4da7-9737-d7d5fd405341">
+                                            <div id="p-3748d04e-4b27-4da7-9737-d7d5fd405341" class="c-bolt-button c-bolt-button--secondary c-bolt-button--item-align-center">
+                                                <a class="c-bolt-button__link" href="/insights/resources/revolutionising-customer-engagement-through-digital-innovation-dts-london">
+                                                    <span class="c-bolt-button__item c-bolt-button__item-text ">Call to Action</span>
+
+                                                </a>
+                                            </div>
+                                        </bolt-button>
+                                    </li>
+                                </ul>
+
+                            </bolt-button-group>
+                        </bolt-teaser>
+
+                        <div class="o-bolt-grid u-bolt-margin-top-large o-bolt-grid--matrix">
+                            <div class="o-bolt-grid__cell u-bolt-width-1/1 u-bolt-width-1/2@small">
+
+                                <bolt-teaser>
+
+                                    <!-- Icon JS + twig integration -->
+
+                                    <bolt-icon id="p-acd6f224-1c6d-4c5f-8a06-3ff90dacdf44" name="careers" background="circle" size="xlarge" color="teal"></bolt-icon>
+
+                                    <h3 class="c-bolt-headline--left c-bolt-headline c-bolt-headline--bold c-bolt-headline--large" id="p-c0834f1c-c7e4-400e-a6de-adaa63de89d1">
+                                        <span class="c-bolt-headline__text">
+                                            Product Name
+                                        </span>
+
+                                    </h3>
+
+                                    <p>Built-in Business Process Management and Case Management helps you quickly build business applications that deliver the outcomes and end-to-end customer experiences your customers demand. Find out why Pega is the perrenial
+                                        leader in BPM and Case Management.</p>
+
+                                </bolt-teaser>
+                            </div>
+                            <div class="o-bolt-grid__cell u-bolt-width-1/1 u-bolt-width-1/2@small">
+
+                                <bolt-teaser>
+
+                                    <!-- Icon JS + twig integration -->
+
+                                    <bolt-icon id="p-d36934e2-e20d-4f9f-8a12-fee821d63c52" name="industries" background="circle" size="xlarge" color="teal"></bolt-icon>
+
+                                    <h3 class="c-bolt-headline--left c-bolt-headline c-bolt-headline--bold c-bolt-headline--large" id="p-ce7f3586-5ca3-4331-bc94-92854af15824">
+                                        <span class="c-bolt-headline__text">
+                                            Product Name
+                                        </span>
+
+                                    </h3>
+
+                                    <p>Maximize value by action with relevance, consistency, and at the right time. Continually adapt your decisions with self-learning, ensuring actions are always relevant and personal on every channel. Harness a single
+                                        decision authority that unifies decisions for consistent experiences. Act with accuracy and speed while making value-added decisions.</p>
+
+                                </bolt-teaser>
+                            </div>
+                            <div class="o-bolt-grid__cell u-bolt-width-1/1 u-bolt-width-1/2@small">
+
+                                <bolt-teaser>
+
+                                    <!-- Icon JS + twig integration -->
+
+                                    <bolt-icon id="p-2e3f7585-6b8e-449e-8a0e-82349fea5ad0" name="asset-data" background="circle" size="xlarge" color="teal"></bolt-icon>
+
+                                    <h3 class="c-bolt-headline--left c-bolt-headline c-bolt-headline--bold c-bolt-headline--large" id="p-5e3f39b7-f2e7-4e85-9f60-253fdcf06430">
+                                        <span class="c-bolt-headline__text">
+                                            Product Name
+                                        </span>
+
+                                    </h3>
+
+                                    <p>Enterprise applications developed in Pega 7 are automatically ready to run across a variety of devices with zero additional work required. Even advanced native mobile device features, such as offline access and push
+                                        notifications, are enabled directly from the Designer Studio.</p>
+
+                                </bolt-teaser>
+                            </div>
+                            <div class="o-bolt-grid__cell u-bolt-width-1/1 u-bolt-width-1/2@small">
+
+                                <bolt-teaser>
+
+                                    <!-- Icon JS + twig integration -->
+
+                                    <bolt-icon id="p-31c6a24e-9a77-4243-8309-5711b87ce2a9" name="careers" background="circle" size="xlarge" color="teal"></bolt-icon>
+
+                                    <h3 class="c-bolt-headline--left c-bolt-headline c-bolt-headline--bold c-bolt-headline--large" id="p-92b77ab8-6c6c-40c6-8814-69b49833f9e4">
+                                        <span class="c-bolt-headline__text">
+                                            Product Name
+                                        </span>
+
+                                    </h3>
+
+                                    <p>Built-in Business Process Management and Case Management helps you quickly build business applications that deliver the outcomes and end-to-end customer experiences your customers demand. Find out why Pega is the perrenial
+                                        leader in BPM and Case Management.</p>
+
+                                </bolt-teaser>
+                            </div>
+                        </div>
+
+                    </div>
+
+                </div>
+
+            </div>
+
+        </div>
+    </bolt-wrapper>
+</bolt-band>


### PR DESCRIPTION
Requested launch-blocker video player updates per UAT feedback. 

No major backend changes should be required if the `<bolt-video>` Twig template is getting used by Drupal, other than choosing when / where to toggle the video player meta data via the `showMeta` prop being added. CC @christophersmith262 

Demo link:
Tall band example: http://5a582ef64c4b9333b6a83446.bolt.netlify.com/?p=pages-tall-video-band-poc


## Video Updates
- Workaround to force close button to properly disappear when closing
- CSS hacks to override video background max size in relation to screen size
- Moving close button to be internally inside component so button positioning can be controlled based on video player size
- Adding ability to conditionally toggle meta data showing up or not
- Adding examples of extra tall bands to test updates
- Adding closeHandler internal method for the internal close button to be bound to

## Misc Fixes
- Remove disconnected callback from shared `renderer-preact.js` util to allow components moved around the page to be re-rendered as expected
- Update CSS reset of internally nested button tag inside `<bolt-button>` to inherit text color