### PR TITLE
Enabling HTML Beautify only on prod deploys

### DIFF
--- a/apps/pattern-lab/.patches/beautifyHTML.patch
+++ b/apps/pattern-lab/.patches/beautifyHTML.patch
@@ -7,20 +7,22 @@ index bceb814..62604aa 100644
  use \PatternLab\Timer;
  use \Symfony\Component\Finder\Finder;
 +use \Gajus\Dindent\Indenter; // Pretty-format HTML output
- 
+
  class Builder {
- 
+
 @@ -271,6 +272,14 @@ class Builder {
  				// write out the various pattern files
  				file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRendered.".html",$markupFull);
  				if (!$exportFiles) {
 +
-+					// Beautify the raw HTML before outputting so the code viewer doesn't look like a mess.
-+					$indenter = new \Gajus\Dindent\Indenter(array(
-+						'indentation_character' => '  '
-+					));
-+					$markup = $indenter->indent($markup);
-+					//$markupEngine = $indenter->indent($markupEngine);
++         if (getenv('NODE_ENV') === 'production') {
++  					// Beautify the raw HTML before outputting so the code viewer doesn't look like a mess.
++  					$indenter = new Indenter(array(
++  						'indentation_character' => '  '
++  					));
++  					$markup = $indenter->indent($markup);
++  					//$markupEngine = $indenter->indent($markupEngine);
++         }
 +
  					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixMarkupOnly.".html",$markup);
  					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".".$patternExtension,$markupEngine);


### PR DESCRIPTION
Removing this cut memory usage on Pattern Lab compiles in half. It's purpose was to pretty print the PL code viewer output.