### PR TITLE
Implementing config solution

### DIFF
--- a/apps/pattern-lab--workshop/.boltrc.js
+++ b/apps/pattern-lab--workshop/.boltrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: 'pl',
   plConfigFile: './config/config.yml',
   dist: './dist/assets',
+  verbosity: 3,
   components: {
     global: [
       '@bolt/core',

--- a/packages/build-tools/commands/build.js
+++ b/packages/build-tools/commands/build.js
@@ -1,9 +1,9 @@
 const log = require('../utils/log');
 const run = require('../utils/run');
 
-module.exports = async (config, options) => {
-  const webpackTasks = require('../tasks/webpack-tasks')(config, options);
-  const patternLabTasks = await require('../tasks/pattern-lab-tasks')(config, options);
+module.exports = async (options) => {
+  const webpackTasks = require('../tasks/webpack-tasks')();
+  const patternLabTasks = await require('../tasks/pattern-lab-tasks')();
   // @todo figure out how to best conditionally run tasks based on environment (`pl`, `drupal`)
 
   async function parallelBuild() {

--- a/packages/build-tools/tasks/pattern-lab-tasks.js
+++ b/packages/build-tools/tasks/pattern-lab-tasks.js
@@ -5,8 +5,9 @@ const events = require('../utils/events');
 const chokidar = require('chokidar');
 const debounce = require('lodash.debounce');
 const log = require('../utils/log');
+const { getConfig } = require('../utils/config-store');
 
-module.exports = async (userConfig, options) => {
+module.exports = async () => {
   const config = Object.assign({
     plConfigFile: 'config/config.yml',
     watchedExtensions: [
@@ -20,7 +21,7 @@ module.exports = async (userConfig, options) => {
     ],
     extraWatches: [],
     debounceRate: 1000,
-  }, userConfig);
+  }, getConfig());
 
   const plConfig = await yaml.readYamlFile(config.plConfigFile);
   const plRoot = path.join(config.plConfigFile, '../..');
@@ -78,7 +79,7 @@ module.exports = async (userConfig, options) => {
 
     // list of all events: https://www.npmjs.com/package/chokidar#methods--events
     watcher.on('all', (event, path) => {
-      if (options.verbosity > 1) {
+      if (config.verbosity > 1) {
         console.log(event, path);
       }
       debouncedCompile();

--- a/packages/build-tools/tasks/webpack-tasks.js
+++ b/packages/build-tools/tasks/webpack-tasks.js
@@ -4,8 +4,10 @@ const createWebpackConfig = require('../create-webpack-config');
 const formatWebpackMessages = require('../utils/formatWebpackMessages');
 const events = require('../utils/events');
 const log = require('../utils/log');
+const { getConfig } = require('../utils/config-store');
 
-module.exports = (config, options) => {
+module.exports = () => {
+  const config = getConfig();
   const webpackConfig = createWebpackConfig(config);
 
   function compile() {
@@ -24,7 +26,7 @@ module.exports = (config, options) => {
           }
           const prettyError = messages.errors.join('\n\n');
 
-          return reject(options.verbosity > 2 ? new Error(prettyError) : prettyError);
+          return reject(config.verbosity > 2 ? new Error(prettyError) : prettyError);
         }
         // Stats config options: https://webpack.js.org/configuration/stats/
         console.log(stats.toString({

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -1,0 +1,83 @@
+const chalk = require('chalk');
+let isInitialized = false;
+let config = {};
+// Welcome to the home of the config!
+// Where does config come from?
+// The order goes like this, as this list increases, the later override the earlier
+// Order inspired by https://www.npmjs.com/package/rc#standards
+// 1. `defaultConfig` just below
+// 2. `userConfig` from `.boltrc.js` that's in same cwd as where `bolt` was ran, unless they use `--config-file path/to/.boltrc.js`
+// 3. Env Vars with `bolt_` prefix; `bolt_verbosity=1` will override `config.verbosity` - case matters!
+// 4. Certain command line options like `bolt build --verbosity 5` - not every config option is overridable this way.
+// For both 3 & 4, it doesn't support deep merges, so only top level properties.
+
+const defaultConfig = {
+  verbosity: 2,
+};
+
+function getEnvVarsConfig() {
+  const envVars = {};
+  Object.keys(process.env).forEach((envVar) => {
+    const parts = envVar.split('bolt_');
+    if (parts.length > 1) {
+      /** @type {string} - All env vars are strings */
+      let value = process.env[envVar];
+
+      // begin coersion, let's get that string into a proper format
+      if (value === 'true') {
+        value = true;
+      } else if (value === 'false') {
+        value = false;
+      } else {
+        const numberAttempt = parseInt(value);
+        if (!isNaN(numberAttempt)) {
+          value = numberAttempt;
+        }
+      }
+
+      envVars[parts[1]] = value;
+    }
+  });
+  return envVars;
+}
+
+function isReady() {
+  if (!isInitialized) {
+    console.log(chalk.red('Must initialize config before trying to get or update it.'));
+    console.log('Check to make sure you are running `init()` from `config-store.js` before `getConfig()` or `updateConfig()` ');
+    process.exit(1);
+  }
+}
+
+function init(userConfig) {
+  config = Object.assign({}, defaultConfig, userConfig, getEnvVarsConfig());
+  isInitialized = true;
+  return config;
+}
+
+/**
+ * Get current config
+ * @returns {object} config
+ */
+function getConfig() {
+  isReady();
+  return config;
+}
+
+/**
+ * Update config
+ * @param {function} updater - This function is passed in current config and it returns new config.
+ */
+function updateConfig(updater) {
+  isReady();
+  const newConfig = updater(config);
+  // console.log('new config:');
+  // console.log(newConfig);
+  config = newConfig;
+}
+
+module.exports = {
+  getConfig,
+  updateConfig,
+  init,
+};


### PR DESCRIPTION
This puts in a really nice & flexible config solution.

Where does config come from?
The order goes like this, as this list increases, the later override the earlier. [Order inspired by `rc`](https://www.npmjs.com/package/rc#standards).

1. `defaultConfig` in `config-store.js`
2. `userConfig` from `.boltrc.js` that's in same cwd as where `bolt` was ran, unless they use `--config-file path/to/.boltrc.js`
3. Env Vars with `bolt_` prefix; `bolt_verbosity=1` will override `config.verbosity` - case matters!
4. Certain command line options like `bolt build --verbosity 5` - not every config option is overridable this way.

Now any file can do this to get the config:

```js
const { getConfig } = require('../utils/config-store');
const config = getConfig();
```

Also, any config can update the config with this:

```js
const { updateConfig, getConfig } = require('../utils/config-store');

updateConfig((currentConfig) => {
  // manipulate it how you'd like to
  currentConfig.verbosity = 5;
  return currentConfig;
});

console.log(getConfig().verbosity); // returns `5`
```

Wahoo! 🎉  ⚡️ 