### PR TITLE
Adding a very very tall Smooth Scroll demo

### DIFF
--- a/bolt-manifest.yml
+++ b/bolt-manifest.yml
@@ -507,6 +507,11 @@ smooth_scroll_demo:
   filename: smooth-scroll.demo.twig
   path: src/_patterns/02-components/bolt-smooth-scroll/demo/smooth-scroll.demo.twig
   namespace: '@bolt/smooth-scroll.demo.twig'
+smooth_scroll_xl_demo:
+  filename: '-smooth-scroll-xl.demo.twig'
+  path: >-
+    src/_patterns/02-components/bolt-smooth-scroll/demo/-smooth-scroll-xl.demo.twig
+  namespace: '@bolt/-smooth-scroll-xl.demo.twig'
 speaker:
   filename: _speaker.twig
   path: src/_patterns/02-components/bolt-device-viewer/src/parts/_speaker.twig

--- a/src/_patterns/02-components/bolt-smooth-scroll/demo/-smooth-scroll-xl.demo.twig
+++ b/src/_patterns/02-components/bolt-smooth-scroll/demo/-smooth-scroll-xl.demo.twig
@@ -1,0 +1,9 @@
+{% extends "@bolt/theme-demo.twig" %}
+{% block demo_content %}
+    <a class="test" href="#anchor-1">Link 1</a>
+    <a href="#anchor-2">Link 2</a>
+    <div style="background-color: lightgrey; height: 3500px;"></div>
+    <div id="anchor-1">Anchor 1</div>
+    <div style="background-color: lightgrey; height: 3500px;"></div>
+    <div id="anchor-2">Anchor 2</div>
+{% endblock %}


### PR DESCRIPTION
This will create a new Smooth Scroll demo that is ~7500px tall. It will only be accessible via the Pattern Lab menu and won't be shown on the View All page (since the file is prefixed with `-`).