### PR TITLE
Bolt Data

### DIFF
--- a/apps/pattern-lab--workshop/composer.json
+++ b/apps/pattern-lab--workshop/composer.json
@@ -44,10 +44,6 @@
       },
       {
         "type": "vcs",
-        "url": "https://github.com/pattern-lab/drupal-twig-extensions"
-      },
-      {
-        "type": "vcs",
         "url": "https://github.com/drupal-pattern-lab/styleguidekit-twig-default",
         "no-api": true
       }
@@ -60,7 +56,7 @@
       "cweagans/composer-patches": "~1.0",
       "pattern-lab/core": "^2.8.10",
       "pattern-lab/drupal-twig-extensions": "^0.2.0",
-      "pattern-lab/patternengine-twig": "^2.2.0",
+      "pattern-lab/patternengine-twig": "^2.2.2",
       "pattern-lab/styleguidekit-twig-default": "^3.0.0",
       "pattern-lab/styleguidekit-assets-default": "*",
       "evanlovely/plugin-twig-namespaces": "dev-master",

--- a/apps/pattern-lab--workshop/config/config.yml
+++ b/apps/pattern-lab--workshop/config/config.yml
@@ -71,4 +71,4 @@ extensions:
 plugins:
   twigNamespaces:
     enabled: true
-    readFromFile: www/build/data/bolt-twig-namespaces.json
+    readFromFile: www/build/data/twig-namespaces.bolt.json

--- a/apps/pattern-lab--workshop/src/_data/data.json
+++ b/apps/pattern-lab--workshop/src/_data/data.json
@@ -1,5 +1,3 @@
 {
-  "bolt": {
-    "version": "1.0.0-alpha"
-  }
+
 }

--- a/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/color-palette/01-brand-colors.twig
+++ b/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/color-palette/01-brand-colors.twig
@@ -1,7 +1,5 @@
-{% set bolt_brand_colors = get_data('@bolt-assets/bolt-brand-colors.data.json').boltBrandColors %}
-
 <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--small">
