### PR TITLE
Hotfix/disable validation

### DIFF
--- a/packages/core-php/src/TwigExtensions/BoltCore.php
+++ b/packages/core-php/src/TwigExtensions/BoltCore.php
@@ -66,7 +66,7 @@ class BoltCore extends \Twig_Extension implements \Twig_Extension_InitRuntimeInt
       'bolt' => [
         'data' => $this->data,
       ],
-      'enable_json_schema_validation' => true,
+      'enable_json_schema_validation' => false,
     ];
   }
 


### PR DESCRIPTION
A quick fix to speed up PL compile. Validation was calling schema for every component (2500 times). 
@EvanLovely and I have discussed how to fix this and I am working on a proper solution (putting the schema data in the global bolt.data object). In the mean time, this will speed up compiles by !! 75% !!