### PR TITLE
Moving publish config tests to Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,13 +84,6 @@
     "npm-run-all": "^4.1.2",
     "web-component-tester": "^6.3.0"
   },
-  "dependencies": {
-    "read-pkg": "^3.0.0",
-    "read-pkg-up": "^3.0.0",
-    "p-iteration": "^1.1.5",
-    "find-pkg": "^2.0.0",
-    "assert": "^1.4.1"
-  },
   "workspaces": [
     "packages/components/bolt-action-blocks",
     "packages/components/bolt-background-shapes",
@@ -135,6 +128,7 @@
     "packages/config-presets/config-eslint",
     "packages/config-presets/config-stylelint",
     "apps/drupal-lab/web/themes/flash",
-    "apps/*"
+    "apps/*",
+    "!apps/drupal-lab"
   ]
 }

--- a/packages/components/bolt-image/src/image.test.js
+++ b/packages/components/bolt-image/src/image.test.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const path = require('path');
 
-describe('image file output', () => {
+describe.skip('image file output', () => {
 
   test('dummy test', () => {
     expect(true).toEqual(true);

--- a/scripts/monorepo-tests.js
+++ b/scripts/monorepo-tests.js
@@ -5,12 +5,6 @@ const { promisify } = require('util');
 const readdir = promisify(fs.readdir);
 const lstat = promisify(fs.lstat);
 
-const readPkgUp = require('read-pkg-up');
-const readPkg = require('read-pkg');
-const findPkg = require('find-pkg');
-const { forEach } = require('p-iteration');
-const assert = require('assert');
-
 /**
  * Monorepo symlink checker for internal `@bolt` packages
  * Ensures every directory in `../node_modules/@bolt/` is a symbolic link, if not then, a package is being pulled from npm instead of the local repo - which causes problems.
@@ -50,41 +44,3 @@ function checkMonorepoSymlinks() {
 }
 
 checkMonorepoSymlinks();
-
-
-/**
- * Monorepo check to confirm components being published have the `publishConfig` config properly set in their package.json file.
- * This is necessary to ensure the Lerna publish to NPM doesn't unexpectedly fail mid-way due to this config option missing.
- */
-async function checkComponentPublicConfig(pkg, pkgPath) {
-  if (!pkg.private && pkg.private !== true) {
-    await assert.notEqual(typeof pkg.publishConfig, 'undefined',
-      `Please add a publishConfig to ${pkg.name}'s package.json, located at ${pkgPath}. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
-
-    await assert.equal(pkg.publishConfig.access, 'public',
-      `Please set publishConfig.access to "public" in ${pkg.name}'s package.json, located ${pkgPath}. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
-  }
-}
-
-
-/**
- * Find the package.json files for Lerna-managed packages for running checks against.
- */
-async function getComponentPackageConfigs() {
-  const rootPkg = await readPkgUp();
-  const pkgs = rootPkg.pkg.workspaces;
-  (await forEach(pkgs, async (pkg) => {
-    const pkgPath = await findPkg(pkg);
-    const pkgInfo = await readPkg(pkgPath);
-
-    try {
-      await checkComponentPublicConfig(pkgInfo, pkgPath);
-    } catch (error) {
-      console.log('🛑  Uh oh! Test for publishConfig config failed!', error);
-      process.exit(1);
-    }
-  }));
-  console.log('✅  Monorepo check that Bolt packages have a `publishConfig` config looks good!');
-}
-
-getComponentPackageConfigs();

--- a/scripts/monorepo.test.js
+++ b/scripts/monorepo.test.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const fs = require('fs-extra');
+const globby = require('globby');
+const rootPkg = require(path.join(__dirname, '../package.json'));
+const assert = require('assert');
+
+describe('monorepo', async () => {
+  /**
+   * Array of object containing the package.json of each monorepo package
+   * @var {Object[]}
+   */
+  let pkgs = [];
+
+  beforeAll(async () => {
+    const pkgDirs = await globby(rootPkg.workspaces);
+    const pkgPaths = pkgDirs.map(pkgDir => path.join(pkgDir, 'package.json'));
+    pkgs = await Promise.all(pkgPaths.map(async (pkgPath) => {
+      const fileString = await fs.readFile(pkgPath);
+      const pkg = JSON.parse(fileString);
+      return pkg;
+    }));
+  });
+
+  /**
+   * Monorepo check to confirm components being published have the `publishConfig` config properly set in their package.json file.
+   * This is necessary to ensure the Lerna publish to NPM doesn't unexpectedly fail mid-way due to this config option missing.
+   */
+  test('Check Component Public Config', async () => {
+    pkgs.forEach((pkg) => {
+      if (!pkg.private && pkg.private !== true) {
+        assert.ok(pkg.publishConfig !== 'undefined', `Please add a publishConfig to ${pkg.name}'s package.json. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`);
+
+        assert.strictEqual(pkg.publishConfig.access, 'public', `Please set publishConfig.access to "public" in ${pkg.name}'s package.json. Check out the Bolt Design System docs section on Adding a New Component for more info: https://bolt-design-system.com/docs/guides/adding-a-new-component.`)
+      }
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,7 +1204,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.1.1, assert@^1.3.0, assert@^1.4.1:
+assert@^1.1.1, assert@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
@@ -4327,12 +4327,6 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
-expand-tilde@^2.0.0, expand-tilde@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
-  dependencies:
-    homedir-polyfill "^1.0.1"
-
 expect@^22.4.0:
   version "22.4.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.0.tgz#371edf1ae15b83b5bf5ec34b42f1584660a36c16"
@@ -4596,18 +4590,6 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
-
-find-file-up@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/find-file-up/-/find-file-up-2.0.1.tgz#4932dd81551af643893f8cda7453f221e3e28261"
-  dependencies:
-    resolve-dir "^1.0.1"
-
-find-pkg@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-pkg/-/find-pkg-2.0.0.tgz#3a7c35c704e11a6e5722c56e45bd7e587507735e"
-  dependencies:
-    find-file-up "^2.0.1"
 
 find-port@^1.0.1:
   version "1.0.1"
@@ -5133,14 +5115,6 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
-global-modules@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
-  dependencies:
-    global-prefix "^1.0.1"
-    is-windows "^1.0.1"
-    resolve-dir "^1.0.0"
-
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -5149,16 +5123,6 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
-
-global-prefix@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
-  dependencies:
-    expand-tilde "^2.0.2"
-    homedir-polyfill "^1.0.1"
-    ini "^1.3.4"
-    is-windows "^1.0.1"
-    which "^1.2.14"
 
 globals@^11.1.0:
   version "11.3.0"
@@ -5467,7 +5431,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
+homedir-polyfill@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -6169,7 +6133,7 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -8229,10 +8193,6 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
-p-iteration@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/p-iteration/-/p-iteration-1.1.5.tgz#c8dd8e61d5bc1a151c7c7ccc2e288c0fb826eb8b"
-
 p-limit@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
@@ -9790,13 +9750,6 @@ resolve-dir@^0.1.0:
   dependencies:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
-
-resolve-dir@^1.0.0, resolve-dir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
-  dependencies:
-    expand-tilde "^2.0.0"
-    global-modules "^1.0.0"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -12292,7 +12245,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.0.8, which@^1.2.12, which@^1.2.14, which@^1.2.4, which@^1.2.9, which@^1.3.0:
+which@1, which@^1.0.8, which@^1.2.12, which@^1.2.4, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
Was thinking this should be in Jest anyway; also [`assert` is a core node module](http://nodejs.org/api/assert.html) so we don't need a new dependency for it. Let's chat soon to go over if you want.