-  {% for colorName, palette in bolt_brand_colors %}
+  {% for colorName, palette in bolt.data.colors.brand %}
     {% include "@bolt/_color-swatch.twig" with {
       color_swatch: {
         colorName: colorName,

--- a/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/color-palette/02-status-colors.twig
+++ b/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/color-palette/02-status-colors.twig
@@ -1,7 +1,5 @@
-{% set bolt_status_colors = get_data('@bolt-assets/bolt-status-colors.data.json').boltStatusColors %}
-
 <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--small">
-  {% for colorName, palette in bolt_status_colors %}
+  {% for colorName, palette in bolt.data.colors.status %}
     {% include "@bolt/_color-swatch.twig" with {
       color_swatch: {
         colorName: colorName,

--- a/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/color-palette/03-accessibility-check.twig
+++ b/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/color-palette/03-accessibility-check.twig
@@ -1,7 +1,5 @@
-{% set bolt_colors = get_data('@bolt-assets/bolt-all-colors.data.json').boltAllColors %}
-
 <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix">
-  {% for colorName, palette in bolt_colors %}
+  {% for colorName, palette in bolt.data.colors.all %}
     <div class="o-bolt-grid__cell u-bolt-width-1/3">
 
       <bolt-swatch class="c-bolt-swatch">

--- a/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/spacing/spacing.twig
+++ b/apps/pattern-lab--workshop/src/_patterns/01-visual-styles/spacing/spacing.twig
@@ -1,0 +1,15 @@
+{# @todo Cleanup this demo and make it look pretty. Add code docs for how to use it in Sass. #}
+<p>Spacing Scale Sequence</p>
+{# Mainly just a demo for how to access the global `bolt` data from inside the custom Twig function `getSpacingScaleSequence()`. #}
+{% for i in getSpacingScaleSequence() %}
+  <span>{{ i }}</span>
+{% endfor %}
+
+<hr>
+
+<p>Spacing Sizes</p>
+{% for key, value in bolt.data.spacing.sizes %}
+  <div>{{ key }}</div>
+  <div style="width: {{ value }}; height: {{ value }}; border: solid 1px black; margin-bottom: 5px;"></div>
+{% endfor %}
+

--- a/packages/build-tools/utils/manifest.js
+++ b/packages/build-tools/utils/manifest.js
@@ -101,7 +101,13 @@ async function writeTwigNamespaceFile(relativeFrom, extraNamespaces = {}) {
         config.srcDir,
         ...allDirs,
       ],
-    }
+    },
+    'bolt-data': {
+      recursive: true,
+      paths: [
+        config.dataDir,
+      ],
+    },
   }, namespaces, extraNamespaces);
 
   await writeFile(

--- a/packages/build-tools/utils/manifest.js
+++ b/packages/build-tools/utils/manifest.js
@@ -57,7 +57,7 @@ function getAllDirs(relativeFrom) {
 }
 
 async function writeBoltManifest() {
-  const filePath = path.resolve(config.dataDir, './bolt-full-manifest.json');
+  const filePath = path.resolve(config.dataDir, './full-manifest.bolt.json');
   try {
     await writeFile(filePath, JSON.stringify(boltManifest, null, '  '));
   } catch(error) {
@@ -111,7 +111,7 @@ async function writeTwigNamespaceFile(relativeFrom, extraNamespaces = {}) {
   }, namespaces, extraNamespaces);
 
   await writeFile(
-    path.join(config.dataDir, 'bolt-twig-namespaces.json'),
+    path.join(config.dataDir, 'twig-namespaces.bolt.json'),
     JSON.stringify(namespaceConfigFile, null, '  ')
   );
 }

--- a/packages/core-php/composer.json
+++ b/packages/core-php/composer.json
@@ -20,6 +20,8 @@
   "require": {
     "twig/twig": "^1.0",
     "basaltinc/twig-tools": "^1.1.1",
-    "michelf/php-markdown": "^1.8.0"
+    "michelf/php-markdown": "^1.8.0",
+    "webmozart/path-util": "^2.3",
+    "shudrum/array-finder": "^1.1"
   }
 }

--- a/packages/core-php/src/TwigExtensions/BoltCore.php
+++ b/packages/core-php/src/TwigExtensions/BoltCore.php
@@ -3,11 +3,71 @@
 namespace Bolt\TwigExtensions;
 
 use Bolt;
-use Twig_Extension;
-use Twig_ExtensionInterface;
 use BasaltInc\TwigTools;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+use \Webmozart\PathUtil\Path; // https://github.com/webmozart/path-util
+use \Shudrum\Component\ArrayFinder\ArrayFinder; // https://github.com/Shudrum/ArrayFinder
 
-class BoltCore extends Twig_Extension implements Twig_ExtensionInterface {
+
+class BoltCore extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface {
+
+  public $data = [];
+
+  function initRuntime(\Twig_Environment $env) {
+    $fullManifestPath = TwigTools\Utils::resolveTwigPath($env, '@bolt-data/full-manifest.bolt.json');
+    $dataDir = dirname($fullManifestPath);
+    $this->data = self::buildBoltData($dataDir);
+  }
+
+  /**
+   * @param $dataDir {string} - Path to data directory
+   * @return {array} - All json files in data parsed as a single data array
+   */
+  function buildBoltData($dataDir) {
+    // Looping through all the files in the data dir, we'll get ones that end in `bolt.json` like `my-stuff.bolt.json`
+    // We're building up a big data array that will look like this:
+    //  'data' => [
+    //    'spacingSizes' => // contents of `spacing-sizes.bolt.json`
+    //    'colors' => [
+    //      'brand' => // contents of `colors/brand.bolt.json`
+    //      'status' => // contents of `colors/status.bolt.json`
+    //    ]
+    //  ]
+    $data = new ArrayFinder();
+    $data->changeSeparator('/');
+    $items = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dataDir), RecursiveIteratorIterator::SELF_FIRST);
+    foreach ($items as $key => $item) {
+      if ($item->isFile() && $item->getExtension() === 'json') {
+        $fullPath = $item->getPathname();
+        // `colors/my-stuff.bolt.json` => `my-stuff.bolt`
+        $extensionLessFilename = Path::getFilenameWithoutExtension($fullPath);
+        if (Path::hasExtension($extensionLessFilename, 'bolt')) {
+          // if file is `colors/my-stuff.bolt.json`, this becomes `myStuff` (which is the key we'll store it's data under)
+          $dataKey = Bolt\Utils::dashesToCamelCase(Path::getFilenameWithoutExtension($extensionLessFilename, 'bolt'));
+          $fileString = file_get_contents($fullPath);
+          $fileData = json_decode($fileString, true);
+          $relativePath = Path::makeRelative($fullPath, $dataDir);
+          // if file is `colors/my-stuff.bolt.json`, this is `colors`, if file is `my-stuff.bolt.json`, this is `.`
+          $subDir = dirname($relativePath);
+          if ($subDir === '.') {// not nested in sub directory
+            $data->set($dataKey, $fileData);
+          } else {// nested in sub directory
+            $data->set($subDir . '/' . $dataKey, $fileData);
+          }
+        }
+      }
+    }
+    return $data->get();
+  }
+
+  public function getGlobals() {
+    return [
+      'bolt' => [
+        'data' => $this->data,
+      ],
+    ];
+  }
 
   public function getFunctions() {
     return [

--- a/packages/core-php/src/TwigExtensions/BoltExtras.php
+++ b/packages/core-php/src/TwigExtensions/BoltExtras.php
@@ -13,6 +13,7 @@ class BoltExtras extends Twig_Extension implements Twig_ExtensionInterface {
     return [
       TwigTools\TwigFunctions::console_log(),
       Bolt\TwigFunctions::deep_merge(),
+      Bolt\TwigFunctions::getSpacingScaleSequence(),
     ];
   }
 

--- a/packages/core-php/src/TwigFunctions.php
+++ b/packages/core-php/src/TwigFunctions.php
@@ -14,4 +14,16 @@ class TwigFunctions {
     });
   }
 
+  public static function getSpacingScaleSequence() {
+    return new Twig_SimpleFunction('getSpacingScaleSequence', function($context) {
+      // Mainly just a demo for how to access the global `bolt` data.
+      $data = $context['bolt']['data']['spacing']['scale'];
+      $scaleValues = array_values($data);
+      sort($scaleValues);
+      return $scaleValues;
+    }, [
+      'needs_context' => true,
+    ]);
+  }
+
 }

--- a/packages/core-php/src/Utils.php
+++ b/packages/core-php/src/Utils.php
@@ -6,8 +6,23 @@ use Michelf\MarkdownExtra;
 
 class Utils {
 
+  /**
+   * Markdown to HTML
+   * @param $string - String of Markdown
+   * @return string - HTML from Markdown
+   */
   public static function convertMarkdown($string) {
     return MarkdownExtra::defaultTransform($string);
+  }
+
+  /**
+   * Dashes to camelCase string converter
+   * @param $string - Takes something like `my-cool-string`
+   * @return string - Returns `myCoolString`
+   */
+  public static function dashesToCamelCase($string) {
+    $str = str_replace('-', '', ucwords($string, '-'));
+    return lcfirst($str);
   }
 
 }

--- a/packages/core/styles/01-settings/settings-colors/_settings-colors.scss
+++ b/packages/core/styles/01-settings/settings-colors/_settings-colors.scss
@@ -138,6 +138,7 @@ $bolt-status-colors: (
 
 $bolt-colors: map-merge($bolt-brand-colors, $bolt-status-colors);
 
-@include export-data('colors/bolt-all-colors.data.json', ('boltAllColors': $bolt-colors));
-@include export-data('colors/bolt-status-colors.data.json', ('boltStatusColors': $bolt-status-colors));
-@include export-data('colors/bolt-brand-colors.data.json', ('boltBrandColors': $bolt-brand-colors));
+@include export-data('colors/all.bolt.json', $bolt-colors);
+@include export-data('colors/status.bolt.json', $bolt-status-colors);
+@include export-data('colors/brand.bolt.json', $bolt-brand-colors);
+

--- a/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
+++ b/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
@@ -25,7 +25,7 @@ $bolt-spacing-values: (
   'xlarge':  4,
   'xxlarge': 8
 );
-@include export-data('spacing/bolt-spacing-scale.data.json', (boltSpacingScale: $bolt-spacing-values));
+@include export-data('spacing/scale.bolt.json', $bolt-spacing-values);
 
 $bolt-spacing-sizes: ();
 

--- a/packages/core/styles/02-tools/tools-spacing/_tools-spacing.scss
+++ b/packages/core/styles/02-tools/tools-spacing/_tools-spacing.scss
@@ -14,7 +14,7 @@
   @return $map;
 }
 $bolt-spacing-sizes: _bolt-create-spacing-map($bolt-spacing-values);
-@include export-data('spacing/bolt-spacing-sizes.data.json', (boltSpacingSizes: $bolt-spacing-sizes));
+@include export-data('spacing/sizes.bolt.json', $bolt-spacing-sizes);
 
 
 // $bolt-spacing-sizes-js: ();


### PR DESCRIPTION
This takes all the JSON data files we compile to the `config.dataDir` (i.e. `./www/build/data/`) and turns them into a big global data object under `bolt.data` and can be accessed from in Twig & PHP. Feel free to inspect by placing `{{ console_log(bolt) }}` in any Twig file. Files in folders get nested inside that folder and the filenames turn to keys after being camelCased (so we can do `bolt.data.myThing` instead of `bolt.data['my-thing']`)

```php
'bolt' => [
  'data' => [
    'spacingSizes' => // contents of `spacing-sizes.bolt.json`
    'colors' => [
      'brand' => // contents of `colors/brand.bolt.json`
      'status' => // contents of `colors/status.bolt.json`
    ]
  ]
]
```

Super excited about this!!

I've changed the colors around to use the new method. I've also made a new custom Twig function that I expect we will delete just to demo how Twig functions can get access to the data as well. The spacing demo page is also very basic, but I just wanted to show off how this could all get used. 