### PR TITLE
Fix: Vertically Center Ratio Object Content

### DIFF
--- a/packages/global/styles/05-objects/objects-ratio/ratio.scss
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.scss
@@ -5,6 +5,7 @@
 .o-bolt-ratio,
 bolt-ratio {
   display: inline-block;
+  vertical-align: middle; // Prevents the average background color from sometimes showing up unexpectedly due to the image being top aligned when it should have been vertically centered.
   position: relative;
   width: 100%;
   overflow: hidden; // Hide placeholder blurred images from leaking through


### PR DESCRIPTION
Update the ratio object to vertically align content by default. Prevents instances where nested image content alignment mis-matches with background container (ie. average background color / placeholder image doesn't match with the actual image itself).

Thanks @mikemai2awesome for pointing out this one to me!