### PR TITLE
Resizing images when prod

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -51,6 +51,7 @@
     "pretty-ms": "^3.1.0",
     "sass-loader": "^6.0.6",
     "semver": "^5.4.1",
+    "sharp": "^0.19.0",
     "style-loader": "^0.19.1",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0",


### PR DESCRIPTION
OK, so `sharp` is awesome! This PR will resize the images when it's a production build. I opened all the files it resized and ran it through my own copy of ImageOptim and got an average savings of 3.5%, so it's looking like it's doing some nice minification for us.

What do we do when an image is smaller than the size we are resizing to? So when the original is 700px wide, and we're dealing with the 1024px size step. Do we not make it? Do we make a 700px wide image with a `-1024` filename suffix?

Also: this sets the ground for removing the need for people to install ImageMagick!