### PR TITLE
Fix for css class names with escaped characters

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -97,36 +97,37 @@ function createConfig(config) {
   }
 
 
-  // @todo Remove workaround for getting classes with `\@` to compile correctly
+  // This workaround has been disabled for now as setting `modules: false` on `css-loader` fixes it; see https://github.com/bolt-design-system/bolt/pull/410
+  // Workaround for getting classes with `\@` to compile correctly
   // CSS Classes like `.u-hide\@large` were getting compiled like `.u-hide-large`.
   // Due to this bug: https://github.com/webpack-contrib/css-loader/issues/578
   // Workaround: using the `string-replace-loader` to change `\@` to our `workaroundAtValue` before passing to `css-loader`, then turning it back afterwards.
-  const workaroundAtValue = '-theAtSymbol-';
+  // const workaroundAtValue = '-theAtSymbol-';
 
   const scssLoaders = [
-    {
-      loader: 'string-replace-loader',
-      query: {
-        search: workaroundAtValue,
-        replace: String.raw`\\@`, // needed to ensure `\` comes through
-      },
-    },
+//     {
+//       loader: 'string-replace-loader',
+//       query: {
+//         search: workaroundAtValue,
+//         replace: String.raw`\\@`, // needed to ensure `\` comes through
+//       },
+//     },
     {
       loader: 'css-loader',
       options: {
         sourceMap: true,
-        modules: true,
+        modules: false,
         importLoaders: true,
         localIdentName: '[local]'
       }
     },
-    {
-      loader: 'string-replace-loader',
-      query: {
-        search: '\\@',
-        replace: workaroundAtValue,
-      },
-    },
+//     {
+//       loader: 'string-replace-loader',
+//       query: {
+//         search: '\\@',
+//         replace: workaroundAtValue,
+//       },
+//     },
     {
       loader: "postcss-loader",
       options: {

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -123,7 +123,7 @@ function createConfig(config) {
     {
       loader: 'string-replace-loader',
       query: {
-        search: '\@',
+        search: '\\@',
         replace: workaroundAtValue,
       },
     },

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -97,7 +97,20 @@ function createConfig(config) {
   }
 
 
+  // @todo Remove workaround for getting classes with `\@` to compile correctly
+  // CSS Classes like `.u-hide\@large` were getting compiled like `.u-hide-large`.
+  // Due to this bug: https://github.com/webpack-contrib/css-loader/issues/578
+  // Workaround: using the `string-replace-loader` to change `\@` to our `workaroundAtValue` before passing to `css-loader`, then turning it back afterwards.
+  const workaroundAtValue = '-theAtSymbol-';
+
   const scssLoaders = [
+    {
+      loader: 'string-replace-loader',
+      query: {
+        search: workaroundAtValue,
+        replace: String.raw`\\@`, // needed to ensure `\` comes through
+      },
+    },
     {
       loader: 'css-loader',
       options: {
@@ -106,6 +119,13 @@ function createConfig(config) {
         importLoaders: true,
         localIdentName: '[local]'
       }
+    },
+    {
+      loader: 'string-replace-loader',
+      query: {
+        search: '\@',
+        replace: workaroundAtValue,
+      },
     },
     {
       loader: "postcss-loader",

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -54,6 +54,7 @@
     "sass-loader": "^6.0.6",
     "semver": "^5.4.1",
     "sharp": "^0.19.0",
+    "string-replace-loader": "^1.3.0",
     "style-loader": "^0.19.1",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0",


### PR DESCRIPTION
OK, this should fix the situation where css classes like `.u-hide\@large` get turned into `.u-hide-large` until [the bug in `css-loader`](https://github.com/webpack-contrib/css-loader/issues/578) can get fixed. /cc @sghoweri 

Jake, can you check to see if this fixes the issue, then merge if it does?