### PR TITLE
Update hack for IE11 button colors to work with button refactoring

### DIFF
--- a/packages/components/button/src/button.scss
+++ b/packages/components/button/src/button.scss
@@ -340,7 +340,8 @@ bolt-button {
 
 
 
-._c-bolt-button--theme-override {
+// Allow forcing light and xlight theme colors in IE11 until http://vjira2:8080/browse/BK-48 is resolved.
+._c-bolt-button--theme-override .c-bolt-button {
   .t-bolt-xlight &,
   .t-bolt-light & {
     $fallback-background-default: bolt-color(indigo, light);


### PR DESCRIPTION
Most component updates aren't being ported over to 1.x one at a time.  This seems like it should be an exception though because Salem has done a lot of net new work on the button in 1.x.

Merge this only if #388 is accepted.