### PR TITLE
Feature/pl tasks tweak

### DIFF
--- a/apps/pattern-lab--workshop/package.json
+++ b/apps/pattern-lab--workshop/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "bolt build",
     "build:noisy": "bolt build --verbosity 5",
-    "start": "bolt build --watch"
+    "start": "bolt build && bolt build --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/build-tools/commands/build.js
+++ b/packages/build-tools/commands/build.js
@@ -32,6 +32,7 @@ module.exports = (options) => {
   async function parallelWatch() {
     try {
       run.parallel([
+        webpackTasks.server,
         patternLabTasks.watch,
         webpackTasks.watch,
         serverTasks.serve,

--- a/packages/build-tools/commands/build.js
+++ b/packages/build-tools/commands/build.js
@@ -1,9 +1,9 @@
 const log = require('../utils/log');
 const run = require('../utils/run');
 
-module.exports = async (options) => {
+module.exports = (options) => {
   const webpackTasks = require('../tasks/webpack-tasks')();
-  const patternLabTasks = await require('../tasks/pattern-lab-tasks')();
+  const patternLabTasks = require('../tasks/pattern-lab-tasks');
   const serverTasks = require('../tasks/server-tasks');
   // @todo figure out how to best conditionally run tasks based on environment (`pl`, `drupal`)
 

--- a/packages/build-tools/tasks/pattern-lab-tasks.js
+++ b/packages/build-tools/tasks/pattern-lab-tasks.js
@@ -1,4 +1,4 @@
-const yaml = require('../utils/yaml');
+const { readYamlFileSync } = require('../utils/yaml');
 const sh = require('../utils/sh');
 const path = require('path');
 const events = require('../utils/events');
@@ -7,91 +7,89 @@ const debounce = require('lodash.debounce');
 const log = require('../utils/log');
 const { getConfig } = require('../utils/config-store');
 
-module.exports = async () => {
-  const config = Object.assign({
-    plConfigFile: 'config/config.yml',
-    watchedExtensions: [
-      'twig',
-      'json',
-      'yaml',
-      'yml',
-      'md',
-      'png',
-      'php',
+const config = Object.assign({
+  plConfigFile: 'config/config.yml',
+  watchedExtensions: [
+    'twig',
+    'json',
+    'yaml',
+    'yml',
+    'md',
+    'png',
+    'php',
+  ],
+  extraWatches: [],
+  debounceRate: 1000,
+}, getConfig());
+
+const plConfig = readYamlFileSync(config.plConfigFile);
+const plRoot = path.join(config.plConfigFile, '../..');
+const plSource = path.join(plRoot, plConfig.sourceDir);
+// const plPublic = path.join(plRoot, plConfig.publicDir);
+const consolePath = path.join(plRoot, 'core/console');
+
+function plBuild(errorShouldExit) {
+  return new Promise((resolve, reject) => {
+    log.taskStart('build: pattern lab');
+    events.emit('pattern-lab:precompile');
+    sh(`php -d memory_limit=4048M ${consolePath} --generate`, errorShouldExit)
+      .then(() => {
+        events.emit('reload');
+        log.taskDone('build: pattern lab');
+        resolve();
+      })
+      .catch(reject);
+  });
+}
+
+function compile() {
+  return plBuild(true);
+}
+
+compile.description = 'Compile Pattern Lab';
+compile.displayName = 'pattern-lab:compile';
+
+function compileWithNoExit() {
+  return plBuild(false);
+}
+
+compileWithNoExit.displayName = 'pattern-lab:compile';
+
+// Used by watches
+const debouncedCompile = debounce(compileWithNoExit, config.debounceRate);
+
+function watch() {
+  const watchedExtensions = config.watchedExtensions.join(',');
+  const plGlob = [path.normalize(`${plSource}/**/*.{${watchedExtensions}}`)];
+  const src = config.extraWatches
+    ? [].concat(plGlob, config.extraWatches)
+    : plGlob;
+
+  log.taskStart('watch: pattern lab');
+  // The watch event ~ same engine gulp uses https://www.npmjs.com/package/chokidar
+  const watcher = chokidar.watch(src, {
+    ignoreInitial: true,
+    cwd: process.cwd(),
+    ignore: [
+      '**/node_modules/**',
+      '**/vendor/**',
     ],
-    extraWatches: [],
-    debounceRate: 1000,
-  }, getConfig());
+  });
 
-  const plConfig = await yaml.readYamlFile(config.plConfigFile);
-  const plRoot = path.join(config.plConfigFile, '../..');
-  const plSource = path.join(plRoot, plConfig.sourceDir);
-  // const plPublic = path.join(plRoot, plConfig.publicDir);
-  const consolePath = path.join(plRoot, 'core/console');
+  // list of all events: https://www.npmjs.com/package/chokidar#methods--events
+  watcher.on('all', (event, path) => {
+    if (config.verbosity > 1) {
+      console.log(event, path);
+    }
+    debouncedCompile();
+  });
 
-  function plBuild(errorShouldExit) {
-    return new Promise((resolve, reject) => {
-      log.taskStart('build: pattern lab');
-      events.emit('pattern-lab:precompile');
-      sh(`php -d memory_limit=4048M ${consolePath} --generate`, errorShouldExit)
-        .then(() => {
-          events.emit('reload');
-          log.taskDone('build: pattern lab');
-          resolve();
-        })
-        .catch(reject);
-    });
-  }
+}
 
-  function compile() {
-    return plBuild(true);
-  }
+watch.description = 'Watch and rebuild Pattern Lab';
+watch.displayName = 'pattern-lab:watch';
 
-  compile.description = 'Compile Pattern Lab';
-  compile.displayName = 'pattern-lab:compile';
-
-  function compileWithNoExit() {
-    return plBuild(false);
-  }
-
-  compileWithNoExit.displayName = 'pattern-lab:compile';
-
-  // Used by watches
-  const debouncedCompile = debounce(compileWithNoExit, config.debounceRate);
-
-  function watch() {
-    const watchedExtensions = config.watchedExtensions.join(',');
-    const plGlob = [path.normalize(`${plSource}/**/*.{${watchedExtensions}}`)];
-    const src = config.extraWatches
-      ? [].concat(plGlob, config.extraWatches)
-      : plGlob;
-
-    log.taskStart('watch: pattern lab');
-    // The watch event ~ same engine gulp uses https://www.npmjs.com/package/chokidar
-    const watcher = chokidar.watch(src, {
-      ignoreInitial: true,
-      cwd: process.cwd(),
-      ignore: [
-        '**/node_modules/**',
-        '**/vendor/**',
-      ],
-    });
-
-    // list of all events: https://www.npmjs.com/package/chokidar#methods--events
-    watcher.on('all', (event, path) => {
-      if (config.verbosity > 1) {
-        console.log(event, path);
-      }
-      debouncedCompile();
-    });
-
-  }
-
-  watch.description = 'Watch and rebuild Pattern Lab';
-  watch.displayName = 'pattern-lab:watch';
-
-  return {
-    compile,
-    watch,
-  };
+module.exports = {
+  compile,
+  watch,
 };

--- a/packages/build-tools/utils/run.js
+++ b/packages/build-tools/utils/run.js
@@ -1,3 +1,5 @@
+const log = require('./log');
+
 // @todo tweak, prod, and test the crap out of this
 
 /**
@@ -6,7 +8,11 @@
  */
 async function series(tasks) {
   for (let task of tasks) {
-    await task();
+    try {
+      await task();
+    } catch (error) {
+      log.errorAndExit('Series task run failed.', error);
+    }
   }
 }
 
@@ -15,11 +21,14 @@ async function series(tasks) {
  * @param {function[]} tasks - An array of functions that return Promises
  */
 async function parallel(tasks) {
-  const allTasks = tasks.map(task => task());
-
-  allTasks.forEach(async (task) => {
-    await task;
-  });
+  try {
+    const allTasks = tasks.map(task => task());
+    allTasks.forEach(async (task) => {
+      await task;
+    });
+  } catch (error) {
+    log.errorAndExit('Parallel task run failed.', error);
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
OK, this does the necessary updates to how the tasks are set up that we talked about @sghoweri - I've also added the `webpackTasks.server` task to the watch and set up `npm start` so it runs build, then watch. Since I got these updates in, I don't think your micro PR we talked about would be necessary. The PL tasks diff may look crazy, but that's b/c I un-indented it, so look at the [diff without whitespace shown](https://github.com/bolt-design-system/bolt/pull/338/files?w=1) for a better look. 