### PR TITLE
RFC (Request for Comment) Simplify Button + Provide More Flexibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -847,6 +847,15 @@
 			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.1.0.tgz",
 			"integrity": "sha512-7toNyVlrl7vJnY3PU0eXIK1KWq8phfnEe1IwOdCMxkIl/BfUkUB2aaVs45R0LSx1qxHRnkqj0vlGtskUvKkNkA=="
 		},
+		"JSONStream": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+			"integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+			"requires": {
+				"jsonparse": "0.0.5",
+				"through": "2.3.8"
+			}
+		},
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -3406,16 +3415,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "github:ai/browserslist#e42e4fa848d3945ce53b9c19255db555512e3268",
+			"version": "github:ai/browserslist#8026f589168e917f40f5690e37d1c63d77b08554",
 			"requires": {
-				"caniuse-lite": "1.0.30000808",
+				"caniuse-lite": "1.0.30000809",
 				"electron-to-chromium": "1.3.33"
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30000808",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz",
-					"integrity": "sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw=="
+					"version": "1.0.30000809",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000809.tgz",
+					"integrity": "sha512-tLn4flj2upmMsko3larTkQh21Vp9pylnNPUOhw5+mubL+67U5Fpm4UG5AutzGBc+gBIPSsPFHDynsiMWp5m46g=="
 				},
 				"electron-to-chromium": {
 					"version": "1.3.33",
@@ -5342,8 +5351,8 @@
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz",
 			"integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
 			"requires": {
-				"is-text-path": "1.0.1",
 				"JSONStream": "1.3.2",
+				"is-text-path": "1.0.1",
 				"lodash": "4.17.4",
 				"meow": "3.7.0",
 				"split2": "2.2.0",
@@ -5351,11 +5360,6 @@
 				"trim-off-newlines": "1.0.1"
 			},
 			"dependencies": {
-				"jsonparse": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-					"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-				},
 				"JSONStream": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -5364,6 +5368,11 @@
 						"jsonparse": "1.3.1",
 						"through": "2.3.8"
 					}
+				},
+				"jsonparse": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+					"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 				},
 				"split2": {
 					"version": "2.2.0",
@@ -10215,14 +10224,6 @@
 						}
 					}
 				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -10231,6 +10232,14 @@
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
 						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"requires": {
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -12684,6 +12693,21 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
 					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+				}
+			}
+		},
+		"hyperhtml": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/hyperhtml/-/hyperhtml-2.5.10.tgz",
+			"integrity": "sha512-YtPDrOvU9ClWL45I8Q6LL2MqItZyOzzmdOdgLXY8UzlOt9QqLwAtBlnj+Z41BWmCUblP0W80rIJrqetmGLwLVw==",
+			"requires": {
+				"lightercollective": "0.0.3"
+			},
+			"dependencies": {
+				"lightercollective": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.3.tgz",
+					"integrity": "sha512-AUIsWs96N5tESFu/XpvYJvoaGg0Qf0i5wcjMgop4OVsRNdzII+clf52/FSGeaMiZym6l34JhO6zNFunFUHV3YA=="
 				}
 			}
 		},
@@ -15526,15 +15550,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
 			"integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
-		},
-		"JSONStream": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-			"integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-			"requires": {
-				"jsonparse": "0.0.5",
-				"through": "2.3.8"
-			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -24681,6 +24696,24 @@
 				"resolve": "1.5.0"
 			}
 		},
+		"recursive-readdir": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+			"integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+			"requires": {
+				"minimatch": "3.0.3"
+			},
+			"dependencies": {
+				"minimatch": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
 		"redent": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -27393,9 +27426,9 @@
 			}
 		},
 		"snyk": {
-			"version": "1.65.3",
-			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.65.3.tgz",
-			"integrity": "sha1-RWmYKnUxcdhSiLA4kTWgrrIB5Cs=",
+			"version": "1.69.7",
+			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.69.7.tgz",
+			"integrity": "sha1-rIeaq7xCWqKot3kAqPbRwhuo0v4=",
 			"requires": {
 				"abbrev": "1.1.1",
 				"ansi-escapes": "1.4.0",
@@ -27409,6 +27442,7 @@
 				"open": "0.0.5",
 				"os-name": "1.0.3",
 				"proxy-from-env": "1.0.0",
+				"recursive-readdir": "2.2.1",
 				"semver": "5.4.1",
 				"snyk-config": "1.0.1",
 				"snyk-go-plugin": "1.4.5",
@@ -27418,11 +27452,10 @@
 				"snyk-nuget-plugin": "1.3.9",
 				"snyk-php-plugin": "1.3.2",
 				"snyk-policy": "1.10.1",
-				"snyk-python-plugin": "1.4.1",
-				"snyk-recursive-readdir": "2.0.0",
+				"snyk-python-plugin": "1.5.6",
 				"snyk-resolve": "1.0.0",
 				"snyk-resolve-deps": "1.7.0",
-				"snyk-sbt-plugin": "1.2.0",
+				"snyk-sbt-plugin": "1.2.3",
 				"snyk-tree": "1.0.0",
 				"snyk-try-require": "1.2.0",
 				"tempfile": "1.1.1",
@@ -27563,6 +27596,19 @@
 					"requires": {
 						"exit-hook": "1.1.1",
 						"onetime": "1.1.0"
+					}
+				},
+				"snyk-python-plugin": {
+					"version": "1.5.6",
+					"resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.5.6.tgz",
+					"integrity": "sha512-YHDi+tEffbqOVp66sFxEYLSIcHcr/ORkxnqulyM7m1jOqzdgb8Rq/460DyGhm09wMEEdvvgt6v+Ld+QGM8GzYw=="
+				},
+				"snyk-sbt-plugin": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.3.tgz",
+					"integrity": "sha512-R8L2+wzB7Zc8BZPmszAoQDjtl9tjLjE6Pf3Mu6tjv22+2rbyADlyfHg7FR+vmQXVFtOuJa43p1orXoaZGatE0g==",
+					"requires": {
+						"debug": "2.6.9"
 					}
 				},
 				"tempfile": {
@@ -27724,29 +27770,6 @@
 				}
 			}
 		},
-		"snyk-python-plugin": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.4.1.tgz",
-			"integrity": "sha512-+nMnZzLomG6fs4DiMWTKhuJABGFRYd3jVPpMwdovTqdLoY9uDHFH6VAZiFzjBPJQZaKz2drcakldZSVDA6uMJA=="
-		},
-		"snyk-recursive-readdir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/snyk-recursive-readdir/-/snyk-recursive-readdir-2.0.0.tgz",
-			"integrity": "sha1-XLWelGmBaeAgWmDn1qUG0LTVL/M=",
-			"requires": {
-				"minimatch": "3.0.2"
-			},
-			"dependencies": {
-				"minimatch": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-					"integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
-					"requires": {
-						"brace-expansion": "1.1.8"
-					}
-				}
-			}
-		},
 		"snyk-resolve": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/snyk-resolve/-/snyk-resolve-1.0.0.tgz",
@@ -27783,11 +27806,6 @@
 					"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
 				}
 			}
