### PR TITLE
Hotfix: Update Core Environmental Check, Fix Ratio Object Inner Selector

### DIFF
--- a/packages/core/utils/environment.js
+++ b/packages/core/utils/environment.js
@@ -5,4 +5,4 @@ export const IS_PROD = process.env.NODE_ENV === 'production';
 
 const { attachShadow } = HTMLElement.prototype;
 
-export const hasNativeShadowDomSupport = attachShadow && attachShadow.toString().indexOf('native code') > -1;
+export const hasNativeShadowDomSupport = (window.ShadyDOM) || (attachShadow && attachShadow.toString().indexOf('native code') > -1);

--- a/packages/global/styles/05-objects/objects-ratio/ratio.scss
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.scss
@@ -23,7 +23,7 @@ bolt-ratio {
   * 1. Fallback selector if JS isn't disabled, but hasn't kicked in yet.
   * 2. Fallback selector for browsers not supporting ::slotted(*) selector
   */
-bolt-ratio > *,
+bolt-ratio *,
 .o-bolt-ratio__inner {
   position: absolute;
   top: 0;


### PR DESCRIPTION
- Updates global Bolt Core check to treat polyfilled bowsers the same as natively supported browsers
- Also updates the Ratio Object's internal selector to work around differences in rendered HTML structure (differs slightly based on polyfills loaded).

Partially addresses the Ratio Object bug in Firefox reported by @charginghawk

Side note: two other existing PRs further button these up by addressing [vertical alignment](https://github.com/bolt-design-system/bolt/pull/565) + [re-rendering issues](https://github.com/bolt-design-system/bolt/pull/561) (ie. get rid of `.innerHTML` workarounds)