### PR TITLE
Adding Netlify deploy script that only deploys to main site on main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,7 @@ install:
 
 script:
 - npm run test
-- travis_wait npm run build #only run deploy if build is successful. Can't do `after_success` b/c if deploy fails, the build still reports success. Can't use `deploy` step b/c Travis skips that on PRs.
-# - npm run deploy
-
-after_success:
-- ./deploy.sh
+- travis_wait npm run build && npm i -g netlify-cli && npm run deploy:netlify # only run deploy if build is successful. Can't do `after_success` b/c if deploy fails, the build still reports success. Can't use `deploy` step b/c Travis skips that on PRs.
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 # - npm run deploy
 
 after_success:
-- netlify deploy -s bolt.netlify.com -t ${NETLIFY_TOKEN} -p dist
+- ./deploy.sh
 
 cache:
   apt: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+branch_name="$(git symbolic-ref HEAD 2>/dev/null)" ||
+branch_name="(unnamed branch)"     # detached HEAD
+
+branch_name=${branch_name##refs/heads/}
+
+cmd="netlify deploy --site-id bolt.netlify.com --path dist"
+
+if [[ $branch_name != 'release/0.x' ]]; then
+  echo 'Draft deploy'
+  cmd="$cmd --draft"
+else
+  echo 'Main deploy, not a draft'
+fi
+
+if [[ $NETLIFY_TOKEN ]]; then
+  cmd="$cmd --access-token $NETLIFY_TOKEN"
+fi
+
+echo 'Begin deploying to Netlify..'
+$cmd

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mocha:build-tools": "mocha ./build-tools/**/tests/*.test.js",
     "mocha:settings": "mocha **/settings-*/tests/*.test.js",
     "deploy": "node build-tools/gulp-tasks/build-slack/index.js",
-    "deploy:netlify": "netlify deploy -s bolt.netlify.com -p dist",
+    "deploy:netlify": "./deploy.sh",
     "publish": "lerna publish",
     "publish:canary": "lerna publish --canary --npm-tag=next",
     "start": "gulp",


### PR DESCRIPTION
The old behavior deployed to http://bolt.netlify.com from every latest commit and branch. This changes it to only to deploy to that when on the main branch, `release/0.x` and deploy to draft sites on other branches which create URLs like http://5a6795abdf995365a3315400.bolt.netlify.com