### PR TITLE
Adding build tools server

### DIFF
--- a/apps/pattern-lab--workshop/.boltrc.js
+++ b/apps/pattern-lab--workshop/.boltrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: 'pl',
   plConfigFile: './config/config.yml',
   dist: './dist/assets',
+  server: './dist',
   verbosity: 3,
   components: {
     global: [

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -41,6 +41,24 @@ program
     });
   });
 
+program
+  .command('serve')
+  .description('Spin up local server')
+  .option('-O, --open', 'Open browser at start.')
+  .action((options) => {
+    log.info('Starting server...');
+
+    configStore.updateConfig((config) => {
+      config.openServerAtStart = typeof options.open === 'undefined'
+        ? config.openServerAtStart
+        : options.open;
+      return config;
+    });
+
+    const serve = require('./tasks/serve');
+    serve.init();
+  });
+
 // `bolt lint`
 program
   .command('lint')

--- a/packages/build-tools/commands/build.js
+++ b/packages/build-tools/commands/build.js
@@ -4,6 +4,7 @@ const run = require('../utils/run');
 module.exports = async (options) => {
   const webpackTasks = require('../tasks/webpack-tasks')();
   const patternLabTasks = await require('../tasks/pattern-lab-tasks')();
+  const serve = require('../tasks/serve');
   // @todo figure out how to best conditionally run tasks based on environment (`pl`, `drupal`)
 
   async function parallelBuild() {
@@ -33,6 +34,7 @@ module.exports = async (options) => {
       run.parallel([
         patternLabTasks.watch,
         webpackTasks.watch,
+        serve.init,
       ]);
     } catch (error) {
       log.errorAndExit('watch', error);

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -29,6 +29,7 @@
     "@theme-tools/sass-import-globbing": "^1.0.0",
     "autoprefixer": "^7.2.4",
     "babel-loader": "^7.1.2",
+    "browser-sync": "^2.23.5",
     "chalk": "^2.3.0",
     "chokidar": "^2.0.0",
     "clean-css-loader": "^0.1.4",

--- a/packages/build-tools/tasks/serve.js
+++ b/packages/build-tools/tasks/serve.js
@@ -1,0 +1,47 @@
+const browserSync = require('browser-sync');
+const events = require('../utils/events');
+const config = require('../utils/config-store').getConfig();
+const log = require('../utils/log');
+const server = browserSync.create();
+
+// https://www.browsersync.io/docs/options
+const serverConfig = {
+  open: config.openServerAtStart,
+};
+
+if (config.env === 'pl') {
+  // https://www.browsersync.io/docs/options#option-server
+  serverConfig.server = config.server;
+}
+
+function init() {
+  log.taskStart('serve');
+  // https://www.browsersync.io/docs/api#api-init
+  server.init(serverConfig, () => {
+    if (config.verbosity > 3) {
+      log.info('BrowserSync set up and ready to go... (this notice may be redundant)');
+    }
+  });
+}
+
+/**
+ * Reload BrowserSync
+ * @param {string[] | string} files - Files to reload. Optional.
+ * @link https://www.browsersync.io/docs/api#api-reload
+ */
+function reload(files) {
+  server.reload(files);
+}
+
+events.on('reload', (files) => {
+  if (config.verbosity > 3) {
+    log.info('Event triggered: "reload"', files);
+  }
+  reload(files);
+});
+
+
+module.exports = {
+  init,
+  reload,
+};

--- a/packages/build-tools/utils/assets.js
+++ b/packages/build-tools/utils/assets.js
@@ -1,0 +1,64 @@
+const path = require('path');
+const log = require('./log');
+
+/**
+ * Get information about a components assets
+ * @param {string} component - Machine name of a component i.e. `@bolt/button`
+ * @returns {{name, basicName: string | * | void}} - Asset info
+ */
+function getAssets(component) {
+  // @todo Ensure package exists
+  const pkgJsonPath = require.resolve(`${component}/package.json`);
+  const pkgPath = path.dirname(pkgJsonPath);
+  const pkg = require(pkgJsonPath);
+  const assets = {
+    name: pkg.name,
+    basicName: pkg.name.replace('@bolt/', 'bolt-'),
+  };
+  // @todo Ensure asset files exist
+  if (pkg.style) assets.style = path.join(pkgPath, pkg.style);
+  if (pkg.main) assets.main = path.join(pkgPath, pkg.main);
+  // @todo Allow verbosity settings
+  // console.log(assets);
+  return assets;
+}
+
+/**
+ * Build WebPack config's `entry` object
+ * @link https://webpack.js.org/configuration/entry-context/#entry
+ * @param {object} components
+ * @prop {string[]} components.global - Array of strings that are package names - all go into the global bundle
+ * @prop {string[]} components.individual - Array of strings that are package names - each go into own bundle
+ * @returns {object} entry - WebPack config `entry`
+ */
+function buildWebpackEntry(components) {
+  const entry = {};
+  if (components.global) {
+    entry['bolt-global'] = [];
+    components.global.forEach((component) => {
+      const assets = getAssets(component);
+      if (assets.style) entry['bolt-global'].push(assets.style);
+      if (assets.main) entry['bolt-global'].push(assets.main);
+    });
+  }
+  if (components.individual) {
+    components.individual.forEach((component) => {
+      const assets = getAssets(component);
+      const files = [];
+      if (assets.style) files.push(assets.style);
+      if (assets.main) files.push(assets.main);
+      if (files) {
+        entry[assets.basicName] = files;
+      } else {
+        log.error(`No assets found for ${assets.name}`, assets);
+      }
+    });
+  }
+  // @todo Allow verbosity settings for seeing `entry`
+  return entry;
+}
+
+module.exports = {
+  getAssets,
+  buildWebpackEntry,
+};

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -13,6 +13,7 @@ let config = {};
 
 const defaultConfig = {
   verbosity: 2,
+  openServerAtStart: false,
 };
 
 function getEnvVarsConfig() {


### PR DESCRIPTION
This contains commits from PR #327 , so either wait till that is merged in for a better diff, or just [look at this diff](https://github.com/bolt-design-system/bolt/compare/feature/build-tools-config...feature/build-tools-updates).

This adds `bolt serve`, and also adds the serve task to `bolt build --watch`!

There's some WebPack entry function cleanup in here too that lays foundations for some future work. Doesn't change around the functionality at all.

There's definitely more I'd like to do in the config department, but just wanted this out.