### PR TITLE
Bolt Versions in Data

### DIFF
--- a/apps/bolt-site/templates/home.twig
+++ b/apps/bolt-site/templates/home.twig
@@ -16,7 +16,7 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-2/3@small" %}
         {% include "@bolt/eyebrow.twig" with {
-          text: "v1.0.0-rc.9"
+          text: bolt.data.fullManifest.version,
         } only %}
 
         {% include "@bolt/headline.twig" with {

--- a/apps/drupal-lab/composer.json
+++ b/apps/drupal-lab/composer.json
@@ -23,8 +23,7 @@
     }
   ],
   "require": {
-    "bolt-design-system/bolt_connect": "^1.0@RC",
-    "bolt-design-system/core-php": "^1.0@RC",
+    "bolt-design-system/bolt_connect": "*",
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "^1.6",
     "drupal-composer/drupal-scaffold": "^2.2",

--- a/packages/build-tools/utils/manifest.js
+++ b/packages/build-tools/utils/manifest.js
@@ -6,9 +6,11 @@ const writeFile = promisify(fs.writeFile);
 const {getDataFile} = require('./yaml');
 const path = require('path');
 const config = require('./config-store').getConfig();
+const pkg = require('../package.json');
 
 let boltManifest = {
   name: 'Bolt Manifest',
+  version: pkg.version,
   components: {
     global: [],
     individual: [],

--- a/packages/core-php/src/TwigExtensions/BoltCore.php
+++ b/packages/core-php/src/TwigExtensions/BoltCore.php
@@ -13,6 +13,16 @@ use \Shudrum\Component\ArrayFinder\ArrayFinder; // https://github.com/Shudrum/Ar
 class BoltCore extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface {
 
   public $data = [];
+  public $version;
+
+  function __construct() {
+    try {
+      $composer_json = json_decode(file_get_contents(Path::join(__DIR__, '../../composer.json')), true);
+      $this->version = $composer_json['version'];
+    } catch(\Exception $e) {
+      // do nothing if this fails
+    }
+  }
 
   function initRuntime(\Twig_Environment $env) {
     try {

--- a/packages/drupal-modules/bolt_connect/bolt_connect.info.yml
+++ b/packages/drupal-modules/bolt_connect/bolt_connect.info.yml
@@ -2,3 +2,4 @@ name: Bolt Connect
 type: module
 description: Connects Drupal to the Bolt Design System
 core: 8.x
+configure: bolt_connect.config_form

--- a/packages/drupal-modules/bolt_connect/composer.json
+++ b/packages/drupal-modules/bolt_connect/composer.json
@@ -24,7 +24,7 @@
     }
   },
   "require": {
-    "bolt-design-system/core-php": "*",
+    "bolt-design-system/core-php": "1.0.0-rc.9",
     "basaltinc/twig-tools": "^1.4.0",
     "webmozart/path-util": "^2.3"
   }

--- a/scripts/update-php-package-versions.js
+++ b/scripts/update-php-package-versions.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const lernaVersion = require(path.join(__dirname, '../lerna.json')).version;
+
+const corePhpPath = path.join(__dirname, '../packages/core-php/composer.json');
+const corePhp = require(corePhpPath);
+corePhp.version = lernaVersion;
+fs.writeFileSync(corePhpPath, JSON.stringify(corePhp, null, '  '));
+
+const boltConnectPath = path.join(__dirname, '../packages/drupal-modules/bolt_connect/composer.json');
+const boltConnect = require(boltConnectPath);
+boltConnect.version = lernaVersion;
+boltConnect.require['bolt-design-system/core-php'] = lernaVersion;
+fs.writeFileSync(boltConnectPath, JSON.stringify(boltConnect, null, '  '));
+
+console.log('Updated Composer packages to latest Lerna version');


### PR DESCRIPTION
Can now get to the version of the build tools (which is same version as all bolt components) by hitting `bolt.data.fullManifest.version`.

Can also get to the version of core-php by hitting `BoltCore->version`.

This also tightens how `bolt_connect` pulls in `core-php` by specifying the exact version.

The end goal is to make sure that the components pulled in via NPM and the PHP packages pulled in via Packagist are the same version.