### PR TITLE
Set release tag for 0.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
       "warnOnFail": false
     }
   },
+  "publishConfig": {
+    "tag": "release-0.x"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bolt-design-system/bolt.git"


### PR DESCRIPTION
This prevents any packages published from the 0.x branch from getting the `latest` tag.   It should be
standard practice to add this to package.json anytime we create a branch to support a no-longer-most-recent major version.