### PR TITLE
chore: port updates to form component from 0.x

### DIFF
--- a/packages/components/bolt-form/src/elements/form-fieldset.twig
+++ b/packages/components/bolt-form/src/elements/form-fieldset.twig
@@ -7,6 +7,7 @@ Available variables:
   - legendInnerAttributes (object) - A Drupal attributes object for the element inside of legend.  This is really
       only present because it's used in Drupal and might therefore be needed.
   - legendTitle (string) - The title to display in the legend element.
+  - legendSize (enum) - A headline size to use for the legend.
   - children (renderable) - The form inputs .
   - errors (string) - Server-side errors
   - descriptionText (string) - An optional description for this fieldset
@@ -21,10 +22,10 @@ Available variables:
     {% include "@bolt/headline.twig" with {
       "text": legendTitle,
       "attributes": legendInnerAttributes,
-      "size": "small"
+      "size": legendSize|default('small')
     } only %}
   </legend>
-  <div class="c-bolt-input-list">
+  <div>
     {% if errors %}
       <div class="c-bolt-input-message c-bolt-input-message--invalid">
         {{ errors }}

--- a/packages/components/bolt-form/src/form-icons.twig
+++ b/packages/components/bolt-form/src/form-icons.twig
@@ -10,11 +10,24 @@
     </li>
 
     {% for icon in icons %}
-      <li class="o-bolt-inline-list__item">
-        <div class="c-bolt-input-icon">
-          <bolt-icon name="{{ icon }}" size="medium"></bolt-icon>
-        </div>
-      </li>
+      {% if icon == 'search' %}
+
+        {# The search icon is a special case; the icon itself needs to be a submit button #}
+        <li class="o-bolt-inline-list__item">
+          <button class="c-bolt-input-icon c-bolt-input-icon--link" type="submit">
+            <bolt-icon name="{{ icon }}" size="medium"></bolt-icon>
+          </button>
+        </li>
+
+      {% else %}
+
+        <li class="o-bolt-inline-list__item">
+          <div class="c-bolt-input-icon">
+            <bolt-icon name="{{ icon }}" size="medium"></bolt-icon>
+          </div>
+        </li>
+
+      {% endif %}
     {% endfor %}
 
   </ul>

--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -252,6 +252,7 @@ $bolt-input-transition: $bolt-transition;
     border-color: $bolt-inline-label-input-border-color;
     border-style: $bolt-inline-label-input-border-style;
     border-width: $bolt-inline-label-input-border-width;
+    background-color: $bolt-input-background-color;
   }
 
   &:after {
@@ -320,6 +321,12 @@ $bolt-input-transition: $bolt-transition;
 
     .c-bolt-inline-label__emphasize {
       @include bolt-font-weight(semibold);
+    }
+  }
+
+  &:disabled ~ .c-bolt-inline-label {
+    &:before {
+      background-color: $bolt-input-background-color--disabled;
     }
   }
 }

--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -75,7 +75,8 @@ $bolt-inline-label-input-border-width: $bolt-border-width;
 
 // Data Inputs
 $bolt-floating-label-text-scale: bolt-strip-unit($bolt-font-size--xsmall);
