### PR TITLE
Feature/better entries

### DIFF
--- a/apps/pattern-lab/.boltrc.js
+++ b/apps/pattern-lab/.boltrc.js
@@ -31,8 +31,6 @@ module.exports = {
   },
   components: {
     global: [
-      './src/styles/pl.scss',
-      './src/scripts/pl.js',
       '@bolt/core',
       '@bolt/global',
       '@bolt/components-action-blocks',
@@ -71,7 +69,12 @@ module.exports = {
       '@bolt/components-video',
     ],
     individual: [
-      '@bolt/components-critical-fonts'
+      {
+        name: 'pl',
+        scss: './src/styles/pl.scss',
+        js: './src/scripts/pl.js',
+      },
+      '@bolt/components-critical-fonts',
     ],
   },
 };

--- a/apps/pattern-lab/src/_meta/_00-head.twig
+++ b/apps/pattern-lab/src/_meta/_00-head.twig
@@ -11,6 +11,7 @@
     {% include "@bolt-components-share/src/_share-meta-example.twig" %}
 
     <link rel="stylesheet" href="{{ assets["bolt-global.css"] }}?cachebuster="{{ cacheBuster }}" media="all" />
+    <link rel="stylesheet" href="{{ assets["pl.css"] }}?cachebuster="{{ cacheBuster }}" media="all" />
 
 
     {# @TODO: wire this up to use Critical CSS #}

--- a/apps/pattern-lab/src/_meta/_01-foot.twig
+++ b/apps/pattern-lab/src/_meta/_01-foot.twig
@@ -6,6 +6,7 @@
     {% set assets = get_data("@bolt-assets/bolt-webpack-manifest.json") %}
 
     <script src="{{ assets["bolt-global.js"] }}?cachebuster="{{ cacheBuster }}"" async></script>
+    <script src="{{ assets["pl.js"] }}?cachebuster="{{ cacheBuster }}"" async></script>
 
     {# Code syntax highlighting - https://github.com/imsky/holder #}
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -335,6 +335,9 @@ function createConfig(config) {
     // Optimize CSS - https://github.com/NMFR/optimize-css-assets-webpack-plugin
     webpackConfig.plugins.push(new OptimizeCssAssetsPlugin({
       canPrint: config.verbosity > 2,
+      cssProcessorOptions: {// passes to `cssnano`
+        zindex: false, // don't alter `z-index` values
+      },
     }));
 
     // @todo Evaluate best source map approach for production

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -64,11 +64,9 @@
       type: object
       properties:
         global:
-          oneOf:
-            - $ref: '#/definitions/componentStrings'
+          $ref: '#/definitions/components'
         individual:
-          oneOf:
-            - $ref: '#/definitions/componentStrings'
+          $ref: '#/definitions/components'
     extraTwigNamespaces:
       type: object
       title: Extra Twig Namespaces
@@ -116,8 +114,24 @@
       default: false
 
   definitions:
-    componentStrings:
+    components:
       type: array
-      uniqueItems: true
       items:
-        - type: string
+        oneOf:
+          -
+            type: string
+          -
+            type: object
+            additionalProperties: false
+            properties:
+              name:
+                type: string
+                description: 'Becomes filename: NAME.css and NAME.js'
+              scss:
+                type: string
+                title: Entry file for Sass. Import statements will be followed
+              js:
+                type: string
+                title: Entry file for JS. Import statements will be followed
+              required:
+                - name

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -64,19 +64,11 @@
       type: object
       properties:
         global:
-          type: array
-          uniqueItems: true
-          # array of objects
-          items:
-            -
-              type: string
+          oneOf:
+            - $ref: '#/definitions/componentStrings'
         individual:
-          type: array
-          uniqueItems: true
-          # array of objects
-          items:
-            -
-              type: string
+          oneOf:
+            - $ref: '#/definitions/componentStrings'
     extraTwigNamespaces:
       type: object
       title: Extra Twig Namespaces
@@ -122,3 +114,10 @@
       type: boolean
       description: Production build, will compress assets.
       default: false
+
+  definitions:
+    componentStrings:
+      type: array
+      uniqueItems: true
+      items:
+        - type: string

--- a/packages/build-tools/utils/general.js
+++ b/packages/build-tools/utils/general.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const log = require('./log');
 
 /**
  * Flatten Array

--- a/packages/build-tools/utils/manifest.js
+++ b/packages/build-tools/utils/manifest.js
@@ -19,10 +19,31 @@ let boltManifest = {
 
 /**
  * Get information about a components assets
- * @param {string} pkgName - Machine name of a component i.e. `@bolt/button` OR path to an entry file i.e. `./src/style.scss`
+ * @param {string|object} pkgName - Name of a component i.e. `@bolt/button`
+ * OR object - see `config.schema.yml` under `definitions.components.items`
  * @returns {{name, basicName: string | * | void}} - Asset info
  */
 async function getPkgInfo(pkgName) {
+  if (typeof pkgName === 'object') {
+    const info = {
+      name: pkgName.name,
+      basicName: pkgName.name,
+      assets: {},
+    };
+    if (pkgName.scss) {
+      info.assets.style = pkgName.scss;
+      info.dir = path.dirname(pkgName.scss);
+      ensureFileExists(pkgName.scss);
+    }
+    if (pkgName.js) {
+      info.assets.main = pkgName.js;
+      // yeah I know we're overwriting `dir`... got to have something though... and it's only used by PL to watch Twig
+      info.dir = path.dirname(pkgName.js);
+      ensureFileExists(pkgName.js);
+    }
+    return info;
+  }
+
   if (pkgName.endsWith('.scss') || pkgName.endsWith('.js')) {
     const pathInfo = path.parse(pkgName);
     const name = pathInfo.name + pathInfo.ext.replace('.', '-');


### PR DESCRIPTION
In `.boltrc.js` to have Bolt Build Tools compile local Sass or JS, you would do this:

```
  components: {
    global: [
       './src/styles/pl.scss',
       './src/scripts/pl.js',
       '@bolt/button',
```

Which would create `pl-scss.css` and `pl-scss.js` (useless & empty except for WebPack helper functions) and also `pl-js.css` (empty) and `pl-js.js`.

This PR changes it so you can do this:

```
  components: {
    global: [
      {
        name: 'pl',
        scss: './src/styles/pl.scss',
        js: './src/scripts/pl.js',
      },
      '@bolt/button',
```

And this will make `pl.css` and `pl.js`. Much cleaner!

I've move the `pl` assets from `global` to `individual` so we have a good test place to ensure that `individual` components don't have code that should be present in the `global` bundle. This approach is used often in Drupal for all the "libraries". 

Also have two bug fixes in here: 4030e29 & 237f212