### PR TITLE
Add Monorepo Pre-Publishing Test for PublishConfig

### DIFF
--- a/apps/bolt-site/content/20-docs/40-guides/10-install-component.md
+++ b/apps/bolt-site/content/20-docs/40-guides/10-install-component.md
@@ -1,27 +1,148 @@
 ---
-title: Installing a Component
+title: Adding a new component
 ---
 
-Install any Bolt Component via `npm` as it's docs suggest. If you were going to install the Card, you'd run:
+When building out a new component, make sure you take a look at some other existing components to get a sense of the coding standards and typical component structure in Bolt. The goal here is to have new and existing components feel just consistant and conherent - nothing should stick out like a sore thumb!
 
-```bash
-npm install --save @bolt/components-card
+Additionally, *all* new components must include the following config within their `package.json`:
+
+```
+"publishConfig": {
+  "access": "public"
+}
 ```
 
-Then add it to `.boltrc.js`:
+This is required so lerna can successfully publish Bolt's packages to NPM!
 
-```diff
-module.exports = {
-  buildDir: 'www/build',
-  components: {
-    global: [
-+     '@bolt/components-card', 
-    ],
-    individual: [
-    ],
+
+Below you'll find a step-by-step guide to walk through the process of adding a new component to the Bolt ecosystem.
+
+**<u>Step 1</u>:**  Create a new dir under `/packages/components/[bolt-NEW-COMPONENT]`
+
+**<u>Step 2</u>:** `cd` into the new dir and create a new `package.json` in the new dir:
+```
+{
+  "name": "@bolt/[NEW-COMPONENT]",
+  "description": "BLANK Component in Bolt",
+  "version": "0.0.0",
+  "homepage": "https://bolt-design-system.com",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bolt-design-system/bolt/"
   },
-};
+  "bugs": {
+    "url": "https://github.com/bolt-design-system/bolt/issues"
+  },
+  "style": "src/[COMPONENT].scss",
+  "main": "src/[COMPONENT].js",
+  "twig": "src/[COMPONENT].twig",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@bolt/core": "0.0.0"
+  }
+}
+```
+**Notes:**
+- Ensure you're ONLY adding the assets needed (e.g. if you don't need JavaScript then don't add `"main": "src/[COMPONENT].js"`)
+- Make sure to add any required Bolt components to `dependencies`
+
+**<u>Step 3</u>:** Add your necessary SCSS and JS files to `[bolt-NEW-COMPONENT]/src/`
+
+- Make sure all are reflected within `package.json`
+- Within your main scss file be sure to import core styles: `@import '@bolt/core';`
+- Within your main JS file be sure to include the pollyfillLoader:
+
+```
+import { polyfillLoader } from '@bolt/core';
+
+polyfillLoader.then((res) => {
+  import('./COMPONENT.standalone.js');
+});
 ```
 
-Continue to do so with as many components as you'd like.
+**<u>Step 4</u>:** Add your necessary Twig files to `[bolt-NEW-COMPONENT]/src/`
 
+- Be sure to follow the general coding style and practices of the Bolt design system (review other components for reference)
+
+**<u>Step 5</u>:** Add a new `README.md` at the root of your component, next to `package.json` (with pertinent details)
+
+- A description of the component's functionality should reside at the very top of the readme
+- Be sure to review an existing readme and include the "Install via NPM" instructions
+- Consider adding a "description" section as well as a "best practices" bullet list
+
+**<u>Step 6</u>:** In the `package.json` file in the root of the Bolt repo, add the new component's folder path to the `workspaces` key. This tells Lerna and Yarn where to look when installing and symlinking together the different packages that make up the Bolt codebase (**hint:** that's what happens when running `npm run bootstrap`)
+
+```
+"workspaces": [
+    "packages/components/bolt-action-blocks",
+    "packages/components/bolt-[COMPONENT-FOLDER-NAME]",
+   ...
+]
+```
+
+**<u>Step 7</u>:** Add component to `package.json` AND `.boltrc.js` within the Pattern Lab dir `/apps/pattern-lab/`
+
+**<u>Step 8</u>:** Build the things! `cd` to the root and run `npm run bootstrap`
+
+- This command will install your references to the new component and will allow you to begin to build/test your new component within Pattern Lab.
+
+**<u>Step 9</u>:** Create a new dir for your component within `/apps/pattern-lab/src/_patterns/02-components/` and add a new "docs" twig file, named like `00-COMPONENT-docs.twig`:
+
+```
+{% set schema = get_data('@bolt-components-COMPONENT/NEW-COMPONENT.schema.yml') %}
+{% set code %}
+  {% verbatim %}
+    {# component implementation example here #}
+  {% endverbatim %}
+{% endset %}
+
+{% include '@utils/docs.twig' with {
+  schema: schema,
+  code: code,
+  readmeFile: '@bolt-components-COMPONENT/README.md',
+} only %}
+```
+
+**<u>Step 10</u>:** Create a new `[NEW-COMPONENT].schema.yml` file within the component dir `/packages/components/[bolt-NEW-COMPONENT]`:
+
+```
+$schema: http://json-schema.org/draft-04/schema#
+title: COMPONENT NAME
+type: object
+required:
+  - src
+  - alt
+properties:
+  sources:
+    type: array
+    description: 'Social media sources to share to'
+    enum:
+      - 'facebook'
+      - 'twitter'
+      - 'linkedin'
+``` 
+
+- <u>Note</u>: that the `required` properties are called out at the top of the file before the component `properties` get set
+- <u>Tip</u>: Review other `*.schema.yml` files for common solutions in structuring data
+- If a default exists, set it within `default` for that property
+- Detailed information about schema data [found here](https://spacetelescope.github.io/understanding-json-schema/)
+
+**<u>Step 11</u>:** within the same directory as step 9 above - add your first demo component within a file named like `05-COMPONENT.twig`.
+
+- This will serve as a space for you to develop and test your new component!
+- When completed - this initial demo should be the simplest implementation of the component available.
+
+**<u>Step 12</u>:** Once you have the initial demo completed - it's time to add our schema validation to our package component within the base twig file (at the very bottom) `/packages/components/[bolt-NEW-COMPONENT]/src/[COMPONENT].twig`:
+
+```
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema('@bolt-components-COMPONENT/COMPONENT.schema.yml', _self) }}
+{% endif %}
+```
+
+- **<u>Note</u>:** Review the developer console for validation errors.
+- As you fix validation errors the process will outline how data should be correctly added
+- The final result will be a well formed schema that will both aid in data validation and generate the schema table within the Pattern Lab docs for your new component

--- a/apps/bolt-site/content/20-docs/40-guides/10-install-component.md
+++ b/apps/bolt-site/content/20-docs/40-guides/10-install-component.md
@@ -1,148 +1,27 @@
 ---
-title: Adding a new component
+title: Installing a Component
 ---
 
-When building out a new component, make sure you take a look at some other existing components to get a sense of the coding standards and typical component structure in Bolt. The goal here is to have new and existing components feel just consistant and conherent - nothing should stick out like a sore thumb!
+Install any Bolt Component via `npm` as it's docs suggest. If you were going to install the Card, you'd run:
 
-Additionally, *all* new components must include the following config within their `package.json`:
-
-```
-"publishConfig": {
-  "access": "public"
-}
+```bash
+npm install --save @bolt/components-card
 ```
 
-This is required so lerna can successfully publish Bolt's packages to NPM!
+Then add it to `.boltrc.js`:
 
-
-Below you'll find a step-by-step guide to walk through the process of adding a new component to the Bolt ecosystem.
-
-**<u>Step 1</u>:**  Create a new dir under `/packages/components/[bolt-NEW-COMPONENT]`
-
-**<u>Step 2</u>:** `cd` into the new dir and create a new `package.json` in the new dir:
-```
-{
-  "name": "@bolt/[NEW-COMPONENT]",
-  "description": "BLANK Component in Bolt",
-  "version": "0.0.0",
-  "homepage": "https://bolt-design-system.com",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bolt-design-system/bolt/"
+```diff
+module.exports = {
+  buildDir: 'www/build',
+  components: {
+    global: [
++     '@bolt/components-card', 
+    ],
+    individual: [
+    ],
   },
-  "bugs": {
-    "url": "https://github.com/bolt-design-system/bolt/issues"
-  },
-  "style": "src/[COMPONENT].scss",
-  "main": "src/[COMPONENT].js",
-  "twig": "src/[COMPONENT].twig",
-  "publishConfig": {
-    "access": "public"
-  },
-  "dependencies": {
-    "@bolt/core": "0.0.0"
-  }
-}
-```
-**Notes:**
-- Ensure you're ONLY adding the assets needed (e.g. if you don't need JavaScript then don't add `"main": "src/[COMPONENT].js"`)
-- Make sure to add any required Bolt components to `dependencies`
-
-**<u>Step 3</u>:** Add your necessary SCSS and JS files to `[bolt-NEW-COMPONENT]/src/`
-
-- Make sure all are reflected within `package.json`
-- Within your main scss file be sure to import core styles: `@import '@bolt/core';`
-- Within your main JS file be sure to include the pollyfillLoader:
-
-```
-import { polyfillLoader } from '@bolt/core';
-
-polyfillLoader.then((res) => {
-  import('./COMPONENT.standalone.js');
-});
+};
 ```
 
-**<u>Step 4</u>:** Add your necessary Twig files to `[bolt-NEW-COMPONENT]/src/`
+Continue to do so with as many components as you'd like.
 
-- Be sure to follow the general coding style and practices of the Bolt design system (review other components for reference)
-
-**<u>Step 5</u>:** Add a new `README.md` at the root of your component, next to `package.json` (with pertinent details)
-
-- A description of the component's functionality should reside at the very top of the readme
-- Be sure to review an existing readme and include the "Install via NPM" instructions
-- Consider adding a "description" section as well as a "best practices" bullet list
-
-**<u>Step 6</u>:** In the `package.json` file in the root of the Bolt repo, add the new component's folder path to the `workspaces` key. This tells Lerna and Yarn where to look when installing and symlinking together the different packages that make up the Bolt codebase (**hint:** that's what happens when running `npm run bootstrap`)
-
-```
-"workspaces": [
-    "packages/components/bolt-action-blocks",
-    "packages/components/bolt-[COMPONENT-FOLDER-NAME]",
-   ...
-]
-```
-
-**<u>Step 7</u>:** Add component to `package.json` AND `.boltrc.js` within the Pattern Lab dir `/apps/pattern-lab/`
-
-**<u>Step 8</u>:** Build the things! `cd` to the root and run `npm run bootstrap`
-
-- This command will install your references to the new component and will allow you to begin to build/test your new component within Pattern Lab.
-
-**<u>Step 9</u>:** Create a new dir for your component within `/apps/pattern-lab/src/_patterns/02-components/` and add a new "docs" twig file, named like `00-COMPONENT-docs.twig`:
-
-```
-{% set schema = get_data('@bolt-components-COMPONENT/NEW-COMPONENT.schema.yml') %}
-{% set code %}
-  {% verbatim %}
-    {# component implementation example here #}
-  {% endverbatim %}
-{% endset %}
-
-{% include '@utils/docs.twig' with {
-  schema: schema,
-  code: code,
-  readmeFile: '@bolt-components-COMPONENT/README.md',
-} only %}
-```
-
-**<u>Step 10</u>:** Create a new `[NEW-COMPONENT].schema.yml` file within the component dir `/packages/components/[bolt-NEW-COMPONENT]`:
-
-```
-$schema: http://json-schema.org/draft-04/schema#
-title: COMPONENT NAME
-type: object
-required:
-  - src
-  - alt
-properties:
-  sources:
-    type: array
-    description: 'Social media sources to share to'
-    enum:
-      - 'facebook'
-      - 'twitter'
-      - 'linkedin'
-``` 
-
-- <u>Note</u>: that the `required` properties are called out at the top of the file before the component `properties` get set
-- <u>Tip</u>: Review other `*.schema.yml` files for common solutions in structuring data
-- If a default exists, set it within `default` for that property
-- Detailed information about schema data [found here](https://spacetelescope.github.io/understanding-json-schema/)
-
-**<u>Step 11</u>:** within the same directory as step 9 above - add your first demo component within a file named like `05-COMPONENT.twig`.
-
-- This will serve as a space for you to develop and test your new component!
-- When completed - this initial demo should be the simplest implementation of the component available.
-
-**<u>Step 12</u>:** Once you have the initial demo completed - it's time to add our schema validation to our package component within the base twig file (at the very bottom) `/packages/components/[bolt-NEW-COMPONENT]/src/[COMPONENT].twig`:
-
-```
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema('@bolt-components-COMPONENT/COMPONENT.schema.yml', _self) }}
-{% endif %}
-```
-
-- **<u>Note</u>:** Review the developer console for validation errors.
-- As you fix validation errors the process will outline how data should be correctly added
-- The final result will be a well formed schema that will both aid in data validation and generate the schema table within the Pattern Lab docs for your new component

--- a/apps/bolt-site/content/20-docs/40-guides/15-Adding-a-new-component.md
+++ b/apps/bolt-site/content/20-docs/40-guides/15-Adding-a-new-component.md
@@ -1,6 +1,20 @@
 ---
 title: Adding a new component
 ---
+
+When building out a new component, make sure you take a look at some other existing components to get a sense of the coding standards and typical component structure in Bolt. The goal here is to have new and existing components feel just consistant and conherent - nothing should stick out like a sore thumb!
+
+Additionally, *all* new components must include the following config within their `package.json`:
+
+```
+"publishConfig": {
+  "access": "public"
+}
+```
+
+This is required so lerna can successfully publish Bolt's packages to NPM!
+
+
 Below you'll find a step-by-step guide to walk through the process of adding a new component to the Bolt ecosystem.
 
 **<u>Step 1</u>:**  Create a new dir under `/packages/components/[bolt-NEW-COMPONENT]`

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean:git": "git clean -xdf && rm -rf apps/**/vendor apps/**/node_modules && find . -empty -type d -delete",
     "clean:lerna": "lerna clean -Y",
     "clean": "npm-run-all --parallel clean:*",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && node scripts/monorepo-tests.js",
     "snyk-protect": "snyk protect",
     "lint:editorconfig": "editorconfig-checker --exclude-pattern './www/**/*' --exclude-pattern './**/sandbox/**/*'",
     "lint:js": "eslint 'packages/**/*.js' 'apps/**/*.js'",
@@ -83,6 +83,13 @@
     "node-fetch": "^2.0.0",
     "npm-run-all": "^4.1.2",
     "web-component-tester": "^6.3.0"
+  },
+  "dependencies": {
+    "read-pkg": "^3.0.0",
+    "read-pkg-up": "^3.0.0",
+    "p-iteration": "^1.1.5",
+    "find-pkg": "^2.0.0",
+    "assert": "^1.4.1"
   },
   "workspaces": [
     "packages/components/bolt-action-blocks",

--- a/package.json
+++ b/package.json
@@ -84,13 +84,6 @@
     "npm-run-all": "^4.1.2",
     "web-component-tester": "^6.3.0"
   },
-  "dependencies": {
-    "read-pkg": "^3.0.0",
-    "read-pkg-up": "^3.0.0",
-    "p-iteration": "^1.1.5",
-    "find-pkg": "^2.0.0",
-    "assert": "^1.4.1"
-  },
   "workspaces": [
     "packages/components/bolt-action-blocks",
     "packages/components/bolt-background-shapes",
@@ -135,6 +128,7 @@
     "packages/config-presets/config-eslint",
     "packages/config-presets/config-stylelint",
     "apps/drupal-lab/web/themes/flash",
-    "apps/*"
+    "apps/*",
+    "!apps/drupal-lab"
   ]
 }

--- a/packages/components/bolt-image/src/image.test.js
+++ b/packages/components/bolt-image/src/image.test.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const path = require('path');
 
-describe('image file output', () => {
+describe.skip('image file output', () => {
 
   test('dummy test', () => {
     expect(true).toEqual(true);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,8 @@
     "yocss": "^0.5.1"
   },
   "bugs": "https://github.com/bolt-design-system/bolt/issues",
-  "homepage": "https://bolt-design-system.com"
+  "homepage": "https://bolt-design-system.com",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/scripts/monorepo-tests.js
+++ b/scripts/monorepo-tests.js
@@ -5,12 +5,6 @@ const { promisify } = require('util');
 const readdir = promisify(fs.readdir);
 const lstat = promisify(fs.lstat);
 
-const readPkgUp = require('read-pkg-up');
-const readPkg = require('read-pkg');
-const findPkg = require('find-pkg');
-const { forEach } = require('p-iteration');
-const assert = require('assert');
-
 /**
  * Monorepo symlink checker for internal `@bolt` packages
  * Ensures every directory in `../node_modules/@bolt/` is a symbolic link, if not then, a package is being pulled from npm instead of the local repo - which causes problems.
@@ -50,41 +44,3 @@ function checkMonorepoSymlinks() {
 }
 
 checkMonorepoSymlinks();
-
-
-/**
- * Monorepo check to confirm components being published have the `publishConfig` config properly set in their package.json file.
- * This is necessary to ensure the Lerna publish to NPM doesn't unexpectedly fail mid-way due to this config option missing.
- */
-async function checkComponentPublicConfig(pkg, pkgPath) {
-  if (!pkg.private && pkg.private !== true) {
-    await assert.notEqual(typeof pkg.publishConfig, 'undefined',
-      `Please add a publishConfig to ${pkg.name}'s package.json, located at ${pkgPath}. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
-
-    await assert.equal(pkg.publishConfig.access, 'public',
-      `Please set publishConfig.access to "public" in ${pkg.name}'s package.json, located ${pkgPath}. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
-  }
-}
-
-
-/**
- * Find the package.json files for Lerna-managed packages for running checks against.
- */
-async function getComponentPackageConfigs() {
-  const rootPkg = await readPkgUp();
-  const pkgs = rootPkg.pkg.workspaces;
-  (await forEach(pkgs, async (pkg) => {
-    const pkgPath = await findPkg(pkg);
-    const pkgInfo = await readPkg(pkgPath);
-
-    try {
-      await checkComponentPublicConfig(pkgInfo, pkgPath);
-    } catch (error) {
-      console.log('🛑  Uh oh! Test for publishConfig config failed!', error);
-      process.exit(1);
-    }
-  }));
-  console.log('✅  Monorepo check that Bolt packages have a `publishConfig` config looks good!');
-}
-
-getComponentPackageConfigs();

--- a/scripts/monorepo-tests.js
+++ b/scripts/monorepo-tests.js
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const {promisify} = require('util');
+const { promisify } = require('util');
 const readdir = promisify(fs.readdir);
 const lstat = promisify(fs.lstat);
+
+const readPkgUp = require('read-pkg-up');
+const readPkg = require('read-pkg');
+const findPkg = require('find-pkg');
+const { forEach } = require('p-iteration');
+const assert = require('assert');
 
 /**
  * Monorepo symlink checker for internal `@bolt` packages
@@ -12,25 +18,23 @@ const lstat = promisify(fs.lstat);
 function checkMonorepoSymlinks() {
   const baseDir = path.resolve(__dirname, '../node_modules/@bolt');
   readdir(baseDir)
-    .then((dirNames) => {
-      return Promise.all(dirNames.map((dirName) => {
-        const item = {
-          path: path.join(baseDir, dirName),
-        };
-        return new Promise((resolve, reject) => {
-          lstat(item.path)
-            .then((stats) => {
-              item.stats = stats;
-              resolve(item);
-            })
-            .catch(reject);
-        });
-      }))
-    })
+    .then(dirNames => Promise.all(dirNames.map((dirName) => {
+      const item = {
+        path: path.join(baseDir, dirName),
+      };
+      return new Promise((resolve, reject) => {
+        lstat(item.path)
+          .then((stats) => {
+            item.stats = stats;
+            resolve(item);
+          })
+          .catch(reject);
+      });
+    })))
     .then((items) => {
       items.forEach((item) => {
         if (!item.stats.isSymbolicLink()) {
-          console.log('Error: Everything in "node_modules/@bolt/" should be a symbolic link to ensure the monorepo is set up correctly. You most likely have a version mismatch between this and something that is using it.');
+          console.log('🛑 Error: Everything in "node_modules/@bolt/" should be a symbolic link to ensure the monorepo is set up correctly. You most likely have a version mismatch between this and something that is using it.');
           console.log(item.path);
           process.exit(1);
         } else {
@@ -39,9 +43,48 @@ function checkMonorepoSymlinks() {
       });
     })
     .catch((error) => {
-      console.log('uh oh!', error);
-      process.exit(1)
+      console.log('🛑 uh oh!', error);
+      process.exit(1);
     });
+  console.log('✅  Monorepo check that `@bolt` packages are symlinked looks good!');
 }
 
 checkMonorepoSymlinks();
+
+
+/**
+ * Monorepo check to confirm components being published have the `publishConfig` config properly set in their package.json file.
+ * This is necessary to ensure the Lerna publish to NPM doesn't unexpectedly fail mid-way due to this config option missing.
+ */
+async function checkComponentPublicConfig(pkg, pkgPath) {
+  if (!pkg.private && pkg.private !== true) {
+    await assert.notEqual(typeof pkg.publishConfig, 'undefined',
+      `Please add a publishConfig to ${pkg.name}'s package.json, located at ${pkgPath}. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
+
+    await assert.equal(pkg.publishConfig.access, 'public',
+      `Please set publishConfig.access to "public" in ${pkg.name}'s package.json, located ${pkgPath}. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
+  }
+}
+
+
+/**
+ * Find the package.json files for Lerna-managed packages for running checks against.
+ */
+async function getComponentPackageConfigs() {
+  const rootPkg = await readPkgUp();
+  const pkgs = rootPkg.pkg.workspaces;
+  (await forEach(pkgs, async (pkg) => {
+    const pkgPath = await findPkg(pkg);
+    const pkgInfo = await readPkg(pkgPath);
+
+    try {
+      await checkComponentPublicConfig(pkgInfo, pkgPath);
+    } catch (error) {
+      console.log('🛑  Uh oh! Test for publishConfig config failed!', error);
+      process.exit(1);
+    }
+  }));
+  console.log('✅  Monorepo check that Bolt packages have a `publishConfig` config looks good!');
+}
+
+getComponentPackageConfigs();

--- a/scripts/monorepo.test.js
+++ b/scripts/monorepo.test.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const fs = require('fs-extra');
+const globby = require('globby');
+const rootPkg = require(path.join(__dirname, '../package.json'));
+const assert = require('assert');
+
+describe('monorepo', async () => {
+  /**
+   * Array of object containing the package.json of each monorepo package
+   * @var {Object[]}
+   */
+  let pkgs = [];
+
+  beforeAll(async () => {
+    const pkgDirs = await globby(rootPkg.workspaces);
+    const pkgPaths = pkgDirs.map(pkgDir => path.join(pkgDir, 'package.json'));
+    pkgs = await Promise.all(pkgPaths.map(async (pkgPath) => {
+      const fileString = await fs.readFile(pkgPath);
+      const pkg = JSON.parse(fileString);
+      return pkg;
+    }));
+  });
+
+  /**
+   * Monorepo check to confirm components being published have the `publishConfig` config properly set in their package.json file.
+   * This is necessary to ensure the Lerna publish to NPM doesn't unexpectedly fail mid-way due to this config option missing.
+   */
+  test('Check Component Public Config', async () => {
+    pkgs.forEach((pkg) => {
+      if (!pkg.private && pkg.private !== true) {
+        assert.ok(pkg.publishConfig !== 'undefined', `Please add a publishConfig to ${pkg.name}'s package.json. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
+
+        assert.strictEqual(pkg.publishConfig.access, 'public', `Please set publishConfig.access to "public" in ${pkg.name}'s package.json. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`)
+      }
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,7 +1204,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.1.1, assert@^1.3.0:
+assert@^1.1.1, assert@^1.3.0, assert@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
@@ -2504,6 +2504,14 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
+clipboard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.0.tgz#4661dc972fb72a4c4770b8db78aa9b1caef52b50"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -3539,6 +3547,10 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -4315,6 +4327,12 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 expect@^22.4.0:
   version "22.4.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.0.tgz#371edf1ae15b83b5bf5ec34b42f1584660a36c16"
@@ -4578,6 +4596,18 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
+
+find-file-up@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/find-file-up/-/find-file-up-2.0.1.tgz#4932dd81551af643893f8cda7453f221e3e28261"
+  dependencies:
+    resolve-dir "^1.0.1"
+
+find-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-pkg/-/find-pkg-2.0.0.tgz#3a7c35c704e11a6e5722c56e45bd7e587507735e"
+  dependencies:
+    find-file-up "^2.0.1"
 
 find-port@^1.0.1:
   version "1.0.1"
@@ -5103,6 +5133,14 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -5111,6 +5149,16 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 globals@^11.1.0:
   version "11.3.0"
@@ -5181,6 +5229,12 @@ gonzales-pe@^4.2.3:
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.2.3.tgz#41091703625433285e0aee3aa47829fc1fbeb6f2"
   dependencies:
     minimist "1.1.x"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 got@^6.7.1:
   version "6.7.1"
@@ -5413,7 +5467,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.0:
+homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -6115,7 +6169,7 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-is-windows@^1.0.2:
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -8175,6 +8229,10 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
+p-iteration@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/p-iteration/-/p-iteration-1.1.5.tgz#c8dd8e61d5bc1a151c7c7ccc2e288c0fb826eb8b"
+
 p-limit@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
@@ -9733,6 +9791,13 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -9976,6 +10041,10 @@ scss-tokenizer@^0.2.3:
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
+
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
 selenium-standalone@^6.7.0:
   version "6.12.0"
@@ -11366,6 +11435,10 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
+
 tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -12219,7 +12292,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.0.8, which@^1.2.12, which@^1.2.4, which@^1.2.9, which@^1.3.0:
+which@1, which@^1.0.8, which@^1.2.12, which@^1.2.14, which@^1.2.4, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,7 +1204,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.1.1, assert@^1.3.0, assert@^1.4.1:
+assert@^1.1.1, assert@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
@@ -4327,12 +4327,6 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
-expand-tilde@^2.0.0, expand-tilde@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
-  dependencies:
-    homedir-polyfill "^1.0.1"
-
 expect@^22.4.0:
   version "22.4.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.0.tgz#371edf1ae15b83b5bf5ec34b42f1584660a36c16"
@@ -4596,18 +4590,6 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
-
-find-file-up@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/find-file-up/-/find-file-up-2.0.1.tgz#4932dd81551af643893f8cda7453f221e3e28261"
-  dependencies:
-    resolve-dir "^1.0.1"
-
-find-pkg@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-pkg/-/find-pkg-2.0.0.tgz#3a7c35c704e11a6e5722c56e45bd7e587507735e"
-  dependencies:
-    find-file-up "^2.0.1"
 
 find-port@^1.0.1:
   version "1.0.1"
@@ -5133,14 +5115,6 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
-global-modules@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
-  dependencies:
-    global-prefix "^1.0.1"
-    is-windows "^1.0.1"
-    resolve-dir "^1.0.0"
-
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -5149,16 +5123,6 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
-
-global-prefix@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
-  dependencies:
-    expand-tilde "^2.0.2"
-    homedir-polyfill "^1.0.1"
-    ini "^1.3.4"
-    is-windows "^1.0.1"
-    which "^1.2.14"
 
 globals@^11.1.0:
   version "11.3.0"
@@ -5467,7 +5431,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
+homedir-polyfill@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -6169,7 +6133,7 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -8229,10 +8193,6 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
-p-iteration@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/p-iteration/-/p-iteration-1.1.5.tgz#c8dd8e61d5bc1a151c7c7ccc2e288c0fb826eb8b"
-
 p-limit@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
@@ -9790,13 +9750,6 @@ resolve-dir@^0.1.0:
   dependencies:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
-
-resolve-dir@^1.0.0, resolve-dir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
-  dependencies:
-    expand-tilde "^2.0.0"
-    global-modules "^1.0.0"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -12292,7 +12245,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.0.8, which@^1.2.12, which@^1.2.14, which@^1.2.4, which@^1.2.9, which@^1.3.0:
+which@1, which@^1.0.8, which@^1.2.12, which@^1.2.4, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
TLDR: add testing coverage to prevent Lerna publishing failures midway through publishing due to a config option missing from the package's package.json file.

- Adds new logic to monorepo tests to asynchronously find the locations and contents to all package.json files of packages being managed by Lerna
- Using this new script ^ - add a two tests to check that a publishConfig config option exists in each package's `package.json` file and that the config is properly set
- Update docs to the "Adding a New Component" to include info on this `publishConfig` option needed

CC @remydenton  