### PR TITLE
Hotfix: Conditionally Inline Encapsulated CSS

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -131,10 +131,10 @@ plugins:
           - src/_patterns/03-templates/default
           - src/_patterns/04-pages/bolt-homepage
           - src/_patterns/04-pages/bolt-theming-qa
+          - src/_patterns/04-pages
           - src/_patterns/04-pages/d8-homepage
           - src/_patterns/04-pages/d8-product-landing
           - src/_patterns/04-pages/d8-resource-details
-          - src/_patterns/04-pages
     roots: {}
 ishMinimum: '240'
 ishMaximum: '2600'

--- a/packages/bolt/bolt-wwwd8.js
+++ b/packages/bolt/bolt-wwwd8.js
@@ -8,7 +8,7 @@
 import { polyfillLoader } from '@bolt/core';
 
 polyfillLoader.then(res => {
-  // import(/* webpackMode: 'eager', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
+  import(/* webpackMode: 'eager', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
 
   import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-device-viewer' */ '@bolt/components-device-viewer/src/device-viewer.standalone');
 

--- a/packages/bolt/bolt.js
+++ b/packages/bolt/bolt.js
@@ -3,7 +3,7 @@
 import { polyfillLoader } from '@bolt/core';
 
 polyfillLoader.then(res => {
-  // import(/* webpackMode: 'eager', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
+  import(/* webpackMode: 'eager', webpackChunkName: 'bolt-ratio-object' */ '@bolt/objects-ratio/src/ratio.standalone');
 
   import(/* webpackMode: 'lazy', webpackChunkName: 'bolt-device-viewer' */ '@bolt/components-device-viewer/src/device-viewer.standalone');
 

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
@@ -6,7 +6,8 @@ import {
   withComponent,
   withPreact,
   css,
-  spacingSizes
+  spacingSizes,
+  hasNativeShadowDomSupport
 } from '@bolt/core';
 
 
@@ -23,9 +24,8 @@ export class BoltRatio extends withComponent(withPreact()) {
 
   constructor(element){
     super(element);
-    if (!this.shadowRoot) {
-      this.attachShadow({ mode: 'open' });
-    }
+    this.useShadow = hasNativeShadowDomSupport;
+
     this.supportsCSSVars = window.CSS && CSS.supports('color', 'var(--primary)');
   }
 
@@ -61,18 +61,32 @@ export class BoltRatio extends withComponent(withPreact()) {
 
   // Called when props have been set regardless of if they've changed. - recalculates ratio if props updated
 
+  renderer(root, html) {
+    if (this.useShadow) {
+      super.renderer(root, html);
+    } else {
+      root.innerHTML = `<div class="o-bolt-ratio__inner">${this.innerHTML}</div>`;
+    }
+  }
+
   // Render out component via Preact
   render() {
     const classes = css(
       'o-bolt-ratio__inner'
     );
 
-    return (
-      <div className={classes}>
-        <style>{styles[0][1]}</style>
-        <slot />
-      </div>
-    )
+    if (this.useShadow) {
+      return (
+        <div className={classes}>
+          {this.useShadow &&
+            <style>
+              {styles[0][1]}
+            </style>
+          }
+          <slot />
+        </div>
+      )
+    }
   }
 
   /** Idea for wiring up ShadyCSS + Preact inspired by https://github.com/daKmoR/lit-html-demos/blob/master/demo/wc02.html **/

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.twig
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.twig
@@ -15,9 +15,8 @@
 
   {# pre-render custom property values before the JS kicks in #}
   {% set attributes = attributes.setAttribute("style", [
-    "--aspect-ratio-height: " ~ 0 ~ ";",
-    "--aspect-ratio-width: " ~ 0 ~ ";",
-    "padding-bottom: " ~ (aspectRatioHeight / aspectRatioWidth * 100) ~ "%;",
+    "--aspect-ratio-height: " ~ aspectRatioHeight ~ ";",
+    "--aspect-ratio-width: " ~ aspectRatioWidth ~ ";"
   ]) %}
 {% endif %}
 

--- a/src/_patterns/02-components/bolt-band/src/band.standalone.js
+++ b/src/_patterns/02-components/bolt-band/src/band.standalone.js
@@ -31,6 +31,7 @@ export class BoltBand extends withComponent(withPreact()) {
 
   constructor(element) {
     super(element);
+    this.useShadow = hasNativeShadowDomSupport;
 
     this.state = {
       ready: false
@@ -214,7 +215,7 @@ export class BoltBand extends withComponent(withPreact()) {
   }
 
   renderer(root, html) {
-    if (hasNativeShadowDomSupport) {
+    if (this.useShadow) {
       super.renderer(root, html);
     } else {
       root.innerHTML = this.innerHTML;
@@ -222,7 +223,7 @@ export class BoltBand extends withComponent(withPreact()) {
   }
 
   render() {
-    if (hasNativeShadowDomSupport){
+    if (this.useShadow){
       return (
         <slot />
       )

--- a/src/_patterns/02-components/bolt-button/src/button.standalone.js
+++ b/src/_patterns/02-components/bolt-button/src/button.standalone.js
@@ -12,7 +12,7 @@ import {
 } from '@bolt/core';
 
 import styles from './button.scss';
-import spacingUtils from '@bolt/utilities-spacing/_utilities.spacing.scss';
+// import spacingUtils from '@bolt/utilities-spacing/_utilities.spacing.scss';
 
 @define
 export class BoltButton extends withComponent(withPreact()) {

--- a/src/_patterns/02-components/bolt-button/src/button.standalone.js
+++ b/src/_patterns/02-components/bolt-button/src/button.standalone.js
@@ -114,15 +114,17 @@ export class BoltButton extends withComponent(withPreact()) {
       buttonText = <span className="c-bolt-button__inner" dangerouslySetInnerHTML={{ __html: this.fallbackText }} />
     }
 
-
     return (
       <div className={classes}>
-        <style>
-          {styles[0][1]}
-          {spacingUtils[0][1]}
-        </style>
+        {this.useShadow &&
+          <style>
+            {styles[0][1]}
+          </style>
+        }
         { buttonText }
       </div>
     )
   }
 }
+
+

--- a/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.standalone.js
+++ b/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.standalone.js
@@ -7,7 +7,8 @@ import {
   withComponent,
   withPreact,
   css,
-  spacingSizes
+  spacingSizes,
+  hasNativeShadowDomSupport
 } from '@bolt/core';
 
 
@@ -40,8 +41,13 @@ class BoltDeviceViewer extends withComponent(withPreact()) {
     // name: props.string,
   }
 
+  constructor(element) {
+    super(element);
+    this.useShadow = hasNativeShadowDomSupport;
+  }
+
   render({ props }) {
-    if (hasNativeShadowDomSupport){
+    if (this.useShadow){
       const classes = css(
         'c-bolt-image-magnifier'
       );
@@ -55,7 +61,7 @@ class BoltDeviceViewer extends withComponent(withPreact()) {
   }
 
   renderer(root, html) {
-    if (!hasNativeShadowDomSupport) {
+    if (!this.useShadow) {
       root.innerHTML = `<div class="c-bolt-image-magnifier">${this.innerHTML}</div>`;
     }
   }
@@ -128,11 +134,20 @@ class BoltImageZoom extends withComponent(withPreact()) {
     }
   }
 
+  renderer(root, html) {
+    if (this.useShadow) {
+      super.renderer(root, html);
+    } else {
+      root.innerHTML = this.innerHTML;
+    }
+  }
 
   render() {
-    return (
-      <slot />
-    )
+    if (this.useShadow) {
+      return (
+        <slot />
+      )
+    }
   }
 
   connectedCallback() {

--- a/src/_patterns/02-components/bolt-icon/src/icon.standalone.js
+++ b/src/_patterns/02-components/bolt-icon/src/icon.standalone.js
@@ -6,7 +6,8 @@ import {
   withComponent,
   withPreact,
   css,
-  spacingSizes
+  spacingSizes,
+  hasNativeShadowDomSupport
 } from '@bolt/core';
 
 import upperCamelCase from 'uppercamelcase';
@@ -35,6 +36,11 @@ export class BoltIcon extends withComponent(withPreact()) {
     color: props.string
   }
 
+  constructor(element){
+    super(element);
+    this.useShadow = hasNativeShadowDomSupport;
+  }
+
   render({ props }) {
     const classes = css(
       'c-bolt-icon',
@@ -59,7 +65,9 @@ export class BoltIcon extends withComponent(withPreact()) {
 
     return (
       <div className={classes}>
-        <style>{styles[0][1]}</style>
+        {this.useShadow &&
+          <style>{styles[0][1]}</style>
+        }
         <IconTag className={iconClasses} size={size} />
         {props.background && props.size == "xlarge" &&
           <span class={backgroundClasses}></span>

--- a/src/_patterns/02-components/bolt-image/src/image.js
+++ b/src/_patterns/02-components/bolt-image/src/image.js
@@ -8,6 +8,5 @@ Object.assign(lazySizes.cfg, {
   lazyClass: 'js-lazyload',
   loadingClass: 'is-lazyloading',
   loadedClass: 'is-lazyloaded',
-  preloadAfterLoad: false,
-  ricTimeout: 50
+  preloadAfterLoad: true
 });

--- a/src/_patterns/02-components/bolt-nav-bar/src/nav-bar.standalone.js
+++ b/src/_patterns/02-components/bolt-nav-bar/src/nav-bar.standalone.js
@@ -19,6 +19,7 @@ class BoltNavList extends withComponent(withPreact()) {
   constructor(element) {
     super(element);
     this.activeLink = false;
+    this.useShadow = hasNativeShadowDomSupport;
 
     // Ensure that 'this' inside the _onWindowResize event handler refers to <bolt-nav-link>
     // even if the handler is attached to another element (window in this case)

--- a/src/_patterns/04-pages/button-perf-test.twig
+++ b/src/_patterns/04-pages/button-perf-test.twig
@@ -1,0 +1,13 @@
+{% extends "@bolt/default-template.twig" %}
+
+{% block global_header %}{% endblock %}
+
+{% block main_content %}
+  {% for i in 0..200 %}
+    {% include "@bolt/button.twig" with {
+      text: "Call to Action " ~ i,
+      url: "www.google.com",
+      style: "secondary"
+    } only %}
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Updating a handful of components to now conditionally bundle CSS if Shadow Dom is supported natively (which, incidentally, helps with performance when doing this sort of thing) in addition to omitting the spacing utility in the button component due to the extremely large file size currently (a known issue which needs to get refactored);

These in combination addres most if not all of the lingering IE 11 performance issues while retaining Custom Element functionality.

Also adding in a button performance test example w/ 200 web components on a page which, in IE 11, performs even better than expected: https://5a73ce9a7b6ee845ca711085--bolt-design-system.netlify.com/patterns/04-pages-button-perf-test/04-pages-button-perf-test.html