### PR TITLE
Decreasing the level of shadow on form inputs from 30 to 20

### DIFF
--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -97,7 +97,7 @@ $bolt-input-border-width: $bolt-border-width;
 $bolt-input-border-style: $bolt-border-style;
 $bolt-input-border-radius: $bolt-border-radius;
 $bolt-input-box-shadow: bolt-color(indigo, light);
-$bolt-input-shadow-level: 'level-30';
+$bolt-input-shadow-level: 'level-20';
 $bolt-input-transition: $bolt-transition;
 
 @mixin bolt-input-placeholder($color) {


### PR DESCRIPTION
The shadow is HUGE! This decreases it down to a similar level as what the design mockup had.