### PR TITLE
prod builds

### DIFF
--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -9,6 +9,7 @@ const configSchema = readYamlFileSync(path.join(__dirname, './utils/config.schem
 program
   .version(packageJson.version)
   .option('-C, --config-file <path>', 'Pass in a specific config file instead of default of ".boltrc.js/json".')
+  .option('--prod', configSchema.properties.prod.description)
   .option('-v, --verbosity <amount>', configSchema.properties.verbosity.description, parseInt);
 
 // We need to initialize config as early as possible
@@ -43,12 +44,16 @@ function updateConfig(options, programInstance) {
       ? config.quick
       : options.quick;
 
+    config.prod = typeof program.prod === 'undefined'
+      ? config.prod
+      : program.prod;
+
     return config;
   });
 
   const config = configStore.getConfig();
   log.dim(`Verbosity: ${config.verbosity}`);
-  log.dim(`WebPack Dev Server: ${config.webpackDevServer}`);
+  log.dim(`Prod: ${config.prod}`);
   if (config.verbosity > 2){
     log.dim(`Opening browser: ${config.openServerAtStart}`);
     log.dim(`Quick mode: ${config.quick}`);

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const npmSass = require('npm-sass');
 const autoprefixer = require('autoprefixer');
 const postcssDiscardDuplicates = require('postcss-discard-duplicates');
@@ -176,7 +177,6 @@ function createConfig(config) {
       filename: "[name].js",
       publicPath: publicPath,
     },
-    devtool: 'cheap-module-eval-source-map',
     resolve: {
       extensions: [".js", ".jsx", ".json", ".svg", ".scss"]
     },
@@ -242,9 +242,6 @@ function createConfig(config) {
         }
       }),
       new webpack.optimize.ModuleConcatenationPlugin(),
-      new webpack.DefinePlugin({
-        'process.env.NODE_ENV': process.env.NODE_ENV === 'production' ? JSON.stringify(process.env.NODE_ENV) : JSON.stringify('development'),
-      }),
       new webpack.ProvidePlugin({
         h: 'preact',
         Promise: 'es6-promise'
@@ -255,6 +252,24 @@ function createConfig(config) {
       // new webpack.ProgressPlugin({ profile: false }),
     ],
   };
+
+  if (config.prod) {
+    webpackConfig.plugins.push(new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }));
+
+    // https://webpack.js.org/plugins/uglifyjs-webpack-plugin/
+    webpackConfig.plugins.push(new UglifyJsPlugin({
+      sourceMap: true,
+    }));
+
+    // @todo Evaluate best source map approach for production
+    webpackConfig.devtool = 'hidden-source-map';
+  } else {// not prod
+    // @todo fix source maps
+    webpackConfig.devtool = 'cheap-module-eval-source-map';
+  }
+
 
  if (config.wwwDir) {
    webpackConfig.devServer = {

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const npmSass = require('npm-sass');
 const autoprefixer = require('autoprefixer');
 const postcssDiscardDuplicates = require('postcss-discard-duplicates');
@@ -119,7 +120,7 @@ function createConfig(config) {
         sourceMap: true,
         modules: false,
         importLoaders: true,
-        localIdentName: '[local]'
+        localIdentName: '[local]',
       }
     },
 //     {
@@ -143,7 +144,7 @@ function createConfig(config) {
       options: {
         skipWarn: true,
         compatibility: "ie9",
-        level: process.env.NODE_ENV === "production" ? 2 : 0,
+        level: config.prod ? 2 : 0,
         inline: ["remote"],
         format: 'beautify',
       }
@@ -258,9 +259,15 @@ function createConfig(config) {
       'process.env.NODE_ENV': JSON.stringify('production'),
     }));
 
-    // https://webpack.js.org/plugins/uglifyjs-webpack-plugin/
+    // Optimize JS - https://webpack.js.org/plugins/uglifyjs-webpack-plugin/
     webpackConfig.plugins.push(new UglifyJsPlugin({
       sourceMap: true,
+      parallel: true,
+    }));
+
+    // Optimize CSS - https://github.com/NMFR/optimize-css-assets-webpack-plugin
+    webpackConfig.plugins.push(new OptimizeCssAssetsPlugin({
+      canPrint: config.verbosity > 2,
     }));
 
     // @todo Evaluate best source map approach for production

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -47,6 +47,7 @@
     "mkdirp": "^0.5.1",
     "node-notifier": "^5.1.2",
     "npm-sass": "^2.2.1",
+    "optimize-css-assets-webpack-plugin": "^3.2.0",
     "ora": "^1.3.0",
     "postcss-discard-duplicates": "^2.1.0",
     "postcss-loader": "^2.0.10",

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -56,6 +56,7 @@
     "sharp": "^0.19.0",
     "string-replace-loader": "^1.3.0",
     "style-loader": "^0.19.1",
+    "uglifyjs-webpack-plugin": "^1.2.0",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0",
     "webpack-manifest-plugin": "^2.0.0-rc.1"

--- a/packages/build-tools/tasks/image-tasks.js
+++ b/packages/build-tools/tasks/image-tasks.js
@@ -13,7 +13,6 @@ const timer = require('../utils/timer');
 const ora = require('ora');
 const sharp = require('sharp');
 const config = require('../utils/config-store').getConfig();
-const isProd = process.env.NODE_ENV === 'production';
 
 // @todo Consider moving this to a place to share
 const boltImageSizes = [
@@ -49,7 +48,7 @@ async function processImage(file, set) {
   const sizes = [null, ...boltImageSizes];
 
   let originalFileBuffer;
-  if (isProd) {
+  if (config.prod) {
     // we want to read the original file once, instead of reading for each size
     originalFileBuffer = await readFile(file);
   }
@@ -71,7 +70,7 @@ async function processImage(file, set) {
       }
     }
 
-    if (isProd) {
+    if (config.prod) {
       if (isOrig) {
         await writeFile(newSizedPath, originalFileBuffer);
       } else {

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -19,7 +19,8 @@ const defaultConfig = {
   verbosity: configSchema.properties.verbosity.default,
   openServerAtStart: configSchema.properties.openServerAtStart.default,
   quick: configSchema.properties.quick.default,
-  webpackDevServer: configSchema.properties.webpackDevServer.default
+  webpackDevServer: configSchema.properties.webpackDevServer.default,
+  prod: process.env.NODE_ENV === 'production',
 };
 
 function getEnvVarsConfig() {
@@ -87,6 +88,9 @@ function updateConfig(updater) {
   // console.log('new config:');
   // console.log(newConfig);
   config = newConfig;
+  if (config.prod) {
+    process.env.NODE_ENV = 'production';
+  }
   return config;
 }
 

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -94,3 +94,7 @@
               dist:
                 type: string
                 description: The output path, which is combined with what `glob` returns.
+    prod:
+      type: boolean
+      description: Production build, will compress assets.
+      default: false


### PR DESCRIPTION
This enables prod builds. 

Doing any of the below will set `config.prod` to `true`:

- Passing in `--prod` to any `bolt` command: `bolt build --prod`, `bolt start --prod` etc. 
    - This also sets `NODE_ENV=production` (which is how PHP Twig Extensions can tap into this).
- Setting `NODE_ENV=production` 

When `config.prod` is true, then:

- WebPack will:
    - Uglify JS
    - Minimize CSS via CSSnano
    - Change the source maps setting
- Image Tasks will actually resize and compress images instead of symlinking them (former PR). 