### PR TITLE
Hotfix: Fix Icon Component 'Contains' Method

### DIFF
--- a/packages/components/bolt-icon/src/icon.standalone.js
+++ b/packages/components/bolt-icon/src/icon.standalone.js
@@ -65,13 +65,15 @@ export class BoltIcon extends withPreact(withComponent()) {
          * The container with the class change contains this particular icon element so
          * we should double-check the color contrast values.
          */
-        if (data.target.contains(elem)) {
-          const recalculatedSecondaryColor = colorContrast(
-            rgb2hex(window.getComputedStyle(elem).getPropertyValue('color')),
-          );
+        if (data.target.contains) {
+          if (data.target.contains(elem)) {
+            const recalculatedSecondaryColor = colorContrast(
+              rgb2hex(window.getComputedStyle(elem).getPropertyValue('color')),
+            );
 
-          elem.setAttribute('contrast-color', recalculatedSecondaryColor);
-          elem.state.secondaryColor = recalculatedSecondaryColor;
+            elem.setAttribute('contrast-color', recalculatedSecondaryColor);
+            elem.state.secondaryColor = recalculatedSecondaryColor;
+          }
         }
       };
 
@@ -136,7 +138,7 @@ export class BoltIcon extends withPreact(withComponent()) {
         {background && size === 'xlarge' &&
           <span className={backgroundClasses}></span>
         }
-      </div>
+    </div>
     );
   }
 }


### PR DESCRIPTION
Fixes JS error getting thrown in the icon component if the browser (like IE 11) doesn't support the Node `contains` method and isn't properly polyfilled. 

@rockymountainhigh1943 this was the same thing we chatted about last week during cross browser testing!