### PR TITLE
Hotfix: Fix Ratio Object Misalignment

### DIFF
--- a/packages/global/styles/05-objects/objects-ratio/ratio.scss
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.scss
@@ -7,7 +7,10 @@ bolt-ratio {
   display: inline-block;
   vertical-align: middle; // Prevents the average background color from sometimes showing up unexpectedly due to the image being top aligned when it should have been vertically centered.
   position: relative;
+  vertical-align: middle;
   width: 100%;
+  height: 0;
+  font-size: 0; // Workaround to IE 11 adding extra whitespace
   overflow: hidden; // Hide placeholder blurred images from leaking through
 
   --aspect-ratio-width: 1;


### PR DESCRIPTION
Fixes instances @mikemai2awesome pointed out where the ratio object can become misaligned with the child content (image), causing the image and the background color shown to not perfectly match up