### PR TITLE
Update Pattern Lab Watch, Reload Tasks, 1st Pass Webpack Dev Server

### DIFF
--- a/packages/build-tools/commands/build.js
+++ b/packages/build-tools/commands/build.js
@@ -32,9 +32,10 @@ module.exports = async (options) => {
   async function parallelWatch() {
     try {
       run.parallel([
-        patternLabTasks.watch,
-        webpackTasks.watch,
+        webpackTasks.server,
+        patternLabTasks.compile,
         serverTasks.serve,
+        patternLabTasks.watch,
       ]);
     } catch (error) {
       log.errorAndExit('watch', error);

--- a/packages/build-tools/commands/build.js
+++ b/packages/build-tools/commands/build.js
@@ -33,7 +33,6 @@ module.exports = (options) => {
     try {
       run.parallel([
         webpackTasks.server,
-        patternLabTasks.watch,
         webpackTasks.watch,
         serverTasks.serve,
         patternLabTasks.watch,

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -177,7 +177,8 @@ function createConfig(config) {
       new webpack.WatchIgnorePlugin([
         /dist\/styleguide/,
         /dist\/annotations/,
-        /styleguide/
+        /styleguide/,
+        path.join(__dirname, 'node_modules')
       ]),
       new webpack.HotModuleReplacementPlugin(),
       new webpack.optimize.CommonsChunkPlugin({
@@ -217,6 +218,7 @@ function createConfig(config) {
         // @TODO: add Pattern Lab Styleguidekit Assets Default dist path here
       ],
       compress: true,
+      clientLogLevel: 'info',
       port: 8080,
       stats: statsPreset(webpackStats[config.verbosity]),
       overlay: {
@@ -230,6 +232,8 @@ function createConfig(config) {
       watchOptions: {
         aggregateTimeout: 500,
         // ignored: /(annotations|fonts|bower_components|dist\/styleguide|node_modules|styleguide|images|fonts|assets)/
+        // Poll using interval (in ms, accepts boolean too)
+        poll: true,
       }
     }
   };

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -47,7 +47,7 @@
     "semver": "^5.4.1",
     "style-loader": "^0.19.1",
     "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.10.1",
+    "webpack-dev-server": "^2.11.0",
     "webpack-manifest-plugin": "^2.0.0-rc.1"
   },
   "publishConfig": {

--- a/packages/build-tools/tasks/webpack-tasks.js
+++ b/packages/build-tools/tasks/webpack-tasks.js
@@ -96,7 +96,12 @@ module.exports = () => {
   function server() {
     return new Promise((resolve, reject) => {
       log.taskStart('webpack:server');
-      // Start a webpack-dev-server
+
+      // Add HMR scripts required to entrypoint
+      if (webpackConfig.devServer.hot) {
+        webpackConfig.entry['bolt-global'].unshift('webpack-dev-server/client?http://localhost:8080/', 'webpack/hot/dev-server');
+      }
+
       new WebpackDevServer(webpack(webpackConfig), webpackConfig.devServer).listen(webpackConfig.devServer.port, 'localhost', function (err) {
         if (err) {
           return reject(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9244,7 +9244,7 @@ webpack-dev-middleware@1.12.2:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-dev-server@^2.10.1:
+webpack-dev-server@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.11.0.tgz#e9d4830ab7eb16c6f92ed68b92f6089027960e1b"
   dependencies:


### PR DESCRIPTION
- Compile PL by default on first run (temp workaround till work @EvanLovely is working on is in place)
- Switch on Hot Module reloading
- Update PL watch tasks to compile based on files in packages folder as well