### PR TITLE
QA fix: vertical alignment of flag items

### DIFF
--- a/src/_patterns/01-core/05-objects/bolt-flag-object/demo/flag~align-middle.json
+++ b/src/_patterns/01-core/05-objects/bolt-flag-object/demo/flag~align-middle.json
@@ -8,5 +8,5 @@
     }
   },
   "content": "Example flag content",
-  "align": "middle"
+  "valign": "middle"
 }

--- a/src/_patterns/01-core/05-objects/bolt-flag-object/src/flag.scss
+++ b/src/_patterns/01-core/05-objects/bolt-flag-object/src/flag.scss
@@ -9,9 +9,9 @@ $bolt-flag-sizes: (
 );
 
 $bolt-flag-alignments: (
-  'top': 'flex-start',
-  'middle': 'center',
-  'bottom': 'flex-end'
+  'top': flex-start,
+  'middle': center,
+  'bottom': flex-end
 );
 
 
@@ -83,35 +83,35 @@ $bolt-flag-alignments: (
 
 
 
-// 
-// 
+//
+//
 // // Flexbox adjustments
 // @supports (display: flex) {
 //   .o-flag {
 //     display: flex;
 //     align-items: flex-start;
-// 
+//
 //     &--center {
 //       align-items: center;
 //     }
-// 
+//
 //     &--bottom {
 //       align-items: flex-end;
 //     }
-//     
+//
 //     &--rev .o-bolt-flag__image {
 //       order: 1;
 //       padding-left: $spacing-unit;
 //       padding-right: $spacing-unit;
 //     }
 //   }
-// 
-// 
+//
+//
 //   .o-bolt-flag__image,
 //   .o-bolt-flag__body {
 //       display: initial;
 //   }
-// 
+//
 //   .o-bolt-flag__body {
 //     // min-width: 0;
 //     // flex: 1 1 auto;

--- a/src/_patterns/01-core/05-objects/bolt-flag-object/src/flag.twig
+++ b/src/_patterns/01-core/05-objects/bolt-flag-object/src/flag.twig
@@ -31,7 +31,7 @@
   {% if figure %}
     <div class="o-bolt-flag__figure">
       {% block flag_figure %}
-        {% set figureContent %}  
+        {% set figureContent %}
           {% include "@bolt/figure.twig" with figure only %}
         {% endset %}
 
@@ -56,7 +56,7 @@
           {{ item.text }}
         {% endif %}
       {% endfor %}
-      
+
       {{ content }}
 
     {% endblock %}


### PR DESCRIPTION
@christophersmith262 You can set `valign: middle` to vertical align items inside a flag object.