### PR TITLE
Adding Build Tools config schema

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -37,6 +37,7 @@
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.2",
     "js-yaml": "^3.10.0",
+    "jsonschema": "^1.2.2",
     "lodash.debounce": "^4.0.8",
     "node-notifier": "^5.1.2",
     "npm-sass": "^2.2.1",

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -1,4 +1,8 @@
 const chalk = require('chalk');
+const path = require('path');
+const { readYamlFileSync } = require('./yaml');
+const schemaValidator = require('./schemas');
+const configSchema = readYamlFileSync(path.join(__dirname, './config.schema.yml'));
 let isInitialized = false;
 let config = {};
 // Welcome to the home of the config!
@@ -52,6 +56,7 @@ function isReady() {
 
 function init(userConfig) {
   config = Object.assign({}, defaultConfig, userConfig, getEnvVarsConfig());
+  schemaValidator.validateSchema(configSchema, config);
   isInitialized = true;
   return config;
 }
@@ -72,6 +77,7 @@ function getConfig() {
 function updateConfig(updater) {
   isReady();
   const newConfig = updater(config);
+  schemaValidator.validateSchema(configSchema, newConfig);
   // console.log('new config:');
   // console.log(newConfig);
   config = newConfig;

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk');
 const path = require('path');
 const { readYamlFileSync } = require('./yaml');
-const schemaValidator = require('./schemas');
+const { validateSchema } = require('./schemas');
 const configSchema = readYamlFileSync(path.join(__dirname, './config.schema.yml'));
 let isInitialized = false;
 let config = {};
@@ -56,7 +56,7 @@ function isReady() {
 
 function init(userConfig) {
   config = Object.assign({}, defaultConfig, userConfig, getEnvVarsConfig());
-  schemaValidator.validateSchema(configSchema, config);
+  validateSchema(configSchema, config);
   isInitialized = true;
   return config;
 }
@@ -77,7 +77,7 @@ function getConfig() {
 function updateConfig(updater) {
   isReady();
   const newConfig = updater(config);
-  schemaValidator.validateSchema(configSchema, newConfig);
+  validateSchema(configSchema, newConfig);
   // console.log('new config:');
   // console.log(newConfig);
   config = newConfig;

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -1,0 +1,55 @@
+  $schema: http://json-schema.org/draft-04/schema#
+  title: Bolt Button
+  type: object
+  required:
+    - env
+    - dist
+    - components
+  additionalProperties: false
+  properties:
+    env:
+      type: string
+      title: Environment Type
+      description: Where is this being compiled? Pattern Lab? Drupal?
+      enum:
+        - pl
+    plConfigFile:
+      type: string
+      title: Pattern Lab Config File Path
+    dist:
+      type: string
+      description: Where it all builds too
+    server:
+      type: string
+      title: Path to server root
+      description: Where static files are served from.
+    verbosity:
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+    components:
+      type: object
+      properties:
+        global:
+          type: array
+          uniqueItems: true
+          # array of objects
+          items:
+            -
+              type: string
+        individual:
+          type: array
+          uniqueItems: true
+          # array of objects
+          items:
+            -
+              type: string
+    openServerAtStart:
+      type: boolean
+      description: If, after starting `npm start`, a Browser opens.
+

--- a/packages/build-tools/utils/schemas.js
+++ b/packages/build-tools/utils/schemas.js
@@ -1,0 +1,23 @@
+const chalk = require('chalk');
+const log = require('./log');
+const { Validator } = require('jsonschema');
+
+function validateSchema(schema, data) {
+  const v = new Validator();
+  const results = v.validate(data, schema);
+  // console.log(results);
+  if (results.errors.length) {
+    log.error(chalk.bold('Config Schema Errors:'));
+    results.errors.forEach((error, i ) => {
+      log.error(`${i+1}) ${error}`);
+    });
+    log.info('Please fix the config being used in Bolt CLI.');
+    process.exit(1);
+  } else {
+    // log.success('No config schema errors.');
+  }
+}
+
+module.exports = {
+  validateSchema,
+};

--- a/packages/build-tools/utils/yaml.js
+++ b/packages/build-tools/utils/yaml.js
@@ -40,6 +40,22 @@ function readYamlFile(file) {
 }
 
 /**
+ * Read Yaml File into Object
+ * @param {string} file - File path
+ * @returns {Promise<object>} Promise resolves with yaml file as object
+ * @see fromYaml
+ * @see writeYamlFile
+ */
+function readYamlFileSync(file) {
+  return fromYaml(fs.readFileSync(file, 'utf8'));
+  // return new Promise((resolve, reject) => {
+  //   readFile(file, 'utf8')
+  //     .then(data => resolve(fromYaml(data)))
+  //     .catch(reject);
+  // });
+}
+
+/**
  * Write Yaml string to File
  * @param {string} file - File path
  * @param {object} data - Object to turn into Yaml
@@ -59,5 +75,6 @@ module.exports = {
   fromYaml,
   toYaml,
   readYamlFile,
+  readYamlFileSync,
   writeYamlFile,
 };


### PR DESCRIPTION
This validates all use of the `bolt` config; to test, add some config that does not belong and try to run any command. Open to any all PRs and ideas for changes to how the config is structured. 