-$bolt-floating-label-text-color: bolt-color(indigo, light); // TODO: [Mai] This is the theme link color
+$bolt-floating-label-text-color: rgba(bolt-color(gray, xdark), 0.5); // TODO: [Denton] This is the theme text color at 66%
+$bolt-floating-label-text-color-active: bolt-color(indigo, light); // TODO: [Mai] This is the theme link color
 $bolt-floating-label-text-indent: calc(#{bolt-spacing(small)} + 2px);
 $bolt-floating-label-transition: $bolt-transition;
 
@@ -94,13 +95,16 @@ $bolt-input-border-color--invalid: bolt-color(error); // TODO: [Mai] This is the
 $bolt-input-border-width: $bolt-border-width;
 $bolt-input-border-style: $bolt-border-style;
 $bolt-input-border-radius: $bolt-border-radius;
-$bolt-input-box-shadow: bolt-color(indigo, light);
-$bolt-input-shadow-level: 'level-30';
+$bolt-input-box-shadow--focus: 0 0 0.35rem bolt-color(indigo, light);
 $bolt-input-transition: $bolt-transition;
 
 @mixin bolt-input-placeholder($color) {
   &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
     color: $color;
+
+    // Workaround for pega.com Drupal, which currently uses sanitize.css.  Once that's
+    // removed, the following line will be unnecessary.
+    opacity: 1;
   }
 
   &::-moz-placeholder { /* Firefox 19+ */
@@ -133,6 +137,11 @@ $bolt-input-transition: $bolt-transition;
   opacity: 1; // [Mai] Reset mobile Safari browser default.
   outline: none;
   transition: all $bolt-input-transition;
+
+  // Force browsers to render this using hardward acceleration.
+  // This resolves a rendering quirk seen in Chrome where the hover
+  // state would only work intermittently.
+  transform: translate3d(0, 0, 0);
 
   // Removing native controls
   -webkit-appearance: none !important;
@@ -172,7 +181,7 @@ $bolt-input-transition: $bolt-transition;
 
   &:focus,
   &:hover {
-    @include bolt-shadow($key: $bolt-input-shadow-level, $base-color: $bolt-input-box-shadow);
+    box-shadow: $bolt-input-box-shadow--focus;
   }
 
   &:focus {
@@ -209,6 +218,13 @@ $bolt-input-transition: $bolt-transition;
   & ~ .c-bolt-floating-label {
     opacity: 1;
     transform: translate3d(0, 0, 0) scale($bolt-floating-label-text-scale);
+  }
+}
+
+.c-bolt-input:focus,
+.c-bolt-custom-input.is-active {
+  & ~ .c-bolt-floating-label {
+    color: $bolt-floating-label-text-color-active;
   }
 }
 

--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -95,7 +95,8 @@ $bolt-input-border-color--invalid: bolt-color(error); // TODO: [Mai] This is the
 $bolt-input-border-width: $bolt-border-width;
 $bolt-input-border-style: $bolt-border-style;
 $bolt-input-border-radius: $bolt-border-radius;
-$bolt-input-box-shadow--focus: 0 0 0.35rem bolt-color(indigo, light);
+$bolt-input-box-shadow: bolt-color(indigo, light);
+$bolt-input-shadow-level: 'level-30';
 $bolt-input-transition: $bolt-transition;
 
 @mixin bolt-input-placeholder($color) {
@@ -181,7 +182,7 @@ $bolt-input-transition: $bolt-transition;
 
   &:focus,
   &:hover {
-    box-shadow: $bolt-input-box-shadow--focus;
+    @include bolt-shadow($key: $bolt-input-shadow-level, $base-color: $bolt-input-box-shadow);
   }
 
   &:focus {

--- a/packages/components/bolt-form/src/inputs/form-checkboxes.twig
+++ b/packages/components/bolt-form/src/inputs/form-checkboxes.twig
@@ -1,1 +1,17 @@
-<div{{ attributes.addClass('form-checkboxes') }}>{{ children }}</div>
+{#
+/**
+ * @file
+ * Theme override for a 'checkboxes' #type form element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the wrapper element.
+ * - children: The rendered checkboxes.
+ */
+#}
+
+{% set classes = [
+  'c-bolt-input-list',
+  'c-bolt-input-list--stack-spacing-none'
+] %}
+
+<div{{ attributes.addClass(classes) }}>{{ children }}</div>


### PR DESCRIPTION
This PR includes all updates made on the [feature/BK-10-forms-consolidated branch](https://github.com/bolt-design-system/bolt/commits/feature/BK-10-forms-consolidated) since the forms components was migrated to 1.x.  The full commit messages and rationale can been seen at my link above.

Yes, I know the proper workflow would have been to make these changes to 1.x first and _then_ move them back to 0.x.  Alas, this was the easier way (since pega.com Drupal, where these fixes were needed, is all using 0.x) and I succumbed to laziness.  Please forgive me :).