-		},
-		"snyk-sbt-plugin": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.0.tgz",
-			"integrity": "sha512-H4/n8/1+7WEgHLJRnzNbvI8p2biE8EBFhM++qJJU1tlIWOHy+Dl1UhwKgFiY8PSXmbQDZccabWje4XlK4a4oAA=="
 		},
 		"snyk-tree": {
 			"version": "1.0.0",
@@ -28541,14 +28559,6 @@
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
 		"string-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -28585,6 +28595,14 @@
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0",
 				"function-bind": "1.1.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringify-entities": {

--- a/packages/bolt-core/index.js
+++ b/packages/bolt-core/index.js
@@ -1,11 +1,14 @@
 // Export non-Bolt dependencies shared across virtually all components
-export { define, props, withComponent } from 'skatejs';
-export { h, render } from 'preact';
+export { define, props, withComponent, withUpdate } from 'skatejs';
+export { h } from 'preact';
 
 // Export Bolt utils
 export * from './utils/css';
+export { declarativeClickHandler } from './utils/declarative-click-handler';
 export * from './utils/environment';
-export { withPreact } from './utils/renderer-preact';
+
+export { withPreact } from './renderers/renderer-preact';
+export { withHyperHTML } from './renderers/renderer-hyperhtml';
 
 // Export Bolt data shared
 export * from './data/spacing-sizes';
@@ -22,4 +25,18 @@ export function findParentTag(el, tag) {
       return el;
   }
   return null;
+}
+
+export function sanitizeBoltClasses(elementToSanitize, prefixesToRemove = ['c-bolt-']) {
+  let prefixes = Array.from(prefixesToRemove);
+  // Remove any `c-bolt-` prefixed classes but leave the rest
+  let remainingClasses;
+
+  prefixes.forEach(function (prefix) {
+    remainingClasses = elementToSanitize.className.split(' ').filter(function (c) {
+      return c.lastIndexOf(prefix, 0) !== 0;
+    });
+  });
+
+  return remainingClasses.join(' ').trim();
 }

--- a/packages/bolt-core/package.json
+++ b/packages/bolt-core/package.json
@@ -18,6 +18,7 @@
     "@webcomponents/webcomponents-platform": "^1.0.0",
     "@webcomponents/webcomponentsjs": "^1.1.0",
     "core-js": "^2.5.1",
+    "hyperhtml": "^2.5.10",
     "document-register-element": "^1.7.2",
     "es6-promise": "^4.1.1",
     "preact": "^8.2.7",

--- a/packages/bolt-core/renderers/renderer-hyperhtml.js
+++ b/packages/bolt-core/renderers/renderer-hyperhtml.js
@@ -1,0 +1,117 @@
+/** @jsx h */
+// HyperHTML Renderer ported to SkateJS
+
+import { shadow, props } from 'skatejs';
+import { hasNativeShadowDomSupport } from '../utils/environment';
+
+import {
+  declarativeClickHandler,
+  findParentTag
+} from '../';
+
+const { hyperHTML, hyper, wire, bind, Component } = require('hyperhtml/cjs');
+
+
+export function withHyperHTML(Base = class extends HTMLElement { }) {
+  return class extends Base {
+
+    static props = {
+      onClick: props.string,
+      onClickTarget: props.string
+    }
+
+    constructor(...args) {
+      super(...args);
+
+      if (findParentTag(this, 'FORM') || this.getAttribute('no-shadow') !== null) {
+        this.useShadow = false;
+      } else {
+        this.useShadow = hasNativeShadowDomSupport;
+      }
+
+      this._replaceElementWithChildren();
+    }
+
+    connectedCallback() {
+      this._checkSlots();
+
+      // Handles external click event hooks
+      this.addEventListener('click', this.clickHandler);
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.removeEventListener('click', this.clickHandler);
+    }
+
+
+    // Attach external events declaratively
+    clickHandler(event) {
+      declarativeClickHandler(this);
+    }
+
+
+    _replaceElementWithChildren(){
+      const placeholderElement = this.querySelectorAll('replace-with-children')[0];
+      if (placeholderElement) {
+        placeholderElement.replaceWith(...placeholderElement.childNodes);
+      }
+    }
+
+
+    addStyles(stylesheet) {
+      let styles = Array.from(stylesheet);
+      styles = styles.join(' ');
+
+      if (this.useShadow) {
+        return hyper.wire() `
+          <style>${ styles } </style>
+        `;
+      }
+    }
+
+
+    // Inspired by https://codepen.io/jovdb/pen/ddRZKo
+    _checkSlots() {
+      const children = this.childNodes;
+      this.slots = {
+        default: []
+      };
+      if (children.length > 0) {
+        [...children].map(child => {
+          const slotName = child.getAttribute ? child.getAttribute("slot") : null;
+          if (!slotName) {
+            this.slots.default.push(child);
+          } else {
+            this.slots[slotName] = child;
+          }
+        });
+      }
+    }
+
+
+    get renderRoot() {
+      if (hasNativeShadowDomSupport && this.useShadow === true) {
+        return super.renderRoot || shadow(this);
+      } else {
+        return this;
+      }
+    }
+
+
+    renderer(renderRoot, renderCallback) {
+      this._renderRoot = renderRoot;
+      this.html = this.html || bind(this._renderRoot);
+      renderCallback();
+    }
+
+
+    updated(...args) {
+      super.updated && super.updated(...args);
+      this.rendering && this.rendering();
+      this.renderer(this.renderRoot, () => this.render && this.render(this));
+      this.rendered && this.rendered();
+    }
+
+  }
+};

--- a/packages/bolt-core/renderers/renderer-preact.js
+++ b/packages/bolt-core/renderers/renderer-preact.js
@@ -3,9 +3,9 @@
 
 import { shadow } from 'skatejs';
 import { h, render } from 'preact';
-import { hasNativeShadowDomSupport } from './environment';
+import { hasNativeShadowDomSupport } from '../utils/environment';
 
-export function withPreact(Base = HTMLElement){
+export function withPreact(Base = class extends HTMLElement { }){
   return class extends Base {
     get props() {
       // We override props so that we can satisfy most use
@@ -32,13 +32,5 @@ export function withPreact(Base = HTMLElement){
         this._preactDom || this._renderRoot.children[0]
       );
     }
-
-    // updated(...args) {
-    //   super.updated && super.updated(...args);
-    //   this.rendering && this.rendering();
-    //   this.renderer(this.renderRoot, () => this.render && this.render(this));
-    //   this.rendered && this.rendered();
-    // }
-
   }
 };

--- a/packages/bolt-core/utils/declarative-click-handler.js
+++ b/packages/bolt-core/utils/declarative-click-handler.js
@@ -1,0 +1,25 @@
+export function declarativeClickHandler(element) {
+  const clickMethod = element.props.onClick;
+  const clickTarget = element.props.onClickTarget;
+
+  if (clickMethod) {
+    if (clickTarget) {
+      const elems = document.querySelectorAll(`.${clickTarget}`);
+      if (elems) {
+        elems.forEach(function (elem) {
+          if (elem[clickMethod]) {
+            elem[clickMethod]();
+          } else {
+            // @TODO: handle call to undefined method
+          }
+        });
+      }
+    } else {
+      if (element[clickMethod]) {
+        element[clickMethod]();
+      } else {
+        // @TODO: handle call to undefined method
+      }
+    }
+  }
+}

--- a/src/_patterns/01-core/04-elements/elements-code/_elements.code.scss
+++ b/src/_patterns/01-core/04-elements/elements-code/_elements.code.scss
@@ -19,7 +19,7 @@ code {
   @include bolt-font-weight(semibold); // This is an edge case to use semibold.
   @include bolt-font-size(xsmall);
 
-  display: block;
+  display: inline;
   letter-spacing: 0.05rem;
   white-space: inherit;
 }

--- a/src/_patterns/02-components/bolt-button/demos/05-button-theming.twig
+++ b/src/_patterns/02-components/bolt-button/demos/05-button-theming.twig
@@ -18,5 +18,15 @@
       style: "text",
       "text": "Button Text"
     } %}
+
+    {% include "@bolt/button.twig" with {
+      style: "primary",
+      text: "Button Theming Override",
+      attributes: {
+        class: [
+          "_c-bolt-button--theme-override"
+        ]
+      }
+    } %}
   </section>
 {% endfor %}

--- a/src/_patterns/02-components/bolt-button/demos/button--data-attributes.twig
+++ b/src/_patterns/02-components/bolt-button/demos/button--data-attributes.twig
@@ -1,0 +1,13 @@
+<p>Test case to verify misc attributes can be tacked onto a <code>&lt;bolt-button&gt;</code> such as data attributes, ids, etc</p>
+
+{% include "@bolt/button.twig" with {
+  text: "Button with Misc Attributes",
+  type: "submit",
+  attributes: {
+    class: [
+      "js-my-external-selector",
+    ],
+    id: "foobar",
+    "data-baz": "bar"
+  }
+} only %}

--- a/src/_patterns/02-components/bolt-button/demos/button--form-submit.twig
+++ b/src/_patterns/02-components/bolt-button/demos/button--form-submit.twig
@@ -1,0 +1,20 @@
+<p>Test case showing a <code>&lt;bolt-button&gt;</code> nested inside of a form to confirm native form submissions work as expected</p>
+
+<form action="/" method="get">
+  First name:<br>
+  <input type="text" name="firstname" value="Mickey">
+
+  <br><br>
+
+  {% include "@bolt/button.twig" with {
+    text: "Submit",
+    type: "submit",
+    attributes: {
+      class: [
+        "u-bolt-margin-bottom"
+      ],
+      id: "foobar",
+      "data-baz": "bar"
+    }
+  } only %}
+</form>

