### PR TITLE
monorepo preflight script start

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "backstop-test": "backstop test",
     "backstop-reference": "backstop reference",
     "bootstrap": "lerna bootstrap --reject-cycles",
+    "postbootstrap": "node scripts/monorepo-tests.js",
     "clean:git": "git clean -xdf",
     "deploy": "netlify deploy -s bolt.netlify.com -p dist",
     "Xlint:js": "eslint ./build-tools",

--- a/scripts/monorepo-tests.js
+++ b/scripts/monorepo-tests.js
@@ -33,6 +33,8 @@ function checkMonorepoSymlinks() {
           console.log('Error: Everything in "node_modules/.bin/@bolt/" should be a symbolic link to ensure the monorepo is set up correctly. You most likely have a version mismatch between this and something that is using it.');
           console.log(item.path);
           process.exit(1);
+        } else {
+          // console.log(`Looks good: ${item.path}`);
         }
       });
     })

--- a/scripts/monorepo-tests.js
+++ b/scripts/monorepo-tests.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const {promisify} = require('util');
+const readdir = promisify(fs.readdir);
+const lstat = promisify(fs.lstat);
+
+/**
+ * Monorepo symlink checker for internal `@bolt` packages
+ * Ensures every directory in `../node_modules/.bin/@bolt/` is a symbolic link, if not then, a package is being pulled from npm instead of the local repo - which causes problems.
+ */
+function checkMonorepoSymlinks() {
+  const baseDir = path.resolve(__dirname, '../node_modules/@bolt');
+  readdir(baseDir)
+    .then((dirNames) => {
+      return Promise.all(dirNames.map((dirName) => {
+        const item = {
+          path: path.join(baseDir, dirName),
+        };
+        return new Promise((resolve, reject) => {
+          lstat(item.path)
+            .then((stats) => {
+              item.stats = stats;
+              resolve(item);
+            })
+            .catch(reject);
+        });
+      }))
+    })
+    .then((items) => {
+      items.forEach((item) => {
+        if (!item.stats.isSymbolicLink()) {
+          console.log('Error: Everything in "node_modules/.bin/@bolt/" should be a symbolic link to ensure the monorepo is set up correctly. You most likely have a version mismatch between this and something that is using it.');
+          console.log(item.path);
+          process.exit(1);
+        }
+      });
+    })
+    .catch((error) => {
+      console.log('uh oh!', error);
+      process.exit(1)
+    });
+}
+
+checkMonorepoSymlinks();

--- a/scripts/monorepo-tests.js
+++ b/scripts/monorepo-tests.js
@@ -7,7 +7,7 @@ const lstat = promisify(fs.lstat);
 
 /**
  * Monorepo symlink checker for internal `@bolt` packages
- * Ensures every directory in `../node_modules/.bin/@bolt/` is a symbolic link, if not then, a package is being pulled from npm instead of the local repo - which causes problems.
+ * Ensures every directory in `../node_modules/@bolt/` is a symbolic link, if not then, a package is being pulled from npm instead of the local repo - which causes problems.
  */
 function checkMonorepoSymlinks() {
   const baseDir = path.resolve(__dirname, '../node_modules/@bolt');
@@ -30,7 +30,7 @@ function checkMonorepoSymlinks() {
     .then((items) => {
       items.forEach((item) => {
         if (!item.stats.isSymbolicLink()) {
-          console.log('Error: Everything in "node_modules/.bin/@bolt/" should be a symbolic link to ensure the monorepo is set up correctly. You most likely have a version mismatch between this and something that is using it.');
+          console.log('Error: Everything in "node_modules/@bolt/" should be a symbolic link to ensure the monorepo is set up correctly. You most likely have a version mismatch between this and something that is using it.');
           console.log(item.path);
           process.exit(1);
         } else {


### PR DESCRIPTION
I'd like to get some scripts to ensure that developers have everything set up correctly, like:

- yarn version
- node version
- correct monorepo bootstrap setup

This is a very basic beginning to test for something I look for all the time: is everything in `./node_modules/@bolt/` a symlink? When it's not, it's bad and tends to be solved when I do one of a couple things:

- point workspaces path to correct package
- ensure the dependencies of something are using the version that the package in the repo is using

These subtleties  no one besides architects should have to deal with; let's prevent them from having to with tools. I totally expect the approach of running this script to evolve and change, but I just wanted to get this basic function out for our use now.