### PR TITLE
Adding Markdown Embed Util

### DIFF
--- a/apps/pattern-lab--workshop/src/_includes/utils/md-embed.twig
+++ b/apps/pattern-lab--workshop/src/_includes/utils/md-embed.twig
@@ -1,0 +1,7 @@
+{# `file` - path to markdown content, like `@bolt-footer/readme.md` #}
+<div class="c-bolt-md-embed">
+  <a href="{{ github_url(file) }}" class="c-bolt-md-embed__edit" target="_blank">Edit this on GitHub</a>
+  <div class="c-bolt-md-embed__content">
+    {{ source(file) | markdown }}
+  </div>
+</div>

--- a/packages/core-php/src/TwigExtensions/BoltExtras.php
+++ b/packages/core-php/src/TwigExtensions/BoltExtras.php
@@ -17,6 +17,7 @@ class BoltExtras extends Twig_Extension implements Twig_ExtensionInterface {
       Bolt\TwigFunctions::create_attribute(),
       Bolt\TwigFunctions::link(),
       Bolt\TwigFunctions::getSpacingScaleSequence(),
+      Bolt\TwigFunctions::github_url(),
     ];
   }
 

--- a/packages/core-php/src/TwigFunctions.php
+++ b/packages/core-php/src/TwigFunctions.php
@@ -2,8 +2,10 @@
 
 namespace Bolt;
 
+use Bolt;
 use \Twig_SimpleFunction;
 use \Drupal\Core\Template\Attribute;
+use \BasaltInc\TwigTools;
 
 class TwigFunctions {
 
@@ -162,6 +164,15 @@ class TwigFunctions {
       return is_array($attributes) ? new Attribute($attributes) : $attributes;
       // print_r(Attribute);
     });
+  }
+
+  public static function github_url() {
+    return new Twig_SimpleFunction('github_url', function(\Twig_Environment $env, $twigPath) {
+      $filePath = TwigTools\Utils::resolveTwigPath($env, $twigPath);
+      return Utils::gitHubUrl($filePath);
+    }, [
+      'needs_environment' => true,
+    ]);
   }
 
 }

--- a/packages/core-php/src/Utils.php
+++ b/packages/core-php/src/Utils.php
@@ -3,8 +3,11 @@
 namespace Bolt;
 
 use Michelf\MarkdownExtra;
+use \Webmozart\PathUtil\Path;
 
 class Utils {
+
+  const repoRoot = __DIR__ . '/../../../';
 
   /**
    * Markdown to HTML
@@ -34,6 +37,18 @@ class Utils {
   public static function dashesToCamelCase($string) {
     $str = str_replace('-', '', ucwords($string, '-'));
     return lcfirst($str);
+  }
+
+  /**
+   * Get path to file on GitHub
+   * @param string $filePath - Absolute path to a file in repo
+   * @return string - URL to file on GitHub
+   */
+  public static function gitHubUrl($filePath) {
+    $relFilePath = Path::makeRelative($filePath, self::repoRoot);
+    $repoBranchName = 'epic/refactor'; // @todo Change branch name to `master`
+    $githubPath = Path::join('https://github.com/bolt-design-system/bolt/blob/', $repoBranchName, $relFilePath);
+    return $githubPath;
   }
 
 }


### PR DESCRIPTION
Adding `md-embed.twig` util for embedding Markdown and linking to GitHub for edits. This let's one do this:

```twig
{% include '@utils/md-embed.twig' with {
  file: 'path/to/doc.md',
} %}

{% include '@utils/md-embed.twig' with {
  file: '@bolt-thing/README.md',
} %}
```

And it will render the markdown **and** put in a link to "Edit this on GitHub". I've got some logic in there to find out where it is in the repo and so it can link to it. This will help a lot by getting rid of [this approach in `docs.twig`](https://github.com/bolt-design-system/bolt/blob/epic/refactor/apps/pattern-lab--workshop/src/_includes/utils/docs.twig#L18-L20)

Not quite ready to merge yet, let's do this first:

- [ ] Get approval on approach from @sghoweri 
- [ ] Change around all the demo docs that manually use the path to the readme
- [ ] Ensure @joekarasek and @rockymountainhigh1943 are aware of new approach