--- a/src/_patterns/02-components/bolt-button/demos/button--icon-only.twig
+++ b/src/_patterns/02-components/bolt-button/demos/button--icon-only.twig
@@ -1,3 +1,5 @@
+<p>Test case to verify icon-only buttons display just an icon + visually hidden text if content is defined.</p>
+
 {% include "@bolt/button.twig" with {
   "text": "Example Icon Only Button",
   "size": "xsmall",

--- a/src/_patterns/02-components/bolt-button/demos/button--no-shadow.twig
+++ b/src/_patterns/02-components/bolt-button/demos/button--no-shadow.twig
@@ -1,0 +1,9 @@
+<p>Test case demoing how buttons can <em>technically</em> have Shadow DOM encapsulation manually disabled as a failsafe.</p>
+
+<p>Use with <strong>extreme caution</strong> as we are already automatically managing this internally based native browser support!</p>
+
+{% include "@bolt/button.twig" with {
+  text: "Submit",
+  style: "primary",
+  noShadow: true
+} only %}

--- a/src/_patterns/02-components/bolt-button/demos/button--static-html.twig
+++ b/src/_patterns/02-components/bolt-button/demos/button--static-html.twig
@@ -1,0 +1,28 @@
+<p>Test case to verify pure HTML-based <code>&lt;bolt-button&gt;</code> tags properly render with either an internal &lt;button&gt; or &lt;a&gt; tag.</p>
+
+<bolt-button color="primary">&lt;button&gt; tag Button</bolt-button>
+
+<bolt-button color="primary" url="https://www.google.com">&lt;a&gt; tag button, no target</bolt-button>
+
+<bolt-button color="primary" target="_blank" url="https://www.google.com">&lt;a&gt; tag button, with target</bolt-button>
+
+
+<h3>Example of manually disabling Shadow DOM + using a static HTML custom element:</h3>
+<bolt-button color="primary" no-shadow>
+<span>Manually Disabling Shadow DOM</span></bolt-button>
+
+
+<p>Please note: manually disabling Shadow DOM + using the Button component manually (ie. writing vanilla HTML and not via a Twig template include) does NOT currently work:</p>
+
+{% verbatim %}
+<code>
+<pre>
+&lt;bolt-button color="primary" no-shadow&gt; Manually Disabling Shadow DOM, no inner wrapper&lt;/bolt-button&gt;
+</pre>
+</code>
+{% endverbatim %}
+
+<section class="u-bolt-padding-medium" style="border: 1px dashed gray">
+  <bolt-button color="primary" no-shadow>
+Manually Disabling Shadow DOM, no inner wrapper</bolt-button>
+</section>

--- a/src/_patterns/02-components/bolt-button/demos/button--utils.twig
+++ b/src/_patterns/02-components/bolt-button/demos/button--utils.twig
@@ -1,0 +1,10 @@
+<p>Test case to verify external utility classes can be applied to the <code>&lt;bolt-button&gt;</code>.</p>
+
+{% include "@bolt/button.twig" with {
+  text: "Button With Utility Classes",
+  utils: [
+    "u-bolt-margin-top",
+    "u-bolt-margin-left",
+    "u-bolt-margin-bottom"
+  ]
+} only %}

--- a/src/_patterns/02-components/bolt-button/package.json
+++ b/src/_patterns/02-components/bolt-button/package.json
@@ -42,7 +42,8 @@
     "@bolt/core": "^0.10.1",
     "@bolt/settings-all": "^0.9.0",
     "@bolt/tools-all": "^0.9.0",
-    "@bolt/utilities-spacing": "^0.9.0"
+    "@bolt/utilities-spacing": "^0.9.0",
+    "@bolt/utilities-visuallyhidden": "^0.9.0"
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/src/_patterns/02-components/bolt-button/src/_button.mixins.scss
+++ b/src/_patterns/02-components/bolt-button/src/_button.mixins.scss
@@ -1,0 +1,342 @@
+// Lightweight style reset for button and input elements
+@mixin bolt-button-reset {
+  @include bolt-padding(0);
+  @include bolt-font-family(body);
+  border: none;
+  background: none;
+}
+
+@mixin bolt-button-raised() {
+  &:not(.c-bolt-button--disabled):not(.c-bolt-button--text):not([disabled]) {
+    &:hover,
+    &.c-bolt-button--hover {
+      transform: $bolt-button-translate--hover;
+    }
+
+    &:hover:before,
+    &.c-bolt-button--hover:before {
+      opacity: 1;
+    }
+
+    &:active,
+    &.c-bolt-button--active {
+      transform: $bolt-button-translate--active;
+    }
+
+    &:active:before,
+    &.c-bolt-button--active:before {
+      opacity: 0;
+    }
+  }
+}
+
+
+@mixin bolt-button {
+  @include bolt-button-reset;
+  @include bolt-no-select;
+  @include bolt-font-weight(semibold);
+  @include bolt-button-raised;
+
+  display: inline-block;
+  display: inline-flex;
+  position: relative;
+  cursor: pointer;
+  text-decoration: none;
+  vertical-align: middle;
+  border-style: $bolt-button-border-style;
+  border-width: $bolt-button-border-width;
+  border-radius: $bolt-button-border-radius;
+  box-shadow: 0  1px  3px rgba(bolt-color(black), 0.12), 0 1px  2px  rgba(bolt-color(black), 0.24);
+  transition: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
+  transform: translate3d(0, 0, 0);
+
+  flex-grow: 1;
+  flex-direction: row; // Vertically center inner content
+  justify-content: center; // Vertically center inner content
+
+  &:before {
+    display: block;
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    content: '';
+    pointer-events: none;
+    border-radius: $bolt-button-border-radius;
+    box-shadow: 0 1px 0.15rem rgba($bolt-shadow-color, 0.1), $bolt-button-shadow--hover;
+    transition: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
+    opacity: 0.2;
+  }
+}
+
+// Temporary styles applied to links and buttons nested inside of the <bolt-button> component, prior to JS kicking in
+@mixin bolt-button-root(){
+  height: 100%;
+  -webkit-appearance: none;
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+  font-weight: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  font: inherit;
+  line-height: inherit;
+  cursor: inherit;
+  color: inherit; // fix for black text browser default
+  display: inline-flex; // vertical alignment w/ icon only button
+  align-items: stretch; // valign inner content
+  flex-grow: 1;
+  justify-content: inherit;
+}
+
+
+
+/**
+  * Button Colors / Types
+  */
+@mixin bolt-button-style--primary() {
+  $primary-background-default: $bolt-color-primary;
+  $primary-background-hover: mix($bolt-global-button-hover-color, $primary-background-default, $bolt-global-button-hover-mix);
+  $primary-background-active: mix($bolt-global-button-active-color, $primary-background-default, $bolt-global-button-active-mix);
+
+  &,
+  &:visited {
+    border-color: $primary-background-default;
+    border-color: var(--bolt-theme-primary-border-default, $primary-background-default);
+
+    color: bolt-text-contrast($primary-background-default);
+    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
+
+    background-color: $primary-background-default;
+    background-color: var(--bolt-theme-primary-background-default, $primary-background-default);
+  }
+
+  &:hover,
+  &.c-bolt-button--hover {
+    border-color: $primary-background-hover;
+    border-color: var(--bolt-theme-primary-border-hover, $primary-background-hover);
+    color: bolt-text-contrast($primary-background-default);
+    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
+    background-color: $primary-background-hover;
+    background-color: var(--bolt-theme-primary-background-hover, $primary-background-hover);
+  }
+
+  &:focus,
+  &.c-bolt-button--focus {
+    border-color: $primary-background-hover;
+    border-color: var(--bolt-theme-primary-border-hover, $primary-background-hover);
+    color: bolt-text-contrast($primary-background-default);
+    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
+    background-color: $primary-background-hover;
+    background-color: var(--bolt-theme-primary-background-hover, $primary-background-hover);
+
+    outline-width: 5px; // Default browser outline styles
+    outline-style: auto; // Default browser outline styles
+    outline-color: rgb(59, 153, 252); // Default browser outline styles
+  }
+
+  &:active,
+  &.c-bolt-button--active {
+    border-color: $primary-background-active;
+    border-color: var(--bolt-theme-primary-border-active, $primary-background-active);
+
+    color: bolt-text-contrast($primary-background-default);
+    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
+
+    background-color: $primary-background-active;
+    background-color: var(--bolt-theme-primary-background-active, $primary-background-active);
+  }
+}
+
+
+@mixin bolt-button-style--secondary() {
+  $secondary-background-default: bolt-color(white);
+  $secondary-background-hover: mix(bolt-color(black), $secondary-background-default, 2%);
+  $secondary-background-active: mix(bolt-color(black), $secondary-background-default, 15%);
+
+  &,
+  &:visited {
+    border-color: $secondary-background-default;
+    border-color: var(--bolt-theme-secondary-border-default, $secondary-background-default);
+
+    color: bolt-text-contrast($secondary-background-default);
+    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
+
+    background-color: $secondary-background-default;
+    background-color: var(--bolt-theme-secondary-background-default, $secondary-background-default);
+  }
+
+  &.c-bolt-button--hover,
+  &:hover {
+    border-color: $secondary-background-hover;
+    border-color: var(--bolt-theme-secondary-border-hover, $secondary-background-hover);
+    color: bolt-text-contrast($secondary-background-default);
+    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
+    background-color: $secondary-background-hover;
+    background-color: var(--bolt-theme-secondary-background-hover, $secondary-background-hover);
+  }
+
+  &:focus,
+  &.c-bolt-button--focus {
+    border-color: $secondary-background-hover;
+    border-color: var(--bolt-theme-secondary-border-hover, $secondary-background-hover);
+    color: bolt-text-contrast($secondary-background-default);
+    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
+    background-color: $secondary-background-hover;
+    background-color: var(--bolt-theme-secondary-background-hover, $secondary-background-hover);
+    outline-width: 5px; // Default browser outline styles
+    outline-style: auto; // Default browser outline styles
+    outline-color: rgb(59, 153, 252); // Default browser outline styles
+  }
+
+  &.c-bolt-button--active,
+  &:active {
+    border-color: $secondary-background-active;
+    border-color: var(--bolt-theme-secondary-border-active, $secondary-background-active);
+
+    color: bolt-text-contrast($secondary-background-default);
+    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
+
+    background-color: $secondary-background-active;
+    background-color: var(--bolt-theme-secondary-background-active, $secondary-background-active);
+  }
+}
+
+
+@mixin bolt-button-style--text(){
+  text-decoration: none;
+  border-color: transparent;
+  background-color: transparent;
+  $bolt-theme-link-default: bolt-color(indigo, light);
+
+  // Removing shadows for text buttons
+  &, &:before {
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  & {
+    opacity: 1;
+    color: currentColor;
+
+    @supports(--css: variables) {
+      color: var(--bolt-theme-heading-link-default, inherit);
+    }
+  }
+
+  &:visited {
+    opacity: 1;
+    color: currentColor;
+
+    @supports(--css: variables) {
+      color: var(--bolt-theme-heading-link-visited, inherit);
+    }
+  }
+
+
+  &:focus,
+  &:hover {
+    opacity: $bolt-global-link-hover-opacity;
+
+    @supports(--css: variables) {
+      opacity: 1;
+      color: var(--bolt-theme-heading-link-hover, inherit);
+    }
+  }
+
+  &:active {
+    opacity: $bolt-global-link-active-opacity;
+
+    @supports(--css: variables) {
+      opacity: 1;
+      color: var(--bolt-theme-heading-link-active, inherit);
+    }
+  }
+}
+
+
+@mixin bolt-button-style--disabled() {
+  cursor: not-allowed;
+  &,
+  &:visited {
+    color: bolt-color(gray);
+    border-color: bolt-color(gray, light);
+    background-color: bolt-color(gray, light);
+  }
+
+  &:hover {
+    color: bolt-color(gray);
+    border-color: bolt-color(gray, light);
+    background-color: bolt-color(gray, light);
+  }
+
+  &:active {
+    color: bolt-color(gray);
+    border-color: bolt-color(gray, light);
+    background-color: bolt-color(gray, light);
+  }
+
+  &:before,
+  &:hover:before,
+  &:active:before {
+    opacity: 1;
+  }
+
+  &,
+  &:hover,
+  &:active {
+    transform: none;
+  }
+}
+
+
+// Teal-specific color. Needs refactoring to combine with primary button logic above ^
+@mixin bolt-button-color--teal {
+  $button-background-color-default: bolt-color(indigo, light);
+  $button-background-color-hover: mix($bolt-global-button-hover-color, $button-background-color-default, $bolt-global-button-hover-mix);
+  $button-background-color-active: mix($bolt-global-button-active-color, $button-background-color-default, $bolt-global-button-active-mix);
+  &.c-bolt-button,
+  &.c-bolt-button:visited {
+    border-color: $button-background-color-default;
+    color: bolt-text-contrast($button-background-color-default);
+    background-color: $button-background-color-default;
+  }
+  &:focus,
+  &:hover {
+    border-color: $button-background-color-hover;
+    color: bolt-text-contrast($button-background-color-default);
+    background-color: $button-background-color-hover;
+  }
+  &:active {
+    border-color: $button-background-color-active;
+    color: bolt-text-contrast($button-background-color-default);
+    background-color: $button-background-color-active;
+  }
+}
+
+// @todo: refactor and revive state color options
+// .c-bolt-button--success {
+//   @include bolt-button-color(success);
+// }
+// .c-bolt-button--warning {
+//   @include bolt-button-color(warning);
+// }
+// .c-bolt-button--error {
+//   @include bolt-button-color(error);
+// }
+
+
+
+@mixin bolt-button-style($style) {
+  @if ($style == 'primary') {
+    @include bolt-button-style--primary;
+  } @else if ($style == 'secondary') {
+    @include bolt-button-style--secondary;
+  } @else if ($style == 'text') {
+    @include bolt-button-style--text;
+  } @else if ($style == 'disabled') {
+    @include bolt-button-style--disabled;
+  }
+}

--- a/src/_patterns/02-components/bolt-button/src/_button.settings.scss
+++ b/src/_patterns/02-components/bolt-button/src/_button.settings.scss
@@ -1,0 +1,12 @@
+// Button config options
+$bolt-color-button-text: bolt-color(white);
+$bolt-color-primary: bolt-color(yellow);
+$bolt-color-secondary: bolt-color(indigo, light);
+$bolt-button-shadow: $bolt-shadow--small;
+$bolt-button-shadow--hover: $bolt-shadow--large;
+$bolt-button-border-width: $bolt-border-width;
+$bolt-button-border-style: $bolt-border-style;
+$bolt-button-border-radius: $bolt-border-radius;
+$bolt-button-transition: $bolt-transition;
+$bolt-button-translate--hover: translate3d(0, -1px, 0);
+$bolt-button-translate--active: translate3d(0, 1px, 0);

--- a/src/_patterns/02-components/bolt-button/src/button.scss
+++ b/src/_patterns/02-components/bolt-button/src/button.scss
@@ -6,424 +6,61 @@ $bolt-export-data: false !global;
 @import '@bolt/settings-all';
 @import '@bolt/tools-all';
 
+@import './button.settings';
+@import './button.mixins';
 
-$bolt-color-button-text: bolt-color(white);
-$bolt-color-primary: bolt-color(yellow);
-$bolt-color-secondary: bolt-color(indigo, light);
-
-
-
-$bolt-button-shadow: $bolt-shadow--small;
-$bolt-button-shadow--hover: $bolt-shadow--large;
-$bolt-button-border-width: $bolt-border-width;
-$bolt-button-border-style: $bolt-border-style;
-$bolt-button-border-radius: $bolt-border-radius;
-$bolt-button-transition: $bolt-transition;
-$bolt-button-translate--hover: translate3d(0, -1px, 0);
-$bolt-button-translate--active: translate3d(0, 1px, 0);
+@import './link';
 
 
 
 
-// Reset browser defaults for button and input
-@mixin bolt-reset-button-styles {
-  @include bolt-padding(0);
-  @include bolt-font-family(body);
-
-  border: none;
-  background: none;
-}
-
-// Placeholder for colors.
-@mixin bolt-link-color {
-  &:link,
-  &:visited {
-    color: $bolt-color-secondary;
-  }
-  // &:visited {
-  //   color: var(--bolt-color-secondary--visited, $bolt-color-secondary);
-  // }
-
-  &:hover {
-    color: mix(white, $bolt-color-secondary, 35%);
-    // color: var(--bolt-color-secondary, mix(white, $bolt-color-secondary, 35%));
-  }
-
-  &:active {
-    color: mix(white, $bolt-color-secondary, 15%);
-    // color: var(--bolt-color-secondary, $bolt-color-secondary);
-  }
-}
-
-@mixin bolt-button-color($hiarchy) {
-  @if $hiarchy == 'primary' {
-
-  } @elseif $hiarchy == 'secondary' {
-
-  }
-
-  @elseif $hiarchy == 'text' {
-    &,
-    &:visited {
-      color: var(--bolt-color-secondary, $bolt-color-secondary);
-      border-color: transparent;
-      background-color: transparent;
-    }
-
-    &:hover {
-      border-color: transparent;
-      background-color: transparent;
-    }
-
-    &:active {
-      border-color: transparent;
-      background-color: transparent;
-    }
-  }
-
-  @elseif $hiarchy == 'success' {
-    &,
-    &:visited {
-      color: bolt-color(white);
-      border-color: bolt-color(success);
-      background-color: bolt-color(success);
-    }
-
-    &:hover {
-      border-color: bolt-color(success, dark);
-      background-color: bolt-color(success, dark);
-    }
-
-    &:active {
-      border-color: bolt-color(success, dark);
-      background-color: bolt-color(success, dark);
-    }
-  }
-  @elseif $hiarchy == 'warning' {
-    &,
-    &:visited {
-      color: bolt-color(black);
-      border-color: bolt-color(warning);
-      background-color: bolt-color(warning);
-    }
-
-    &:hover {
-      border-color: bolt-color(warning, dark);
-      background-color: bolt-color(warning, dark);
-    }
-
-    &:active {
-      border-color: bolt-color(warning, dark);
-      background-color: bolt-color(warning, dark);
-    }
-  }
-
-  @elseif $hiarchy == 'error' {
-    &,
-    &:visited {
-      color: bolt-color(white);
-      border-color: bolt-color(error);
-      background-color: bolt-color(error);
-    }
-
-    &:hover {
-      border-color: bolt-color(error, dark);
-      background-color: bolt-color(error, dark);
-    }
-
-    &:active {
-      border-color: bolt-color(error, dark);
-      background-color: bolt-color(error, dark);
-    }
-  }
-
-  @elseif $hiarchy == 'disabled' {
-    &,
-    &:visited {
-      color: bolt-color(gray);
-      border-color: bolt-color(gray, light);
-      background-color: bolt-color(gray, light);
-    }
-
-    &:hover {
-      color: bolt-color(gray);
-      border-color: bolt-color(gray, light);
-      background-color: bolt-color(gray, light);
-    }
-
-    &:active {
-      color: bolt-color(gray);
-      border-color: bolt-color(gray, light);
-      background-color: bolt-color(gray, light);
-    }
-  }
-}
-
-// TODO: move to utils. temp workaround to flash of unstyled text in IE11
-.u-bolt-transitionless {
-  transition: none !important;
-}
-
-@mixin bolt-button {
-  @include bolt-reset-button-styles;
-  @include bolt-no-select;
-  @include bolt-font-weight(semibold);
-
-  display: inline-block;
-  display: inline-flex;
-  position: relative;
-  cursor: pointer;
-  text-decoration: none;
-  vertical-align: middle;
-  border-style: $bolt-button-border-style;
-  border-width: $bolt-button-border-width;
-  border-radius: $bolt-button-border-radius;
-  // box-shadow: 0 1px 0.15rem rgba(21,22,25,0.2);
-  box-shadow: 0  1px  3px rgba(bolt-color(black), 0.12), 0 1px  2px  rgba(bolt-color(black), 0.24);
-  transition: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
-  transform: translate3d(0, 0, 0);
-
-  &:before {
-    display: block;
-    position: absolute;
-    z-index: -1;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    content: '';
-    pointer-events: none;
-    border-radius: $bolt-button-border-radius;
-    box-shadow: 0 1px 0.15rem rgba($bolt-shadow-color, 0.1), $bolt-button-shadow--hover;
-    transition: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
-    opacity: 0.2;
-  }
-
-  &:not([disabled]):not(.c-bolt-button--text) {
-    &:hover,
-    &.c-bolt-button--hover {
-      transform: $bolt-button-translate--hover;
-    }
-
-    &:hover:before,
-    &.c-bolt-button--hover:before {
-      opacity: 1;
-    }
-
-    &:active,
-    &.c-bolt-button--active {
-      transform: $bolt-button-translate--active;
-    }
-
-    &:active:before,
-    &.c-bolt-button--active:before {
-      opacity: 0;
-    }
-  }
-}
-
-
+/** Base Button Styles **/
 bolt-button {
   display: inline-block; // Fallback
   display: inline-flex; // So equal height works
 }
 
-// Button colors
 .c-bolt-button {
   @include bolt-button;
-  flex-direction: row; // Vertically center inner content
-  justify-content: center; // Vertically center inner content
+
+  // Inner <a> or <button> nested inside of the custom element tag
+  &__root {
+     @include bolt-button-root;
+  }
 }
 
+
+
+/** Button Style Variations **/
 .c-bolt-button--primary {
-  $primary-background-default: $bolt-color-primary;
-  $primary-background-hover: mix($bolt-global-button-hover-color, $primary-background-default, $bolt-global-button-hover-mix);
-  $primary-background-active: mix($bolt-global-button-active-color, $primary-background-default, $bolt-global-button-active-mix);
-
-  &,
-  &:visited {
-    border-color: $primary-background-default;
-    border-color: var(--bolt-theme-primary-border-default, $primary-background-default);
-
-    color: bolt-text-contrast($primary-background-default);
-    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
-
-    background-color: $primary-background-default;
-    background-color: var(--bolt-theme-primary-background-default, $primary-background-default);
-  }
-
-  &:hover,
-  &.c-bolt-button--hover {
-    border-color: $primary-background-hover;
-    border-color: var(--bolt-theme-primary-border-hover, $primary-background-hover);
-    color: bolt-text-contrast($primary-background-default);
-    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
-    background-color: $primary-background-hover;
-    background-color: var(--bolt-theme-primary-background-hover, $primary-background-hover);
-  }
-
-  &:focus,
-  &.c-bolt-button--focus {
-    border-color: $primary-background-hover;
-    border-color: var(--bolt-theme-primary-border-hover, $primary-background-hover);
-    color: bolt-text-contrast($primary-background-default);
-    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
-    background-color: $primary-background-hover;
-    background-color: var(--bolt-theme-primary-background-hover, $primary-background-hover);
-
-    outline-width: 5px; // Default browser outline styles
-    outline-style: auto; // Default browser outline styles
-    outline-color: rgb(59, 153, 252); // Default browser outline styles
-  }
-
-  &:active,
-  &.c-bolt-button--active {
-    border-color: $primary-background-active;
-    border-color: var(--bolt-theme-primary-border-active, $primary-background-active);
-
-    color: bolt-text-contrast($primary-background-default);
-    color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
-
-    background-color: $primary-background-active;
-    background-color: var(--bolt-theme-primary-background-active, $primary-background-active);
-  }
-}
-
-
-@mixin bolt-button-secondary() {
-  $secondary-background-default: bolt-color(white);
-  $secondary-background-hover: mix(bolt-color(black), $secondary-background-default, 2%);
-  $secondary-background-active: mix(bolt-color(black), $secondary-background-default, 15%);
-
-  &,
-  &:visited {
-    border-color: $secondary-background-default;
-    border-color: var(--bolt-theme-secondary-border-default, $secondary-background-default);
-
-    color: bolt-text-contrast($secondary-background-default);
-    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
-
-    background-color: $secondary-background-default;
-    background-color: var(--bolt-theme-secondary-background-default, $secondary-background-default);
-  }
-
-  &.c-bolt-button--hover,
-  &:hover {
-    border-color: $secondary-background-hover;
-    border-color: var(--bolt-theme-secondary-border-hover, $secondary-background-hover);
-    color: bolt-text-contrast($secondary-background-default);
-    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
-    background-color: $secondary-background-hover;
-    background-color: var(--bolt-theme-secondary-background-hover, $secondary-background-hover);
-  }
-
-  &:focus,
-  &.c-bolt-button--focus {
-    border-color: $secondary-background-hover;
-    border-color: var(--bolt-theme-secondary-border-hover, $secondary-background-hover);
-    color: bolt-text-contrast($secondary-background-default);
-    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
-    background-color: $secondary-background-hover;
-    background-color: var(--bolt-theme-secondary-background-hover, $secondary-background-hover);
-    outline-width: 5px; // Default browser outline styles
-    outline-style: auto; // Default browser outline styles
-    outline-color: rgb(59, 153, 252); // Default browser outline styles
-  }
-
-  &.c-bolt-button--active,
-  &:active {
-    border-color: $secondary-background-active;
-    border-color: var(--bolt-theme-secondary-border-active, $secondary-background-active);
-
-    color: bolt-text-contrast($secondary-background-default);
-    color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
-
-    background-color: $secondary-background-active;
-    background-color: var(--bolt-theme-secondary-background-active, $secondary-background-active);
-  }
+  @include bolt-button-style(primary);
 }
 
 .c-bolt-button--secondary {
-  @include bolt-button-secondary;
+  @include bolt-button-style(secondary);
 }
 
+.c-bolt-button--text {
+  @include bolt-button-style(text);
+}
+
+.c-bolt-button[disabled],
+.c-bolt-button--disabled {
+  @include bolt-button-style(disabled);
+}
 
 // Allow forcing light and xlight theme colors in IE11 until http://vjira2:8080/browse/BK-48 is resolved.
 .t-bolt-xlight,
 .t-bolt-light {
   ._c-bolt-button--theme-override {
-    $fallback-background-default: bolt-color(indigo, light);
-    $fallback-background-hover: mix($bolt-global-button-hover-color, $fallback-background-default, $bolt-global-button-hover-mix);
-    $fallback-background-active: mix($bolt-global-button-active-color, $fallback-background-default, $bolt-global-button-active-mix);
-
-    &.c-bolt-button,
-    &.c-bolt-button__inner,
-    &.c-bolt-button:visited,
-    &.c-bolt-button__inner:visited {
-      border-color: $fallback-background-default;
-      color: bolt-text-contrast($fallback-background-default);
-      background-color: $fallback-background-default;
-    }
-
-    &:focus,
-    &:hover {
-      border-color: $fallback-background-hover;
-      color: bolt-text-contrast($fallback-background-default);
-      background-color: $fallback-background-hover;
-    }
-
-    &:active {
-      border-color: $fallback-background-active;
-      color: bolt-text-contrast($fallback-background-default);
-      background-color: $fallback-background-active;
-    }
+    @include bolt-button-color--teal;
   }
 }
 
 
 
-.c-bolt-button--success {
-  @include bolt-button-color(success);
-}
 
-.c-bolt-button--warning {
-  @include bolt-button-color(warning);
-}
-
-.c-bolt-button--error {
-  @include bolt-button-color(error);
-}
-
-.c-bolt-button[disabled],
-.c-bolt-button--disabled {
-  @include bolt-button-color(disabled);
-  cursor: not-allowed;
-
-  &:before,
-  &:hover:before,
-  &:active:before {
-    opacity: 1;
-  }
-
-  &,
-  &:hover,
-  &:active {
-    transform: none;
-  }
-}
-
-
-// Removing shadows for text buttons
-
-.c-bolt-button--text,
-.c-bolt-button--text:before, {
-  border-radius: 0;
-  box-shadow: none;
-}
-
-
-// Button sizes
-
+/** Button Size Variations **/
 .c-bolt-button,
 .c-bolt-button--medium {
   @include bolt-padding(medium, squished);
@@ -480,7 +117,9 @@ bolt-button {
 }
 
 
-// Button width variations
+
+
+/** Button Width Variations **/
 bolt-button[width='full'],
 .c-bolt-button--full {
   width: 100%;
@@ -493,14 +132,19 @@ bolt-button[width='full@small'],
   }
 }
 
-// Rounded button option
+
+
+
+/** Rounded off buttons (ie. pills or icon-only buttons) **/
 .c-bolt-button--rounded,
 .c-bolt-button--rounded:before {
   border-radius: 50rem;
 }
 
 
-// Button alignment options
+
+
+/** Button Alignments **/
 .c-bolt-button--center {
   align-items: center;
   justify-content: center;
@@ -519,29 +163,26 @@ bolt-button[width='full@small'],
   text-align: right;
 }
 
-.c-bolt-button__item,
-.c-bolt-button__link,
-.c-bolt-button__button {
-  display: inline-flex; // vertical align content
-  align-self: center;
-}
 
-.c-bolt-button__button {
-  -webkit-appearance: none;
-  background-color: transparent;
-  border: 0;
-  font-weight: inherit;
-  font-size: inherit;
-  font-family: inherit;
-  cursor: inherit;
-  color: inherit; // fix for black text browser default
-  padding: 0;
-  display: inline-flex; // vertical alignment w/ icon only button
-}
 
+
+/** Handle Button Icon Alignment + Before / After **/
 .c-bolt-link__text + .c-bolt-link__icon,
 .c-bolt-button__item-text + .c-bolt-button__icon {
   @include bolt-margin-left(xxsmall);
+
+  .c-bolt-button--icon-only & {
+    @include bolt-margin-left(0);
+  }
+}
+
+.c-bolt-link__icon + .c-bolt-link__text,
+.c-bolt-button__icon + .c-bolt-button__item-text {
+  @include bolt-margin-left(xsmall);
+
+  .c-bolt-button--icon-only & {
+    @include bolt-margin-left(0);
+  }
 }
 
 .c-bolt-link__icon,
@@ -551,128 +192,4 @@ bolt-button[width='full@small'],
   vertical-align: middle;
   align-self: center;
   line-height: 1; // workaround so icons can be vertically aligned properly
-}
-
-.c-bolt-link__icon + .c-bolt-link__text,
-.c-bolt-button__icon + .c-bolt-button__item-text {
-  @include bolt-margin-left(xsmall);
-}
-
-
-// Links
-
-.c-bolt-link {
-  @include bolt-reset-button-styles;
-  display: inline-block;
-  display: inline-flex; //So icons are vcentered
-  text-decoration: underline;
-  transition: all $bolt-button-transition;
-}
-
-
-
-.c-bolt-button--text {
-  text-decoration: none;
-  border-color: transparent;
-  background-color: transparent;
-  $bolt-theme-link-default: bolt-color(indigo, light);
-
-  & {
-    opacity: 1;
-    color: currentColor;
-
-    @supports(--css: variables) {
-      color: var(--bolt-theme-heading-link-default, inherit);
-    }
-  }
-
-  &:visited {
-    opacity: 1;
-    color: currentColor;
-
-    @supports(--css: variables) {
-      color: var(--bolt-theme-heading-link-visited, inherit);
-    }
-  }
-
-
-  &:focus,
-  &:hover {
-    opacity: $bolt-global-link-hover-opacity;
-
-    @supports(--css: variables) {
-      opacity: 1;
-      color: var(--bolt-theme-heading-link-hover, inherit);
-    }
-  }
-
-  &:active {
-    opacity: $bolt-global-link-active-opacity;
-
-    @supports(--css: variables) {
-      opacity: 1;
-      color: var(--bolt-theme-heading-link-active, inherit);
-    }
-  }
-}
-
-
-
-
-.c-bolt-link--headline {
-  cursor: pointer;
-  text-decoration: none;
-  color: inherit;
-  color: var(--bolt-theme-heading-link-default, --bolt-theme-text);
-}
-
-.c-bolt-link--headline:hover {
-    color: inherit;
-    text-decoration: underline;
-    color: var(--bolt-theme-heading-link-hover, --bolt-theme-text);
-  }
-
-.c-bolt-link--headline:active {
-  color: inherit;
-  color: var(--bolt-theme-heading-link-active, --bolt-theme-text);
-}
-
-.c-bolt-link--headline:visited {
-  color: inherit;
-  color: var(--bolt-theme-heading-link-visited, --bolt-theme-text);
-}
-
-
-.c-bolt-link {
-  // &:link,
-  // &:visited {
-  //   // color: $bolt-color-secondary;
-  // }
-  // // &:visited {
-  // //   color: var(--bolt-color-secondary--visited, $bolt-color-secondary);
-  // // }
-
-  // &:hover {
-  //   color: mix(white, $bolt-color-secondary, 35%);
-  //   // color: var(--bolt-color-secondary, mix(white, $bolt-color-secondary, 35%));
-  // }
-
-  // &:active {
-  //   color: mix(white, $bolt-color-secondary, 15%);
-  //   // color: var(--bolt-color-secondary, $bolt-color-secondary);
-  // }
-}
-
-// Inner component wrapper to the button added when rendering via Preact - doesn't apply to the component's pre-rendered state
-.c-bolt-button__inner {
-  display: flex;
-
-  // Sass-portion of the workaround technique to hide the focus outline styles on <button> tag buttons without wrecking accessibility
-  // Technique inspired by https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2, https://jmperezperez.com/outline-focus-ring-a11y/, and https://marcysutton.com/button-focus-hell/
-  &:not(.is-focused) {
-    &:focus,
-    &:active {
-      outline: none;
-    }
-  }
 }

--- a/src/_patterns/02-components/bolt-button/src/button.standalone.js
+++ b/src/_patterns/02-components/bolt-button/src/button.standalone.js
@@ -1,166 +1,57 @@
 import {
-  h,
-  render,
   define,
   props,
   withComponent,
-  withPreact,
   css,
-  spacingSizes,
-  renderToString,
   hasNativeShadowDomSupport,
-  findParentTag
+  withHyperHTML,
+  sanitizeBoltClasses
 } from '@bolt/core';
 
 import styles from './button.scss';
-// import spacingUtils from '@bolt/utilities-spacing/_utilities.spacing.scss';
+import visuallyhiddenUtils from '@bolt/utilities-visuallyhidden/_utilities.visuallyhidden.scss';
+
 
 @define
-export class BoltButton extends withComponent(withPreact()) {
+export class BoltButton extends withHyperHTML(withComponent()) {
   static is = 'bolt-button';
 
   static props = {
     color: props.string,
+    text: props.string,
     size: props.string,
     rounded: props.boolean,
     iconOnly: props.boolean,
-    disabled: props.boolean,
     size: props.string,
     width: props.string,
     align: props.string,
+
+    disabled: props.boolean,
+
+    target: props.string,
     url: props.string,
-    onClick: props.string,
-    onClickTarget: props.string,
+
     isHover: props.boolean,  // test hover psuedo state
     isActive: props.boolean, // test active psuedo state
     isFocus: props.boolean,  // test focus psuedo state
+
+    onClick: props.string, // Managed by base class
+    onClickTarget: props.string, // Managed by base class
   }
 
-  constructor(element) {
-    super(element);
-
-    if (findParentTag(this, 'FORM')){
-      this.useShadow = false;
-    } else {
-      this.useShadow = hasNativeShadowDomSupport;
-    }
-
-    this.originalElem = this.querySelectorAll('.c-bolt-button')[0];
-
-    if (this.originalElem) {
-      // Remove any `c-bolt-` classes getting passed in since the component's core styles should be based on the component's props
-      var extraClasses = this.originalElem.className.split(' ').filter(function (c) {
-        return c.lastIndexOf('c-bolt-', 0) !== 0;
-      });
-      extraClasses = extraClasses.join(' ').trim();
-      this.originalElem.className = `c-bolt-button__inner ${extraClasses}`;
-    }
-
-    if (!this.useShadow) {
-      if (this.originalElem) {
-        this.fallbackText = this.originalElem.innerHTML;
-      } else {
-        this.fallbackText = this.innerHTML;
-      }
-    }
+  constructor() {
+    super();
   }
 
-  connectedCallback(){
-    // Set default button states
-    this.state = {
-      isMouseActive: false,
-      isFocused: false,
-      isFirstRender: true
-    };
-
-  /**
-   * 1. Handles external click event hooks
-   * 2. Handles internal focus and click events relating to conditionally toggling focus state
-   * 3. Note: `focus` here won't work in IE 11
-   */
-    this.addEventListener('click', this.clickHandler); /* [1] */
-    this.addEventListener('mousedown', this.mousedownHandler); /* [2] */
-    this.addEventListener('focusin', this.focusHandler); /* [2, 3] */
-
-    if (!this.useShadow) {
-      this.enableTransitions = false;
-      const self = this;
-
-      setTimeout(function () {
-        const buttonElem = self.querySelector('.c-bolt-button');
-
-        if (buttonElem) {
-          self.enableTransitions = true;
-          buttonElem.classList.remove('u-bolt-transitionless');
-          self.render(self.props, self.enableTransitions = true);
-        }
-      }, 300);
-    } else {
-      this.enableTransitions = true;
-    }
+  connecting(){
+    // Connected callback work goes here - syntactic sugar SkateJS provides so we don't have to remeber to call `super()`
   }
 
-  disconnectedCallback(){
-    this.removeEventListener('click', this.clickHandler);
-    this.removeEventListener('mousedown', this.mousedownHandler);
-    this.removeEventListener('focusin', this.focusHandler);
+  disconnected() {
+    // Disconnected callback work goes here - syntactic sugar SkateJS provides so we don't have to remeber to call `super()`
   }
 
 
-  // Handle conditionally toggling state classes based on interaction. Based on https://marcysutton.com/button-focus-hell/ and https://jmperezperez.com/outline-focus-ring-a11y/ and https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2
-  mousedownHandler(event){
-    const elem = this; // Needed for scoping the setTimeout
-
-    elem.state.isMouseActive = true;
-    setTimeout(function () {
-      elem.state.isMouseActive = false;
-    }, 100);
-  }
-
-  focusHandler(event) {
-    if (this.state.isMouseActive === false) {
-      this.state.isFocused = true;
-      this.renderRoot.firstChild.classList.add('is-focused');
-
-      this.addEventListener('blur', this.blurHandler);
-    }
-  }
-
-  blurHandler(event) {
-    this.state.isFocused = false;
-    // this.render(this.props, this.state);
-    this.renderRoot.firstChild.classList.remove('is-focused');
-
-    this.removeEventListener('blur', this.blurHandler);
-  }
-
-
-  // Attach external events declaratively
-  clickHandler(event) {
-    const clickMethod = this.props.onClick;
-    const clickTarget = this.props.onClickTarget;
-
-    if (clickMethod) {
-      if (clickTarget) {
-        const elems = document.querySelectorAll(`.${clickTarget}`);
-        if (elems) {
-          elems.forEach(function (elem) {
-            if (elem[clickMethod]) {
-              elem[clickMethod]();
-            } else {
-              // @TODO: handle call to undefined method
-            }
-          });
-        }
-      } else {
-        if (this[clickMethod]) {
-          this[clickMethod]();
-        } else {
-          // @TODO: handle call to undefined method
-        }
-      }
-    }
-  }
 
   render({ props, state }) {
     // Setup the combo of classes to apply based on state + extras added
@@ -172,8 +63,7 @@ export class BoltButton extends withComponent(withPreact()) {
       this.props.iconOnly ? `c-bolt-button--icon-only` : '',
       this.props.width ? `c-bolt-button--${this.props.width}` : '',
       this.props.align ? `c-bolt-button--${this.props.align}` : 'c-bolt-button--center',
-      this.originalElem ? this.originalElem.className : '',
-      this.enableTransitions === false ? 'u-bolt-transitionless' : '',
+      this.props.disabled ? 'c-bolt-button--disabled' : '',
 
       // Test out psuedo states via prop values
       this.props.isHover ? `c-bolt-button--hover` : '',
@@ -182,71 +72,46 @@ export class BoltButton extends withComponent(withPreact()) {
     );
 
 
-    // Grab all of the original inner element's attributes & pass everything to vdom element. @TODO: move all of the logic below to @bolt/core
-    let originalProps = {};
-    if (this.originalElem && this.state.isFirstRender === true) {
+    /**
+     * Given that our base HyperHTML Class is configured to automatically organizing top level children into separate slot buckets (ie.
+     * `this.slots.default`) AND we need to apply padding styles to the <button> or <link> getting passed in, we need to identify which Dom Node in
+     * our default Slot is the one we should apply our component classes to.
+     *
+     * If for some reason a container can't be found (ex. if creating a `<bolt-button color="primary">Hello World</bolt-button>` element by hand),
+     * We'll need to generate a wrapper container + figure out if this should be a <button> or <a> tag
+    */
 
-      // Is this the 1st time rendering the button? Or subsequent renders?
-      this.state.isFirstRender = false;
-
-      if (this.useShadow){
-        this.innerHTML = this.originalElem.innerHTML;
+    let childElementIndex = null;
+    this.slots.default.forEach(function (item, i) {
+      if (item.nodeType === 1) {
+        childElementIndex = i;
       }
+    });
 
-      for (var i = 0, l = this.originalElem.attributes.length; i < l; ++i) {
-        var nodeName = this.originalElem.attributes.item(i).nodeName;
-        var nodeValue = this.originalElem.attributes.item(i).nodeValue;
-        originalProps[nodeName] = nodeValue;
-      }
+    if (childElementIndex !== null){
+      let sanitizedClasses = sanitizeBoltClasses(this.slots.default[childElementIndex]);
+      this.slots.default[childElementIndex].className = `${sanitizedClasses} ${classes}`;
     }
-
-    // Convert component props to dash-cased attributes. @TODO: move to @bolt/core as a shared util function.
-    function camelCaseToDash(myStr) {
-      return myStr.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-    }
-
-    // Select + convert the prop names from this component so we can remove from new element
-    let propsToRemove = Object.keys(this.props).map(val => camelCaseToDash(val));
-    propsToRemove.push('class');
-
-    // Loop through the original attributes on the inner element and remove the props defined by the component
-    const filteredProps = Object.keys(originalProps)
-      .filter(key => !propsToRemove.includes(key))
-      .reduce((obj, key) => {
-        obj[key] = originalProps[key];
-        return obj;
-      }, {});
-
 
     // Decide on if the rendered button tag should be a <button> or <a> tag, based on if a URL exists OR if a link was passed in from the getgo
     const hasUrl = this.props.url.length > 0 && this.props.url !== 'null';
-    const hasLinkTag = this.originalElem && this.originalElem.tagName === 'A';
+
+    // Assign default target attribute value if one isn't specified
+    const urlTarget = this.props.target && hasUrl ? this.props.target : '_self';
 
 
-    const ButtonTag = hasUrl || hasLinkTag ? 'a' : 'button';
-    const disabled = this.props.disabled ? { 'disabled': 'disabled' } : {};
-    const href = this.props.url.length > 0 && this.props.url !== 'null' ? { 'href': this.props.url } : {};
+    // Add inline <style> tag automatically if Shadow DOM is natively supported
+    return this.html`
+      ${ this.addStyles([styles, visuallyhiddenUtils]) }
 
-
-    // Depending on if the user natively supports the ShadowDom, conditionally render a slot or psuedo-slot polyfill we're manually handling here.
-    let buttonText;
-    if (this.useShadow){
-      buttonText = <slot />;
-    } else {
-      buttonText = <span className="c-bolt-button__inner" dangerouslySetInnerHTML={{ __html: this.fallbackText }} />
-    }
-
-    return (
-      <ButtonTag className={classes} {...disabled} {...href} {...filteredProps}>
-        {this.useShadow &&
-          <style>
-            {styles[0][1]}
-          </style>
-        }
-        { buttonText }
-      </ButtonTag>
-    )
+      ${
+        childElementIndex === null ? (
+          hasUrl ?
+            this.html`<a href="${this.props.url}" class="${classes}" target="${urlTarget}">${this.slots.default}</a>` :
+            this.html`<button class="${classes}">${this.slots.default}</button>`
+        )
+        : this.slots.default
+      }
+    `
   }
 }
-
-

--- a/src/_patterns/02-components/bolt-button/src/button.twig
+++ b/src/_patterns/02-components/bolt-button/src/button.twig
@@ -174,6 +174,10 @@
     {% if rounded %} rounded=" {{ rounded }}" {% endif %}
     {% if iconOnly %} icon-only="true" {% endif %}
     {% if disabled == true %} disabled {% endif %}
+
+    {# Failsafe to manually switch off Shadow DOM encapsulation #}
+    {% if noShadow %} no-shadow {% endif %}
+
     {% if target or attributes['target'] %} target="{{ target | default(attributes['target']) }}" {% endif %}
 
 

--- a/src/_patterns/02-components/bolt-button/src/button.twig
+++ b/src/_patterns/02-components/bolt-button/src/button.twig
@@ -145,6 +145,10 @@
 {% endif %}
 
 
+{# shorthand for manually setting HTML attribute `type` such as submit or reset #}
+{% if type %}
+  {% set attributes = attributes.setAttribute("type", type) %}
+{% endif %}
 
 {% set classes = [
   baseClass,

--- a/src/_patterns/02-components/bolt-button/src/button.twig
+++ b/src/_patterns/02-components/bolt-button/src/button.twig
@@ -164,9 +164,7 @@
   {% set attributes = attributes.setAttribute("disabled", true) %}
 {% endif %}
 
-
-{# set iconpos = iconpos | default("right") #}
-
+{# Set up the custom element's prop values based on the params passed into the Twig template - used to hydrate the component's initial state and appearance once the Button Component's JavaScript kicks in #}
  <bolt-button
     {% if align %} align="{{ align }}" {% endif %}
     {% if style %} color="{{ style }}" {% endif %}

--- a/src/_patterns/02-components/bolt-button/src/button.twig
+++ b/src/_patterns/02-components/bolt-button/src/button.twig
@@ -199,16 +199,21 @@
     {# workaround to still allow external utility classes to get added (ex. for spacing or layout tweaks) while still encapsulating internal styling #}
     {% if utils %} class="{{ utils|join(' ') }}"{% endif %}
   >
-    <span class="{{ "#{baseClass}__item #{baseClass}__item-text" }} {% if iconOnly %}u-bolt-visuallyhidden{% endif %}">{{ text }}</span>
 
 
   {# choose a semantic <a> tag or <button> tag for better accessibility, depending on whether or not a url is getting passed along #}
   <{{ tag }} {{ attributes.addClass('c-bolt-button__root') | without('on-click') | without('on-click-target') }}>
 
+    {# Add component-specific classes to a Bolt temp element that gets removed and replaced by it's children once the JS kicks in #}
+    <replace-with-children class="{{ classes|join(' ') }}">
+      <span class="{{ "#{baseClass}__item" }} {{ iconOnly ? 'u-bolt-visuallyhidden' : '' }}">{{ text }}</span>
+
       {% if icon %}
-      <span class="{{ "#{baseClass}__icon" }} {% if iconOnly %}u-bolt-margin-left-none {% endif %}">
+        <span class="{{ "#{baseClass}__icon" }}">
           {% include "@bolt/icon.twig" with icon only %}
         </span>
       {% endif %}
+    </replace-with-children>
+
   </{{ tag }}>
 </bolt-button>

--- a/src/_patterns/02-components/bolt-button/src/button.twig
+++ b/src/_patterns/02-components/bolt-button/src/button.twig
@@ -199,8 +199,11 @@
     {# workaround to still allow external utility classes to get added (ex. for spacing or layout tweaks) while still encapsulating internal styling #}
     {% if utils %} class="{{ utils|join(' ') }}"{% endif %}
   >
-  <{{ tag }} {{ attributes.addClass(classes) }}>
     <span class="{{ "#{baseClass}__item #{baseClass}__item-text" }} {% if iconOnly %}u-bolt-visuallyhidden{% endif %}">{{ text }}</span>
+
+
+  {# choose a semantic <a> tag or <button> tag for better accessibility, depending on whether or not a url is getting passed along #}
+  <{{ tag }} {{ attributes.addClass('c-bolt-button__root') | without('on-click') | without('on-click-target') }}>
 
       {% if icon %}
       <span class="{{ "#{baseClass}__icon" }} {% if iconOnly %}u-bolt-margin-left-none {% endif %}">

--- a/src/_patterns/02-components/bolt-button/src/button.twig
+++ b/src/_patterns/02-components/bolt-button/src/button.twig
@@ -105,6 +105,7 @@
   "additionalProperties": false
 } %}
 
+{# re-assign old itemAlignment paramater to the new `align` name that's replacing it; avoids breaking change till post v1.0 #}
 {% if itemAlignment %}
   {% if itemAlignment == "start" %}
     {% set itemAlignment = "left" %}
@@ -113,6 +114,7 @@
   {% set align = itemAlignment %}
 {% endif %}
 
+{# set up psuedo self-validation by limiting param values to what's specifically allowed in the component schema #}
 {% set alignOptions = schema.properties.align.enum %}
 {% set roundedOptions = schema.properties.rounded.enum %}
 {% set sizeOptions = schema.properties.size.enum %}
@@ -121,6 +123,7 @@
 {% set widthOptions = schema.properties.width.enum %}
 
 
+{# check if the value set to a prop is allowed or defined. if not, default to the default value specified in the component's schema (if one exists) #}
 {% set align =  align in alignOptions ? align : schema.properties.align.default %}
 {% set rounded = rounded in roundedOptions ? rounded : schema.properties.rounded.default %}
 {% set size = size in sizeOptions ? size : schema.properties.size.default %}

--- a/src/_patterns/02-components/bolt-button/src/button.twig
+++ b/src/_patterns/02-components/bolt-button/src/button.twig
@@ -167,24 +167,47 @@
 
 {# set iconpos = iconpos | default("right") #}
 
-<bolt-button
-  {% if align %} align="{{ align }}" {% endif %}
-  {% if style %} color="{{ style }}" {% endif %}
-  {% if size %} size="{{ size }}" {% endif %}
+ <bolt-button
+    {% if align %} align="{{ align }}" {% endif %}
+    {% if style %} color="{{ style }}" {% endif %}
+    {% if size %} size="{{ size }}" {% endif %}
   {% if url %} url="{{ url }}" {% endif %}
-  {% if width %} width="{{ width }}" {% endif %}
-  {% if rounded %} rounded=" {{ rounded }}" {% endif %}
-  {% if iconOnly %} icon-only="true" {% endif %}
-  {% if disabled == true %} disabled {% endif %}
-  {{ attributes | without('class') }}
->
+    {% if width %} width="{{ width }}" {% endif %}
+    {% if rounded %} rounded=" {{ rounded }}" {% endif %}
+    {% if iconOnly %} icon-only="true" {% endif %}
+    {% if disabled == true %} disabled {% endif %}
+    {% if target or attributes['target'] %} target="{{ target | default(attributes['target']) }}" {% endif %}
+
+
+    {# todo: rename on-click + on-click-target to only allow onClick + onClickTarget to unify the prop syntax; deprecate adding these via attributes #}
+    {% if onClick or attributes['on-click'] %} on-click="{{ onClick | default(attributes['on-click']) }}" {% endif %}
+    {% if onClickTarget or attributes['on-click-target'] %} on-click-target="{{ onClickTarget | default(attributes['on-click-target']) }}" {% endif %}
+
+
+    {#
+      @todo: create Twig function to translate shorthand utility class references to actual classnames
+      For example:
+
+      {% include "@bolt/button.twig' with {
+        text: "Example Button",
+        color: "primary",
+        utils: [
+          "-mb-sm", --> small negative margin bottom spacing
+          "mt-md"   --> medium margin top spacing
+        ]
+      } %}
+    #}
+    {# @todo: share `utils` prop across all Twig components #}
+    {# workaround to still allow external utility classes to get added (ex. for spacing or layout tweaks) while still encapsulating internal styling #}
+    {% if utils %} class="{{ utils|join(' ') }}"{% endif %}
+  >
   <{{ tag }} {{ attributes.addClass(classes) }}>
     <span class="{{ "#{baseClass}__item #{baseClass}__item-text" }} {% if iconOnly %}u-bolt-visuallyhidden{% endif %}">{{ text }}</span>
 
-    {% if icon %}
+      {% if icon %}
       <span class="{{ "#{baseClass}__icon" }} {% if iconOnly %}u-bolt-margin-left-none {% endif %}">
-        {% include "@bolt/icon.twig" with icon only %}
-      </span>
-    {% endif %}
+          {% include "@bolt/icon.twig" with icon only %}
+        </span>
+      {% endif %}
   </{{ tag }}>
 </bolt-button>

--- a/src/_patterns/02-components/bolt-button/src/link.scss
+++ b/src/_patterns/02-components/bolt-button/src/link.scss
@@ -1,0 +1,33 @@
+// Links
+.c-bolt-link {
+  @include bolt-button-reset;
+  display: inline-block;
+  display: inline-flex;
+  align-items: center; // So icons are vertically centered
+  text-decoration: underline;
+  transition: all $bolt-button-transition;
+}
+
+
+.c-bolt-link--headline {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  color: var(--bolt-theme-heading-link-default, --bolt-theme-text);
+}
+
+.c-bolt-link--headline:hover {
+  color: inherit;
+  text-decoration: underline;
+  color: var(--bolt-theme-heading-link-hover, --bolt-theme-text);
+}
+
+.c-bolt-link--headline:active {
+  color: inherit;
+  color: var(--bolt-theme-heading-link-active, --bolt-theme-text);
+}
+
+.c-bolt-link--headline:visited {
+  color: inherit;
+  color: var(--bolt-theme-heading-link-visited, --bolt-theme-text);
+}

--- a/src/_patterns/02-components/bolt-icon/src/icon.scss
+++ b/src/_patterns/02-components/bolt-icon/src/icon.scss
@@ -10,6 +10,8 @@ bolt-icon {
   // display: inline-flex;
   color: inherit;
   color: var(--bolt-color-icon, inherit);
+  width: 1em; // Default icon size if size prop not specified
+  height: 1em; // Default icon size if size prop not specified
 
   &:not(:resolved){
     padding-bottom: 100%; // Default square icons

--- a/src/_patterns/02-components/bolt-video/src/_videojs-enhancements.scss
+++ b/src/_patterns/02-components/bolt-video/src/_videojs-enhancements.scss
@@ -14,7 +14,7 @@
 }
 
 .video-js .vjs-big-play-button.vjs-big-play-button {
-  @include bolt-button-secondary;
+  @include bolt-button-style(secondary);
   margin-top: auto;
   margin-left: auto;
   width: 4.5rem;


### PR DESCRIPTION
@remydenton check these out when you get a chance -- all these updates below are based on the conversations we had on Friday and are meant to put a nail in the button component woes + providing you guys more flexibility while also avoiding any major breaking changes or losing out on any functionality already in place.

**TLDR:** Makes the button component do a heckofalot less (but still some) work without really changing or breaking current functionality, while also providing more control downstream on how the Button component can get configured and customized. Also fixes a couple small things in the process to boot.

^ also, the HyperHTML renderer mentioned below, if this PR checks out, is my go-to workaround for addressing some additional JS-hook related issues @charginghawk and I have chatted about (fallout relating to the IE 11 hotfix work from a couple weeks ago) as this rendering approach doesn't require us to load the ShadyDom polyfill while still allowing us at least some control on how children content of a component gets rendered (without breaking existing JS hooks *fingers crossed*).

**Longer version:**

### Button Twig Template Updates
- Removes the duplicate attributes object on the Button component
- Updates the button component custom element to check for on-click and on-click-target params specified while still supporting the previous attributes object way of adding these
- Adds shorthand for specifying button type attribute
- Adds the `target` attribute to the button component if specified (used in dynamically created inner tag)
- Add a new `utils` prop to provide a workaround if utility classes need to get manually added to outer custom element
- Updating button component internal styling to apply component-specific styling separate from the link or button being added
- (Also on the JS-side of things) Adds a new `<replace-with-children>` custom element that gives us a safe, repeatable place to store and render CSS classes on a component prior to any JS kicking in. The best part of this is when this does kick in, the element itself gets removed yet it's children stay precisely in place

### Button JavaScript Logic Updates
- Scales back the Button component's JS to do a heck of a lot less work
- Moves our declarative click handler to a standalone function to apply to give us the ability to tack on this logic to multiple components without having to duplicating JavaScript logic
- Workaround to setting innerHTML or using `<slots>`. Adds in a new alternative (yet still super lightweight) component renderer, HyperHTML, as a Plan B option if a lot of internal DOM manipulations are necessary prior to things getting rendered (ie. as is the case for the Button Component) - temporary solution we can run with till we have a more robust solution of doing this via Preact (or similar equivalents such as snabbdom
- Add a new `noShadow` fallback option in our Button component's Twig template + JS to provide a workaround to manually disabling Shadow DOM encapsulation if **absolutely necessary** in specific use cases

### Button Sass Updates
- Moves a sizable amount of Button component Sass logic into Sass mixins as another potential route for providing Button component-like functionality in Bolt without forcing everyone down a one-size-fits-all path
- Breaks out the button component's similar-but-different link component styling into separate partial
- Update the video component's CSS to use new Button mixin naming convention
- Add visually hidden utility class as dependency to button component -- used in icon-only buttons
- Documentation: adds in additional button component test cases -- including buttons to submit forms -- as smoke tests for the updated button component

### Misc Updates
- Moves component renderers into separate folder in Bolt core
- Fix: add default icon size height and width to match pre-js behavior of icons with sizes defined