### PR TITLE
Adding option for enabling WebPack Dev Server

### DIFF
--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -35,6 +35,9 @@ function updateConfig(options, programInstance) {
       ? config.openServerAtStart
       : options.open;
 
+    config.webpackDevServer = typeof options.webpackDevServer === 'undefined'
+      ? config.webpackDevServer
+      : options.webpackDevServer;
 
     config.quick = typeof options.quick === 'undefined'
       ? config.quick
@@ -45,6 +48,7 @@ function updateConfig(options, programInstance) {
 
   const config = configStore.getConfig();
   log.dim(`Verbosity: ${config.verbosity}`);
+  log.dim(`WebPack Dev Server: ${config.webpackDevServer}`);
   if (config.verbosity > 2){
     log.dim(`Opening browser: ${config.openServerAtStart}`);
     log.dim(`Quick mode: ${config.quick}`);
@@ -78,6 +82,7 @@ program
   .command('serve')
   .description('Spin up local server')
   .option('-O, --open', configSchema.properties.openServerAtStart.description)
+  .option('--webpack-dev-server', configSchema.properties.webpackDevServer.description)
   .action((options) => {
     updateConfig(options, program);
     require('./tasks/task-collections').serve();
@@ -101,6 +106,7 @@ program
   .command('start')
   .option('-O, --open', configSchema.properties.openServerAtStart.description)
   .option('-Q, --quick', configSchema.properties.quick.description)
+  .option('--webpack-dev-server', configSchema.properties.webpackDevServer.description)
   .action((options) => {
     updateConfig(options, program);
     require('./tasks/task-collections').start();

--- a/packages/build-tools/tasks/server-tasks.js
+++ b/packages/build-tools/tasks/server-tasks.js
@@ -9,21 +9,25 @@ const serverConfig = {
   open: config.openServerAtStart,
   startPath: '/index.html', // Since `/` doesn't do anything and we want to avoid double browserSync notifications from the very beginning
   host: 'localhost',
-  port: 3000,
-
-  // proxy the Webpack Dev Server endpoint
-  // through BrowserSync
-  proxy: 'http://localhost:8080/',
+  
   snippetOptions: {
     blacklist: ['/index.html', '/', '/?*'] // prevents double browsersync
   }
 };
 
-if (config.env === 'pl') {
-  // https://www.browsersync.io/docs/options#option-server
-  serverConfig.serveStatic = [];
-  serverConfig.serveStatic.push(config.srcDir);
-  serverConfig.serveStatic.push(config.wwwDir);
+if (config.webpackDevServer) {
+  // proxy the Webpack Dev Server endpoint
+  serverConfig.proxy = 'http://localhost:8080/';
+  if (config.env === 'pl') {
+    // https://www.browsersync.io/docs/options#option-server
+    serverConfig.serveStatic = [];
+    serverConfig.serveStatic.push(config.srcDir);
+    serverConfig.serveStatic.push(config.wwwDir);
+  }
+} else {
+  serverConfig.server = [
+    config.wwwDir,
+  ];
 }
 
 function serve() {

--- a/packages/build-tools/tasks/task-collections.js
+++ b/packages/build-tools/tasks/task-collections.js
@@ -40,7 +40,9 @@ async function serve() {
     const serverTasks = [];
     if (config.wwwDir) {
       serverTasks.push(extraTasks.server.serve());
-      serverTasks.push(webpackTasks.server());
+      if (config.webpackDevServer) {
+        serverTasks.push(webpackTasks.server());
+      }
     }
     return Promise.all(serverTasks);
   } catch (error) {

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -19,6 +19,7 @@ const defaultConfig = {
   verbosity: configSchema.properties.verbosity.default,
   openServerAtStart: configSchema.properties.openServerAtStart.default,
   quick: configSchema.properties.quick.default,
+  webpackDevServer: configSchema.properties.webpackDevServer.default
 };
 
 function getEnvVarsConfig() {

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -29,6 +29,10 @@
       type: string
       title: Path to server root
       description: "Where static files are served from. The wwwDir config specifies the public web distribution directory. This directory is commonly the root directory for a server, where all static files can be served. This directory is built and rebuilt directly from the source files. Note: We recommend this directory is not committed to a repository."
+    webpackDevServer:
+      type: boolean
+      default: false
+      description: Enable the WebPack Dev Server.
     dataDir:
       type: string
       description: This is the directory where generated json data files exist with information about the overall build. Defaults to `data` inside `buildDir`


### PR DESCRIPTION
This disables the WebPack Dev Server by default, which allows us to have two servers running at the same time since Browser Sync will just grab the next highest available port number. 

It can be enabled in any of these ways:

- Adding `webpackDevServer: true` to the `.boltrc.js` file
- Setting an Env Var of `bolt_webpackDevServer=true`
- Passing `--webpack-dev-server` into command