### PR TITLE
Fix: Re-enable Webpack CSS Build Char Fix on Master

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -104,32 +104,34 @@ function createConfig(config) {
   // CSS Classes like `.u-hide\@large` were getting compiled like `.u-hide-large`.
   // Due to this bug: https://github.com/webpack-contrib/css-loader/issues/578
   // Workaround: using the `string-replace-loader` to change `\@` to our `workaroundAtValue` before passing to `css-loader`, then turning it back afterwards.
-  // const workaroundAtValue = '-theAtSymbol-';
+  const workaroundAtValue = '-theAtSymbol-';
 
   const scssLoaders = [
-//     {
-//       loader: 'string-replace-loader',
-//       query: {
-//         search: workaroundAtValue,
-//         replace: String.raw`\\@`, // needed to ensure `\` comes through
-//       },
-//     },
+    {
+      loader: 'string-replace-loader',
+      query: {
+        search: workaroundAtValue,
+        replace: String.raw`\\@`, // needed to ensure `\` comes through
+        flags: 'g'
+      },
+    },
     {
       loader: 'css-loader',
       options: {
         sourceMap: true,
-        modules: true,
+        modules: false, // needed for JS referencing classNames directly, such as critical fonts
         importLoaders: 2,
         localIdentName: '[local]',
       }
     },
-//     {
-//       loader: 'string-replace-loader',
-//       query: {
-//         search: '\\@',
-//         replace: workaroundAtValue,
-//       },
-//     },
+    {
+      loader: 'string-replace-loader',
+      query: {
+        search: /\\@/,
+        replace: workaroundAtValue,
+        flags: 'g'
+      },
+    },
     {
       loader: "postcss-loader",
       options: {


### PR DESCRIPTION
Re-enable the workaround to the `\@` character bug in the Webpack CSS Loader to work around us needing CSS modules enabled in latest build; Also updates the find and replace ever so slightly so all the breakpoint Sass suffixes are replaced properly (some were getting wiped with the original implementation switched on verbatim).  