### PR TITLE
Refactor: Clean Up, Consolidate Bolt's Spacing Utility Class

### DIFF
--- a/packages/global/styles/07-utilities/_utilities-spacing.scss
+++ b/packages/global/styles/07-utilities/_utilities-spacing.scss
@@ -1,113 +1,70 @@
 $bolt-export-data: false !global;
 
-$bolt-direction-index: 0;
 
-// @TODO: fix broken logic -- values not being output automatically as expected.
-.u-bolt-margin-none {
-  margin: 0 !important;
+// Add additional spacing size rules for handling auto and zero'd rules
+$bolt-spacing-sizes-extras: (
+  'none': 0,
+  'auto': 'auto'
+);
+
+// Merge extra size options into Sass Map of sizes that already exist, tacking on to the front
+$bolt-spacing-sizes: map-merge($bolt-spacing-sizes-extras, $bolt-spacing-sizes);
+
+
+
+
+// prefix prop name if value set
+@function bolt-prefix-prop-name($propName) {
+  @if ($propName !='') {
+    @return '-' + $propName;
+  } @else {
+    @return $propName;
+  }
 }
 
-.u-bolt-margin-right-none {
-  margin-right: 0 !important;
-}
+@mixin bolt-spacing-sizes-utils($breakpoint: null) {
+  @each $prop in $bolt-spacing-properties {
+    @for $i from 1 through length($bolt-spacing-directions) {
+      $direction: nth($bolt-spacing-directions, $i);
 
-.u-bolt-margin-left-none {
-  margin-left: 0 !important;
-}
+      @each $type in $bolt-spacing-types {
+        @each $size, $value in $bolt-spacing-sizes {
 
-.u-bolt-margin-top-none {
-  margin-top: 0 !important;
-}
+          $sizeName: bolt-prefix-prop-name($size);
+          $typeName: bolt-prefix-prop-name($type);
+          $directionName: bolt-prefix-prop-name($direction);
+          $propName: '-' + $prop;
 
-.u-bolt-margin-bottom-none {
-  margin-top: 0 !important;
-}
+          // Ex. .u-bolt-margin-left-large@small
+          // Ex. .u-bolt-margin-left-squish
+          // Ex. .u-bolt-margin-right
 
-
-.u-bolt-padding-none {
-  padding: 0 !important;
-}
-
-.u-bolt-padding-right-none {
-  padding-right: 0 !important;
-}
-
-.u-bolt-padding-left-none {
-  padding-left: 0 !important;
-}
-
-.u-bolt-padding-top-none {
-  padding-top: 0 !important;
-}
-
-.u-bolt-padding-bottom-none {
-  padding-top: 0 !important;
-}
-
-@each $property in $bolt-spacing-properties {
-  @for $i from 1 through length($bolt-spacing-directions) {
-    $direction: nth($bolt-spacing-directions, $i);
-
-    @each $type in $bolt-spacing-types {
-      @each $size, $value in $bolt-spacing-sizes {
-
-        $sizeName: $size;
-        @if ($size != '') {
-          $sizeName: '-' + $sizeName;
-        }
-
-        $typeName: $type;
-        @if ($type != '') {
-          $typeName: '-' + $typeName;
-        }
-
-        $directionName: $direction;
-        @if ($direction != '') {
-          $directionName: '-' + $directionName;
-        }
-
-        $propertyName: $property;
-        $propertyName: '-' + $propertyName;
-
-        .u-bolt#{$propertyName}#{$directionName}#{$sizeName}#{$typeName} {
-
-          $sizes: null null null null;
-          $size-index: index($bolt-spacing-directions, $direction);
-
-          @if ($direction != '') {
-            $sizes: set-nth($sizes, $size-index - 1, $size);
-          } @else {
-            $sizes: $size $size $size $size;
-          }
-
-          $normalizedSizes: _bolt-normalize-spacing-sizes($sizes, null);
-          @include _bolt-directional-property(#{$property}, false, $normalizedSizes, important);
-        }
-
-
-        // Loop over our breakpoints
-        // @TODO: consolidate the output inside this selector + the one above into a single function
-        @each $breakpoint in $breakpoints {
-          $breakpointName: nth($breakpoint, 1);
-          @include respond-to($breakpointName) {
-            .u-bolt#{$propertyName}#{$directionName}#{$sizeName}#{$typeName}\@#{$breakpointName} {
-
-              $sizes: null null null null;
-              $size-index: index($bolt-spacing-directions, $direction);
-
-              @if ($direction != '') {
-                $sizes: set-nth($sizes, $size-index - 1, $size);
-              } @else {
-                $sizes: $size $size $size $size;
-              }
-
-              $normalizedSizes: _bolt-normalize-spacing-sizes($sizes, null);
-              @include _bolt-directional-property(#{$property}, false, $normalizedSizes, important);
+          .u-bolt#{$propName}#{$directionName}#{$sizeName}#{$typeName}#{$breakpoint} {
+            $sizes: null null null null;
+            $size-index: index($bolt-spacing-directions, $direction);
+            @if ($direction !='') {
+              $sizes: set-nth($sizes, $size-index - 1, $size);
+            } @else {
+              $sizes: $size $size $size $size;
             }
+            $normalizedSizes: _bolt-normalize-spacing-sizes($sizes, null);
+
+            @include _bolt-directional-property(#{$prop}, false, $normalizedSizes, important);
           }
         }
       }
     }
+  }
+}
 
+
+
+@include bolt-spacing-sizes-utils;
+
+// Loop over our breakpoints
+@each $breakpoint in $breakpoints {
+  $breakpointName: nth($breakpoint, 1);
+  @include respond-to($breakpointName) {
+    @include bolt-spacing-sizes-utils(\@#{$breakpointName});
   }
 }


### PR DESCRIPTION
No functional changes to this technically - basically just cleaning up some tech debt with the initial implementation:

- Properly adds in `auto` and `none` values (which were previously getting hard coded in)
- Re-arranges the for-loop so breakpoints getting output are consolidated (ie. not unnecessarily duplicated) to save a couple hundred lines of outputted code ;)
- Cleans up the file for maintainability + match convention used in the partial handling width utility classes

todo (not in this PR): output negative utility class value equivalents to this

CC @mikemai2awesome @joekarasek @rockymountainhigh1943 @remydenton 