### PR TITLE
Adding solo commands for PL and WebPack

### DIFF
--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -11,7 +11,7 @@ program
 
 // We need to initialize config as early as possible
 const configFilePath = path.resolve(process.cwd(), program.configFile || '.boltrc');
-configStore.init(require(configFilePath));
+const config = configStore.init(require(configFilePath));
 // Now that config is initilized, we can start requiring other things
 
 const { buildBoltManifest } = require('./utils/manifest');
@@ -119,6 +119,26 @@ program
     updateConfig(options, program);
     require('./tasks/task-collections').images();
   });
+
+program
+  .command('webpack')
+  .alias('wp')
+  .description('WebPack Compile')
+  .action((options) => {
+    updateConfig(options, program);
+    require('./tasks/webpack-tasks').compile();
+  });
+
+if (config.env === 'pl'){
+  program
+    .command('pattern-lab')
+    .alias('pl')
+    .description('Pattern Lab Compile')
+    .action((options) => {
+      updateConfig(options, program);
+      require('./tasks/pattern-lab-tasks').compile();
+    });
+}
 
 // This will tell you all that got `require()`-ed
 // We want to only load what we need - that's why not all `require` statements are at top

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -120,13 +120,18 @@ program
     require('./tasks/task-collections').images();
   });
 
+
 program
   .command('webpack')
   .alias('wp')
   .description('WebPack Compile')
-  .action((options) => {
+  .action(async (options) => {
     updateConfig(options, program);
-    require('./tasks/webpack-tasks').compile();
+    try {
+      await require('./tasks/webpack-tasks').compile();
+    } catch (error) {
+      log.errorAndExit('WebPack failed', error);
+    }
   });
 
 if (config.env === 'pl'){
@@ -134,9 +139,13 @@ if (config.env === 'pl'){
     .command('pattern-lab')
     .alias('pl')
     .description('Pattern Lab Compile')
-    .action((options) => {
+    .action(async (options) => {
       updateConfig(options, program);
-      require('./tasks/pattern-lab-tasks').compile();
+      try {
+        await require('./tasks/pattern-lab-tasks').compile();
+      } catch (error) {
+        log.errorAndExit('Pattern Lab failed', error);
+      }
     });
 }
 


### PR DESCRIPTION
This adds `bolt pattern-lab` (alias: `bolt pl`) and `bolt webpack` (alias: `bolt wp`) to the build tools.

Just a little tip for you personally Salem, run this to get a global `bolt`:

```bash
cd apps/pattern-lab--workshop/node_modules/.bin/
ln -s `pwd`/bolt /usr/local/bin
```

Now you can run `bolt` commands anywhere... and yes, if you ran that in `apps/example_drupal_theme` it'd still work and only run there. 