### PR TITLE
Fix Rendering in IE 11 for 0.x Release + Replace `InnerHTML` Renderer Workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3417,14 +3417,14 @@
 		"browserslist": {
 			"version": "github:ai/browserslist#8026f589168e917f40f5690e37d1c63d77b08554",
 			"requires": {
-				"caniuse-lite": "1.0.30000809",
+				"caniuse-lite": "1.0.30000810",
 				"electron-to-chromium": "1.3.33"
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30000809",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000809.tgz",
-					"integrity": "sha512-tLn4flj2upmMsko3larTkQh21Vp9pylnNPUOhw5+mubL+67U5Fpm4UG5AutzGBc+gBIPSsPFHDynsiMWp5m46g=="
+					"version": "1.0.30000810",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz",
+					"integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA=="
 				},
 				"electron-to-chromium": {
 					"version": "1.3.33",

--- a/packages/bolt-core/polyfills/webcomponents-hi-sd-ce-pf-index.js
+++ b/packages/bolt-core/polyfills/webcomponents-hi-sd-ce-pf-index.js
@@ -5,4 +5,4 @@
  * Used in: IE 11
  */
 
-import 'document-register-element';
+import '@webcomponents/custom-elements/src/custom-elements.js';

--- a/packages/bolt-core/renderers/renderer-hyperhtml.js
+++ b/packages/bolt-core/renderers/renderer-hyperhtml.js
@@ -28,8 +28,6 @@ export function withHyperHTML(Base = class extends HTMLElement { }) {
       } else {
         this.useShadow = hasNativeShadowDomSupport;
       }
-
-      this._replaceElementWithChildren();
     }
 
     connectedCallback() {
@@ -44,18 +42,9 @@ export function withHyperHTML(Base = class extends HTMLElement { }) {
       this.removeEventListener('click', this.clickHandler);
     }
 
-
     // Attach external events declaratively
     clickHandler(event) {
       declarativeClickHandler(this);
-    }
-
-
-    _replaceElementWithChildren(){
-      const placeholderElement = this.querySelectorAll('replace-with-children')[0];
-      if (placeholderElement) {
-        placeholderElement.replaceWith(...placeholderElement.childNodes);
-      }
     }
 
 

--- a/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
+++ b/src/_patterns/01-core/05-objects/bolt-ratio-object/src/ratio.standalone.js
@@ -14,7 +14,7 @@ import {
 import styles from './ratio.scss';
 
 @define
-export class BoltRatio extends withComponent(withPreact()) {
+export class BoltRatio extends withPreact(withComponent()) {
   static is = 'bolt-ratio';
 
   static props = {

--- a/src/_patterns/02-components/bolt-band/src/band.standalone.js
+++ b/src/_patterns/02-components/bolt-band/src/band.standalone.js
@@ -4,7 +4,7 @@ import {
   define,
   props,
   withComponent,
-  withPreact,
+  withHyperHTML,
   hasNativeShadowDomSupport
 } from '@bolt/core';
 
@@ -22,7 +22,7 @@ import {
 
 
 @define
-export class BoltBand extends withComponent(withPreact()) {
+export class BoltBand extends withHyperHTML(withComponent()) {
   static is = 'bolt-band';
 
   static get observedAttributes() {
@@ -59,6 +59,10 @@ export class BoltBand extends withComponent(withPreact()) {
     * `connectedCallback()` sets up the role, event handler and initial state.
     */
   connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
     // Shim Shadow DOM styles. This needs to be run in `connectedCallback()`
     // because if you shim Custom Properties (CSS variables) the element
     // will need access to its parent node.
@@ -72,6 +76,15 @@ export class BoltBand extends withComponent(withPreact()) {
   }
 
   disconnectedCallback() {
+    if (super.disconnectedCallback) {
+      super.disconnectedCallback();
+    }
+
+    this.removeEventListener('playing', this.playHandler);
+    this.removeEventListener('pause', this.pauseHandler);
+    this.removeEventListener('ended', this.finishedHandler);
+    this.removeEventListener('close', this.collapse);
+
     this.removeEventListener('videoExpandedHeightSet', this._adjustExpandedHeightToMatchVideo);
   }
 
@@ -214,19 +227,15 @@ export class BoltBand extends withComponent(withPreact()) {
     }
   }
 
-  renderer(root, html) {
-    if (this.useShadow) {
-      super.renderer(root, html);
-    } else {
-      root.innerHTML = this.innerHTML;
-    }
-  }
-
   render() {
-    if (this.useShadow){
-      return (
+    if (this.useShadow) {
+      return this.html`
         <slot />
-      )
+      `
+    } else {
+      return this.html`
+        ${this.slots.default}
+      `
     }
   }
 }

--- a/src/_patterns/02-components/bolt-button/src/button.standalone.js
+++ b/src/_patterns/02-components/bolt-button/src/button.standalone.js
@@ -4,6 +4,7 @@ import {
   withComponent,
   css,
   hasNativeShadowDomSupport,
+  withPreact,
   withHyperHTML,
   sanitizeBoltClasses
 } from '@bolt/core';
@@ -11,6 +12,24 @@ import {
 import styles from './button.scss';
 import visuallyhiddenUtils from '@bolt/utilities-visuallyhidden/_utilities.visuallyhidden.scss';
 
+
+@define
+export class ReplaceWithChildren extends withPreact(withComponent()) {
+  static is = 'replace-with-children';
+
+  constructor(elem) {
+    super(elem);
+    this.useShadow = hasNativeShadowDomSupport;
+  }
+
+  connectedCallback(){
+    if (hasNativeShadowDomSupport){
+      this.replaceWith(...this.childNodes);
+    } else {
+      this.className = '';
+    }
+  }
+}
 
 @define
 export class BoltButton extends withHyperHTML(withComponent()) {
@@ -39,19 +58,17 @@ export class BoltButton extends withHyperHTML(withComponent()) {
     onClickTarget: props.string, // Managed by base class
   }
 
-  constructor() {
-    super();
+  constructor(elem) {
+    super(elem);
+    this.useShadow = hasNativeShadowDomSupport;
   }
 
-  connecting(){
-    // Connected callback work goes here - syntactic sugar SkateJS provides so we don't have to remeber to call `super()`
+  connecting() {
   }
 
-  disconnected() {
-    // Disconnected callback work goes here - syntactic sugar SkateJS provides so we don't have to remeber to call `super()`
+  disconnecting() {
+
   }
-
-
 
   render({ props, state }) {
     // Setup the combo of classes to apply based on state + extras added

--- a/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.standalone.js
+++ b/src/_patterns/02-components/bolt-device-viewer/src/device-viewer.standalone.js
@@ -34,7 +34,7 @@ const animationEvent = whichAnimationEvent();
 
 
 @define
-class BoltDeviceViewer extends withComponent(withPreact()) {
+class BoltDeviceViewer extends withPreact(withComponent()) {
   static is = 'bolt-device-viewer';
 
   static props = {
@@ -83,13 +83,17 @@ class BoltDeviceViewer extends withComponent(withPreact()) {
 
 
 @define
-class BoltImageZoom extends withComponent(withPreact()) {
+class BoltImageZoom extends withPreact(withComponent()) {
   static is = 'bolt-image-zoom';
 
   static props = {
     mangify: props.boolean
   }
 
+  constructor(element) {
+    super(element);
+    this.useShadow = hasNativeShadowDomSupport;
+  }
 
   /**
      * `screenElem` returns the screen element inside the device viewer
@@ -134,21 +138,7 @@ class BoltImageZoom extends withComponent(withPreact()) {
     }
   }
 
-  renderer(root, html) {
-    if (this.useShadow) {
-      super.renderer(root, html);
-    } else {
-      root.innerHTML = this.innerHTML;
-    }
-  }
 
-  render() {
-    if (this.useShadow) {
-      return (
-        <slot />
-      )
-    }
-  }
 
   connectedCallback() {
     const driftZoomImageUrl = this.querySelector('img').getAttribute('data-zoom');

--- a/src/_patterns/02-components/bolt-icon/src/icon.standalone.js
+++ b/src/_patterns/02-components/bolt-icon/src/icon.standalone.js
@@ -27,7 +27,7 @@ const colors = [
 
 
 @define
-export class BoltIcon extends withComponent(withPreact()) {
+export class BoltIcon extends withPreact(withComponent()) {
   static is = 'bolt-icon';
 
   static props = {

--- a/src/_patterns/02-components/bolt-nav-bar/src/nav-bar.standalone.js
+++ b/src/_patterns/02-components/bolt-nav-bar/src/nav-bar.standalone.js
@@ -4,6 +4,7 @@ import {
   define,
   props,
   withComponent,
+  withHyperHTML,
   withPreact,
   css,
   spacingSizes,
@@ -59,9 +60,12 @@ let gumshoeStateModule = (function () {
   return pub;
 }());
 
-// Behavior for `<bolt-nav-list>` parent container
-class BoltNavList extends withComponent(withPreact()) {
 
+@define
+export class BoltNavList extends withHyperHTML(withComponent()) {
+  static is = 'bolt-nav-list';
+
+  // Behavior for `<bolt-nav-list>` parent container
   static get observedAttributes() { return ['offset']; }
 
   constructor(element) {
@@ -75,18 +79,14 @@ class BoltNavList extends withComponent(withPreact()) {
   }
 
   render() {
-    if (hasNativeShadowDomSupport) {
-      return (
+    if (this.useShadow) {
+      return this.html`
         <slot />
-      )
-    }
-  }
-
-  renderer(root, html) {
-    if (hasNativeShadowDomSupport) {
-      super.renderer(root, html);
+      `
     } else {
-      root.innerHTML = this.innerHTML;
+      return this.html`
+         ${this.slots.default}
+      `
     }
   }
 
@@ -184,6 +184,7 @@ class BoltNavList extends withComponent(withPreact()) {
 
   // `<bolt-nav-link>` emits a custom event when the link is active
   connectedCallback() {
+    this._checkSlots();
     this._indicator = this.querySelector(indicatorElement);
     this.addEventListener('activateLink', this._onActivateLink);
     window.addEventListener('optimizedResize', this._onWindowResize);
@@ -209,13 +210,14 @@ class BoltNavList extends withComponent(withPreact()) {
     window.removeEventListener('optimizedResize', this._onWindowResize);
   }
 }
-customElements.define('bolt-nav-list', BoltNavList);
 
 
 
+@define
+export class BoltNavLink extends withHyperHTML(withComponent()) { // Behavior for `<bolt-nav-link>` children
 
-// Behavior for `<bolt-nav-link>` children
-class BoltNavLink extends withComponent(withPreact()) {
+  static is = 'bolt-nav-link';
+
   // The element reacts to changes to the `active` attribute.
   static get observedAttributes() {
     return ['active'];
@@ -278,23 +280,19 @@ class BoltNavLink extends withComponent(withPreact()) {
   }
 
   render() {
-    if (hasNativeShadowDomSupport) {
-      return (
+    if (this.useShadow) {
+      return this.html`
         <slot />
-      )
-    }
-  }
-
-
-  renderer(root, html) {
-    if (hasNativeShadowDomSupport) {
-      super.renderer(root, html);
+      `
     } else {
-      root.innerHTML = this.innerHTML;
+      return this.html`
+         ${this.slots.default}
+      `
     }
   }
 
   connectedCallback() {
+    this._checkSlots();
     this.addEventListener('click', this.onClick);
 
     // Set an initially active link if appropriate.
@@ -321,7 +319,6 @@ class BoltNavLink extends withComponent(withPreact()) {
     this.removeEventListener('click', this.onClick);
   }
 }
-customElements.define('bolt-nav-link', BoltNavLink);
 
 
 

--- a/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
+++ b/src/_patterns/02-components/brightcove-player/src/brightcove-player.standalone.js
@@ -18,7 +18,7 @@ let index = 0;
 import metaStyles from './brightcove-meta.scss';
 
 @define
-class BrightcoveMeta extends withComponent(withPreact()) {
+class BrightcoveMeta extends withPreact(withComponent()) {
   static is = 'brightcove-meta';
 
   static props = {
@@ -50,7 +50,7 @@ class BrightcoveMeta extends withComponent(withPreact()) {
 
 
 @define
-class BrightcoveVideo extends withComponent(withPreact()) {
+class BrightcoveVideo extends withPreact(withComponent()) {
   static is = 'brightcove-player';
 
   static props = {


### PR DESCRIPTION
- Swaps out the mixin order on JS classes using Preact to fix IE11 errors previously getting thrown
- Replaces the document-register-element JS polyfill for IE11 with more resilient custom-elements.js solution
- Move `<replace-with-children>` custom element logic to standalone Class + IE11 workaround
- Wire up HyperHTML renderer in a few extra places causing JS binding behavior with previous release

CC @remydenton @charginghawk   