### PR TITLE
Feature/build assets tests

### DIFF
--- a/packages/components/bolt-button-group/package.json
+++ b/packages/components/bolt-button-group/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/bolt-design-system/bolt/issues"
   },
   "style": "src/button-group.scss",
-  "twig": "button-group.twig",
+  "twig": "src/button-group.twig",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/components/bolt-page-header/package.json
+++ b/packages/components/bolt-page-header/package.json
@@ -22,7 +22,6 @@
     "access": "public"
   },
   "style": "src/_page-header.scss",
-  "twig": "src/page-header.twig",
   "dependencies": {
     "@bolt/core": "^0.5.0-beta.1"
   }


### PR DESCRIPTION
This enhancement relates to all components that registered in `.boltrc.js` and then looked at to grab their scss, js, and twig files for webpack to compile: now each file reference is checked for it's existence. 

This is a good thing b/c the tests caught two errors we had: 8cef100 & 6ab2d4e

@remydenton Can you confirm that the Bolt Page Header should not have `src/page-header.twig` in it? You can see my change in 6ab2d4e

Most of the changes are renaming `getAssets()` to `getPkgInfo()` and making it so that function returns this format for each package:

```js
const pkgInfo = {
  name: '@bolt/components-button',
  basicName: 'bolt-components-button',
  assets: {
        style: '/Users/Evan/dev/clients/pega-bolt/bolt/packages/components/button/src/button.scss',
        main: '/Users/Evan/dev/clients/pega-bolt/bolt/packages/components/button/src/button.js',
        twig: [
           '/Users/Evan/dev/clients/pega-bolt/bolt/packages/components/button/src/button.twig'
        ]
   }
}
```

Before, `style`, `main`, and `twig` were at the top level and not under `assets` (b/c it was `getAssets()`.

And if you're wondering why it's and absolute path, it's cause that is all in memory and unique to each environment and compile and just makes things generally easier.