### PR TITLE
Re-enabling Strict Schema for Build Tools

### DIFF
--- a/apps/pattern-lab--workshop/.boltrc.js
+++ b/apps/pattern-lab--workshop/.boltrc.js
@@ -1,70 +1,12 @@
-// Thanks to StencilJS (https://stenciljs.com/docs/stencil-config) for a little inspiration for some of these configuration names. Naming things is hard!
-
 module.exports = {
   // Environmental variable / preset to use
   env: 'pl',
-
-
-  /**
-   * The srcDir config specifies the source directory.
-   * @param {string} [srcDir=src] - The source directory.
-   */
   srcDir: 'src',
-
-
-  /**
-   * The publicPath config sets the client-side base path for all built / asynchronously
-   * loaded assets. By default the loader script will automatically figure out the relative
-   * path to load your components, but uses publicPath as a fallback. It's recommended to have
-   * it start with a `/`.
-   *
-   * Note: this ONLY sets the base path the browser requests -- it does not set where files
-   * are saved during build. To change where files are saved at build time, use the buildDir
-   * config.
-   *
-   * @param {string} [publicPath=/build] - The publicPath directory.
-   */
   publicPath: '/build/',
-
-
-  /**
-   * The buildDir config specifies where Bolt's compiled files are saved after every
-   * build.These are the generated scripts which will be requested by the browser. The build
-   * directory should be relative to the wwwDir setting.
-   *
-   * @param {string} [buildDir=build] - The buildDir directory.
-   */
   buildDir: 'build',
-
-
-  /**
-    * The wwwDir config specifies the public web distribution directory.
-    * This directory is commonly the root directory for a server, where all
-    * static files can be served. This directory is built and rebuilt directly
-    * from the source files.
-    *
-    * Note: We recommend this directory is not committed to a repository.
-    *
-    * @param {string} [wwwDir=www] - The wwwDir directory.
-    */
   wwwDir: 'www',
-
-
-//   copy
-// The copy config is an array of objects that define any files or folders that you would like to get copied over to your buildDir when a build is performed.Each object in the array must include a src property which can be either an absolute path, a relative path or a glob pattern.You can also provide the optional dest property which can be either an absolute path or a path relative to your buildDir.
-
-
-  // Where does your PL config.yml live?
   plConfigFile: './config/config.yml',
-
-
-  /**
-   * How 'loud' or 'quiet' do you want the console output to be?
-   * @param {int} [verbosity=3] -  Logging level (Range of 0 to 5)
-   */
-  verbosity: 2, //
-
-
+  verbosity: 2,
   components: {
     global: [
       '@bolt/core',
@@ -88,14 +30,6 @@ module.exports = {
       '@bolt/components-unordered-list'
     ],
     individual: [
-
     ],
-    // individual: [
-    // ],
   },
-
-  // Dev-server specific config settings (ex. port to use)
-  devServer: {
-    open: true
-  }
 };

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -48,8 +48,8 @@ program
     log.info('Starting server...');
 
     configStore.updateConfig((config) => {
-      config.devServer.open = typeof options.open === 'undefined'
-        ? config.devServer.open
+      config.openServerAtStart = typeof options.open === 'undefined'
+        ? config.openServerAtStart
         : options.open;
       return config;
     });

--- a/packages/build-tools/tasks/server-tasks.js
+++ b/packages/build-tools/tasks/server-tasks.js
@@ -6,7 +6,7 @@ const server = browserSync.create();
 
 // https://www.browsersync.io/docs/options
 const serverConfig = {
-  open: config.devServer.open,
+  open: config.openServerAtStart,
   startPath: '/index.html', // Since `/` doesn't do anything and we want to avoid double browserSync notifications from the very beginning
   host: 'localhost',
   port: 3000,

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -23,8 +23,7 @@ const defaultConfig = {
 function getEnvVarsConfig() {
   const envVars = {};
   Object.keys(process.env).forEach((envVar) => {
-    const parts = envVar.split('bolt_');
-    if (parts.length > 1) {
+    if (envVar.startsWith('bolt_')) {
       /** @type {string} - All env vars are strings */
       let value = process.env[envVar];
 
@@ -40,6 +39,7 @@ function getEnvVarsConfig() {
         }
       }
 
+      const parts = envVar.split('bolt_');
       envVars[parts[1]] = value;
     }
   });

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -1,5 +1,7 @@
+# Thanks to StencilJS (https://stenciljs.com/docs/stencil-config) for a little inspiration for some of these configuration names. Naming things is hard!
+
   $schema: http://json-schema.org/draft-04/schema#
-  title: Bolt Button
+  title: Bolt Build Tools
   type: object
   required:
     - env
@@ -13,22 +15,29 @@
       description: Where is this being compiled? Pattern Lab? Drupal?
       enum:
         - pl
+    srcDir:
+      type: string
+      title: Source Directory
     plConfigFile:
       type: string
       title: Pattern Lab Config File Path
     buildDir:
       type: string
-      description: Where it all builds too
+      description: The buildDir config specifies where Bolt's compiled files are saved after every build. These are the generated scripts which will be requested by the browser. The build directory should be relative to the wwwDir setting (i.e. inside it).
     wwwDir:
       type: string
       title: Path to server root
-      description: Where static files are served from.
+      description: "Where static files are served from. The wwwDir config specifies the public web distribution directory. This directory is commonly the root directory for a server, where all static files can be served. This directory is built and rebuilt directly from the source files. Note: We recommend this directory is not committed to a repository."
     publicPath:
       type: string
       title: Path to publicPath directory
-      description: Sets the client-side base path for all built / asynchronously loaded assets
+      description: "The publicPath config sets the client-side base path for all built / asynchronously loaded assets. By default the loader script will automatically figure out the relative path to load your components, but uses publicPath as a fallback. It's recommended to have it start with a `/`. Note: this ONLY sets the base path the browser requests -- it does not set where files are saved during build. To change where files are saved at build time, use the buildDir config."
+    openServerAtStart:
+      type: boolean
+      description: If, after starting `npm start`, a Browser opens.
     verbosity:
       type: integer
+      description: Logging level (Range of 0 to 5) How 'loud' or 'quiet' do you want the console output to be?
       enum:
         - 0
         - 1
@@ -53,9 +62,3 @@
           items:
             -
               type: string
-    devServer:
-      type: object
-      properties:
-        open:
-          type: boolean
-          description: If, after starting `npm start`, a Browser opens.

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -5,7 +5,7 @@
     - env
     - buildDir
     - components
-  additionalProperties: true
+  additionalProperties: false
   properties:
     env:
       type: string


### PR DESCRIPTION
IMHO, this is really important to keep on. If we don’t, we’ll be lazy with keeping the schema updated. If this build fails, let’s work together on this PR to document the config till it passes. 