### PR TITLE
Re-enabling schema validation

### DIFF
--- a/packages/core-php/src/TwigExtensions/BoltCore.php
+++ b/packages/core-php/src/TwigExtensions/BoltCore.php
@@ -66,6 +66,7 @@ class BoltCore extends \Twig_Extension implements \Twig_Extension_InitRuntimeInt
       'bolt' => [
         'data' => $this->data,
       ],
+      'enable_json_schema_validation' => true,
     ];
   }
 


### PR DESCRIPTION
Schema validation only happens if `enable_json_schema_validation` is set to true; this was done in the old `_twig-components/` approach, but we forgot to migrate that over to our new approach with the Twig Extensions; so here we go. 

/cc @joekarasek @sghoweri @rockymountainhigh1943 