### PR TITLE
Fix Ratio Object Hotfix

### DIFF
--- a/packages/global/styles/05-objects/objects-ratio/ratio.scss
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.scss
@@ -26,7 +26,8 @@ bolt-ratio {
   * 1. Fallback selector if JS isn't disabled, but hasn't kicked in yet.
   * 2. Fallback selector for browsers not supporting ::slotted(*) selector
   */
-bolt-ratio *,
+bolt-ratio > *,
+bolt-ratio img,
 .o-bolt-ratio__inner {
   position: absolute;
   top: 0;


### PR DESCRIPTION
Hotfix to fix ratio object hotfix

If this fix is working as expected this page should be working again in Chrome and in Firefox (the issue originally flagged in): https://bolt-design-system.com/pattern-lab/?p=components-video--show-meta