### PR TITLE
Add simplified card pattern (BK-200)

### DIFF
--- a/src/_patterns/02-components/bolt-card/src/card-simple.twig
+++ b/src/_patterns/02-components/bolt-card/src/card-simple.twig
@@ -1,0 +1,15 @@
+{#
+  'Simple Card' provides only the card background and a single, flexible card_content variable for content.
+  Prefer this pattern unless you need more fine-grained control.
+#}
+
+{% extends "@bolt/card.twig" %}
+
+{% set theme = theme|default("light") %}
+
+{% block card_media %}{% endblock %}
+{% block card_footer %}{% endblock %}
+
+{% block card_body %}
+  {{ card_content }}
+{% endblock %}


### PR DESCRIPTION
This is a pattern @sghoweri and I discussed a week or two ago.  It allows using card just for the background.

I don't think this is an ideal solution (for example, it's a little confusing in the context of the main card pattern, which potentially should have been named "teaser card" instead.  We also probably don't want consumers to override the `card_media` or `card_footer` blocks when using it, but they could).  The main advantage is it's fully backwards compatible and hopefully simple enough to layer on too much additional complexity to the overall card pattern.