### PR TITLE
Fixing Silent Errors

### DIFF
--- a/apps/pattern-lab/core/console
+++ b/apps/pattern-lab/core/console
@@ -13,6 +13,19 @@ use \PatternLab\Console;
 use \PatternLab\Dispatcher;
 use \PatternLab\Timer;
 
+// This function will handle any PHP Errors, Warnings, or Notices and fail the compile
+// Without this, it's easy to accidentally let "PHP Notice: Array to String conversion" sneak in over time, which outputs onto the Pattern Lab page.
+set_error_handler('exceptions_error_handler');
+
+function exceptions_error_handler($severity, $message, $filename, $lineno) {
+  if (error_reporting() == 0) {
+    return;
+  }
+  if (error_reporting() & $severity) {
+    throw new ErrorException($message, 0, $severity, $filename, $lineno);
+  }
+}
+
 // check to see if json_decode exists. might be disabled in installs of PHP 5.5
 if (!function_exists("json_decode")) {
 	print "Please check that your version of PHP includes the JSON extension. It's required for Pattern Lab to run. Aborting.\n";

--- a/apps/pattern-lab/src/_patterns/02-components/button/10-button-sizes.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/10-button-sizes.twig
@@ -1,6 +1,6 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
-{% for size in schema.properties.size.enum|remove_null %}
+{% for size in schema.properties.size.enum %}
   <p>Button Size Variation: {{ size }}</p>
 
   {% include "@bolt-components-button/button.twig" with {

--- a/apps/pattern-lab/src/_patterns/02-components/button/15-button-styles.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/15-button-styles.twig
@@ -1,6 +1,6 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
-{% for style in schema.properties.style.enum|remove_null %}
+{% for style in schema.properties.style.enum %}
   <p>{{ style|capitalize }} Button States</p>
 
   {% include "@bolt-components-button/button.twig" with {

--- a/apps/pattern-lab/src/_patterns/02-components/button/25-button-widths.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/25-button-widths.twig
@@ -1,6 +1,6 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
-{% for width in schema.properties.width.enum|remove_null %}
+{% for width in schema.properties.width.enum %}
   <p>Button Width Variations: {{ width ? width : 'Default' }}</p>
 
   {% include "@bolt-components-button/button.twig" with {

--- a/apps/pattern-lab/src/_patterns/02-components/button/30-button-tags.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/30-button-tags.twig
@@ -1,6 +1,6 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
-{% for tag in schema.properties.tag.enum|remove_null %}
+{% for tag in schema.properties.tag.enum %}
   <p>Button Tag: {{ tag }}</p>
 
   {% include "@bolt-components-button/button.twig" with {

--- a/apps/pattern-lab/src/_patterns/02-components/button/35-button-align-items.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/35-button-align-items.twig
@@ -1,7 +1,7 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
 
-{% for align in schema.properties.align.enum|remove_null %}
+{% for align in schema.properties.align.enum %}
   <p>Align: {{ align }}</p>
 
   {% include "@bolt-components-button/button.twig" with {

--- a/apps/pattern-lab/src/_patterns/02-components/button/40-button-transform.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/40-button-transform.twig
@@ -1,7 +1,7 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
 
-{% for transform in schema.properties.transform.enum|remove_null %}
+{% for transform in schema.properties.transform.enum %}
   <p>Transform: {{ transform }}</p>
 
   {% include "@bolt-components-button/button.twig" with {

--- a/apps/pattern-lab/src/_patterns/02-components/headline/15-headline-align-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/headline/15-headline-align-variations.twig
@@ -1,6 +1,6 @@
 {% set schema = bolt.data.components['@bolt-components-headline'].schema %}
 
-{% for align in schema.properties.align.enum|remove_null %}
+{% for align in schema.properties.align.enum %}
   <p>Align: {{ alignmentName }}</p>
   {% include "@bolt-components-headline/headline.twig" with {
     text: "This is an example of align " ~ align,

--- a/apps/pattern-lab/src/_patterns/02-components/headline/20-headline-style-and-weight-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/headline/20-headline-style-and-weight-variations.twig
@@ -1,8 +1,8 @@
 {% set schema = bolt.data.components['@bolt-components-headline'].schema %}
 
-{% for size in schema.properties.size.enum|remove_null %}
-  {% for weight in schema.properties.weight.enum|remove_null %}
-    {% for style in schema.properties.style.enum|remove_null %}
+{% for size in schema.properties.size.enum %}
+  {% for weight in schema.properties.weight.enum %}
+    {% for style in schema.properties.style.enum %}
       {% include "@bolt-components-headline/text.twig" with {
         text: "This is " ~ weight ~ " weight and " ~ style ~ " text",
         weight: weight,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lint:style": "stylelint 'packages/**/*.scss' 'apps/**/*.scss'",
     "lint:style:fix": "npm run lint:style -- --fix",
     "lint:twig": "./packages/core-php/vendor/bin/twig-lint lint packages --only-print-errors && ./packages/core-php/vendor/bin/twig-lint lint apps --only-print-errors",
+    "lint:yaml": "yamllint 'packages/**/*.yml' --ignore='**/vendor/**'",
     "lint": "npm-run-all --continue-on-error --serial lint:*",
     "test:js": "jest",
     "test:js:watch": "jest --watch",
@@ -82,7 +83,8 @@
     "lerna": "^2.5.1",
     "node-fetch": "^2.0.0",
     "npm-run-all": "^4.1.2",
-    "web-component-tester": "^6.3.0"
+    "web-component-tester": "^6.3.0",
+    "yaml-lint": "^1.2.2"
   },
   "workspaces": [
     "packages/components/bolt-action-blocks",

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -64,7 +64,7 @@ function init(userConfig) {
   // End setting programatic defaults
 
   config = Object.assign({}, defaultConfig, userConfig, getEnvVarsConfig());
-  validateSchema(configSchema, config);
+  validateSchema(configSchema, config, 'Please fix the config being used in Bolt CLI.');
   isInitialized = true;
   return config;
 }
@@ -85,7 +85,7 @@ function getConfig() {
 function updateConfig(updater) {
   isReady();
   const newConfig = updater(config);
-  validateSchema(configSchema, newConfig);
+  validateSchema(configSchema, newConfig, 'Please fix the config being used in Bolt CLI.');
   // console.log('new config:');
   // console.log(newConfig);
   config = newConfig;

--- a/packages/build-tools/utils/manifest.js
+++ b/packages/build-tools/utils/manifest.js
@@ -4,6 +4,7 @@ const { promisify } = require('util');
 const fs = require('fs');
 const writeFile = promisify(fs.writeFile);
 const {getDataFile} = require('./yaml');
+const { validateSchemaSchema } = require('./schemas');
 const path = require('path');
 const config = require('./config-store').getConfig();
 const pkg = require('../package.json');
@@ -81,7 +82,10 @@ async function getPkgInfo(pkgName) {
       ensureFileExists(info.assets.main);
     }
     if (pkg.schema) {
-      info.schema = await getDataFile(path.join(dir, pkg.schema));
+      const schemaFilePath = path.join(dir, pkg.schema);
+      const schema = await getDataFile(schemaFilePath);
+      validateSchemaSchema(schema, `Schema not valid for: ${schemaFilePath}`);
+      info.schema = schema;
     }
     // @todo Allow verbosity settings
     // console.log(assets);

--- a/packages/build-tools/utils/schemaSchema-v4.json
+++ b/packages/build-tools/utils/schemaSchema-v4.json
@@ -1,0 +1,148 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "$schema": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/packages/build-tools/utils/schemas.js
+++ b/packages/build-tools/utils/schemas.js
@@ -1,23 +1,33 @@
 const chalk = require('chalk');
 const log = require('./log');
+const schemaSchema = require('./schemaSchema-v4');
 const { Validator } = require('jsonschema');
 
-function validateSchema(schema, data) {
+function validateSchema(schema, data, errorMsg) {
   const v = new Validator();
   const results = v.validate(data, schema);
   // console.log(results);
   if (results.errors.length) {
     log.error(chalk.bold('Config Schema Errors:'));
-    results.errors.forEach((error, i ) => {
-      log.error(`${i+1}) ${error}`);
+    results.errors.forEach((error, i) => {
+      log.warning(`${i + 1}) ${error}`);
     });
-    log.info('Please fix the config being used in Bolt CLI.');
-    process.exit(1);
+    log.errorAndExit(errorMsg);
   } else {
     // log.success('No config schema errors.');
   }
 }
 
+/**
+ * Validates JSON Schemas itself against the JSON Schema Schema (so meta)
+ * @param {object} schema
+ * @param {string} errorMessage
+ */
+function validateSchemaSchema(schema, errorMessage) {
+  validateSchema(schemaSchema, schema, errorMessage);
+}
+
 module.exports = {
   validateSchema,
+  validateSchemaSchema,
 };

--- a/packages/components/bolt-block-list/block-list.schema.yml
+++ b/packages/components/bolt-block-list/block-list.schema.yml
@@ -19,9 +19,9 @@ properties:
     description: All of the items in the block list - can have simple text **or** `items`
     items:
       anyOf:
-        type: object
-        properties:
-          text:
-            type: string
-        type: string
-        description: Outputs any content added
+        - type: object
+          properties:
+            text:
+              type: string
+        - type: string
+          description: Outputs any content added

--- a/packages/components/bolt-button/button.schema.yml
+++ b/packages/components/bolt-button/button.schema.yml
@@ -10,10 +10,7 @@ properties:
     description: 'The text displayed inside a button'
     type: string
   transform:
-      type:
-        anyOf:
-          - string
-          - null
+      type: string
       description: Text transformation.
       default: null
       enum:
@@ -27,10 +24,7 @@ properties:
   tag:
     title: 'Semantic tag'
     description: 'What should this element semantically be?'
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     enum:
       - a
       - link
@@ -40,10 +34,7 @@ properties:
       - null
     default: button
   size:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     title: 'Button Size'
     description: 'How large is this button?'
     default: medium
@@ -56,10 +47,7 @@ properties:
       - null
   align:
     title: 'Button Alignment'
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     enum:
       - left
       - center
@@ -67,10 +55,7 @@ properties:
       - null
     default: center
   style:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     title: 'Button Style'
     description: 'What''s the button style / theme?'
     default: primary
@@ -80,10 +65,7 @@ properties:
       - text
       - null
   width:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     title: 'Button Width'
     default: null
     description: 'Should a button be full width, it''s default size, or full width, but only on smaller screens?'
@@ -92,10 +74,7 @@ properties:
       - full@small
       - null
   rounded:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     title: 'Rounded Corners?'
     description: 'What kind of rounded corners should the button have?'
     default: null

--- a/packages/components/bolt-button/button.schema.yml
+++ b/packages/components/bolt-button/button.schema.yml
@@ -12,12 +12,12 @@ properties:
   transform:
       type: string
       description: Text transformation.
-      default: null
+      default: none
       enum:
         - uppercase
         - lowercase
         - capitalize
-        - null
+        - none
   theme:
     description: 'Themes, which are globally defined.'  # @todo Pulling this information in is a work in progress. Should be dynamically generated
 #    $ref: '@bolt/theme.schema.json#/properties/themes'
@@ -31,7 +31,6 @@ properties:
       - button
       - submit
       - reset
-      - null
     default: button
   size:
     type: string
@@ -44,7 +43,6 @@ properties:
       - medium
       - large
       - xlarge
-      - null
   align:
     title: 'Button Alignment'
     type: string
@@ -52,7 +50,6 @@ properties:
       - left
       - center
       - right
-      - null
     default: center
   style:
     type: string
@@ -63,31 +60,22 @@ properties:
       - primary
       - secondary
       - text
-      - null
   width:
     type: string
     title: 'Button Width'
-    default: null
     description: 'Should a button be full width, it''s default size, or full width, but only on smaller screens?'
     enum:
       - full
       - full@small
-      - null
   rounded:
     type: string
     title: 'Rounded Corners?'
     description: 'What kind of rounded corners should the button have?'
-    default: null
     enum:
       - rounded
-      - null
   iconOnly:
     type: boolean
     title: 'Icon Only?'
     description: 'Is this an icon-only button (with visually hidden text)?'
-    default: false
     required:
       - icon
-    enum:
-      - true
-      - false

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -16,23 +16,21 @@
 {% endif %}
 
 {# set up psuedo self-validation by limiting param values to what's specifically allowed in the component schema #}
-{% set alignOptions = schema.properties.align.enum|remove_null %}
+{% set alignOptions = schema.properties.align.enum %}
 {% set roundedOptions = schema.properties.rounded.enum %}
-{% set sizeOptions = schema.properties.size.enum|remove_null %}
-{% set styleOptions = schema.properties.style.enum|remove_null %}
-{% set tagOptions = schema.properties.tag.enum|remove_null %}
-{% set transformOptions = schema.properties.transform.enum|remove_null %}
-{% set widthOptions = schema.properties.width.enum|remove_null %}
+{% set sizeOptions = schema.properties.size.enum %}
+{% set styleOptions = schema.properties.style.enum %}
+{% set tagOptions = schema.properties.tag.enum %}
+{% set transformOptions = schema.properties.transform.enum %}
+{% set widthOptions = schema.properties.width.enum %}
 
 {# check if the value set to a prop is allowed or defined. if not, default to the default value specified in the component's schema (if one exists) #}
 {% set align =  align in alignOptions ? align : schema.properties.align.default %}
 {% set iconOnly = iconOnly | default(false) %}
-{% set rounded = rounded in roundedOptions ? rounded : schema.properties.rounded.default %}
 {% set size = size in sizeOptions ? size : schema.properties.size.default %}
 {% set style = style in styleOptions ? style : schema.properties.style.default %}
 {% set tag = tag in tagOptions ? tag : schema.properties.tag.default %}
 {% set transform = transform in transformOptions ? transform : schema.properties.transform.default %}
-{% set width = width in widthOptions ? width : schema.properties.width.default %}
 
 {% if tag == "submit" %}
   {% set tag = "button" %}
@@ -56,8 +54,8 @@
   baseClass,
   disabled ? baseClass ~ "--disabled" : "",
   size in sizeOptions ? baseClass ~ "--" ~ size : "",
-  width in widthOptions and width != "" ? baseClass ~ "--" ~ width : "",
-  rounded in roundedOptions and rounded != schema.properties.rounded.default ? baseClass ~ "--" ~ rounded : "",
+  width in widthOptions ? baseClass ~ "--" ~ width : "",
+  rounded in roundedOptions ? baseClass ~ "--" ~ rounded : "",
   style in styleOptions ? baseClass ~ "--" ~ style : baseClass ~ "--primary",
   transform in transformOptions ? baseClass ~ "--" ~ transform : "",
   align in alignOptions ? baseClass ~ "--" ~ align : "",

--- a/packages/components/bolt-device-viewer/device-viewer.schema.yml
+++ b/packages/components/bolt-device-viewer/device-viewer.schema.yml
@@ -27,7 +27,6 @@ properties:
     default: false
     type: boolean
   image:
-    description:
     type: object
     properties:
       src:

--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -8,10 +8,7 @@ properties:
     type: string
     description: Text content of the headline.
   tag:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     description: Html tag.
     default: p
     enum:
@@ -25,12 +22,8 @@ properties:
       - span
       - cite
       - div
-      - null
   align:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     description: Text alignment.
     default: null
     enum:
@@ -39,10 +32,7 @@ properties:
       - right
       - null
   weight:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     description: Font weights.
     default: regular
     enum:
@@ -51,10 +41,7 @@ properties:
       - semibold
       - null
   style:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     description: Font styles.
     default: normal
     enum:
@@ -62,10 +49,7 @@ properties:
       - italic
       - null
   size:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     description: Font size.
     default: medium
     enum:
@@ -78,10 +62,7 @@ properties:
       - xxxlarge
       - null
   transform:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     description: Text transformation.
     enum:
       - uppercase
@@ -90,18 +71,18 @@ properties:
       - null
     default: null
   url:
-    type:
-      anyOf:
-        - string
-        - null
+    type: string
     description: If provided, turns headline into a link to given url.
   icon:
-    type:
-      anyOf:
-        - object
-        - boolean
     description: Bolt icon. Excepts the same options as Bolt Icon Component `@bolt-components-icon`
-    ref: '@bolt-components-icon/icon.schema.yml'
+    anyOf:
+      -
+        type: object
+        ref: '@bolt-components-icon/icon.schema.yml'
+      -
+        type: boolean
+        enum:
+          - false
   quoted:
     type: boolean
     description: Adds quoted styling to text.

--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -25,12 +25,11 @@ properties:
   align:
     type: string
     description: Text alignment.
-    default: null
+    default: left
     enum:
       - left
       - center
       - right
-      - null
   weight:
     type: string
     description: Font weights.
@@ -39,7 +38,6 @@ properties:
       - bold
       - regular
       - semibold
-      - null
   style:
     type: string
     description: Font styles.
@@ -47,7 +45,6 @@ properties:
     enum:
       - normal
       - italic
-      - null
   size:
     type: string
     description: Font size.
@@ -60,7 +57,6 @@ properties:
       - xlarge
       - xxlarge
       - xxxlarge
-      - null
   transform:
     type: string
     description: Text transformation.
@@ -68,8 +64,6 @@ properties:
       - uppercase
       - lowercase
       - capitalize
-      - null
-    default: null
   url:
     type: string
     description: If provided, turns headline into a link to given url.
@@ -81,12 +75,6 @@ properties:
         ref: '@bolt-components-icon/icon.schema.yml'
       -
         type: boolean
-        enum:
-          - false
   quoted:
     type: boolean
     description: Adds quoted styling to text.
-    default: false
-    enum:
-      - false
-      - true

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -1,33 +1,23 @@
 {% set schema = bolt.data.components['@bolt-components-headline'].schema %}
 {% set types = ["headline", "subheadline", "eyebrow", "text"] %} {# Pre-defined types #}
 
-{% set tags = schema.properties.tag.enum|remove_null %}
-{% set weights = schema.properties.weight.enum|remove_null %}
-{% set styles = schema.properties.style.enum|remove_null %}
-{% set transformProps = schema.properties.transform.enum|remove_null %}
-{% set sizes = schema.properties.size.enum|remove_null %}
-{% set alignments = schema.properties.align.enum|remove_null %}
-
-{% set _defaultTag = schema.properties.tag.default %}
-{% set _defaultWeight = schema.properties.weight.default %}
-{% set _defaultStyle = schema.properties.style.default %}
-{% set _defaultType = "text" %}
-{% set _defaultSize = schema.properties.size.default %}
-{% set _defaultAlignment = schema.properties.align.default %}
-{% set _defaultTransform = schema.properties.transform.default %}
-
+{% set tags = schema.properties.tag.enum %}
+{% set weights = schema.properties.weight.enum %}
+{% set styles = schema.properties.style.enum %}
+{% set transformProps = schema.properties.transform.enum %}
+{% set sizes = schema.properties.size.enum %}
+{% set alignments = schema.properties.align.enum %}
 
 {% if tags != "any" %}
-  {% set tag = tag in tags ? tag : _defaultTag %}
+  {% set tag = tag in tags ? tag : schema.properties.tag.default %}
 {% else %}
-  {% set tag = tag ?? _defaultTag %}
+  {% set tag = tag ?? schema.properties.tag.default %}
 {% endif %}
-{% set weight = weight | default(_defaultWeight) %}
-{% set style = style | default(_defaultStyle) %}
-{% set type = type in types ? type : _defaultType %}
-{% set size = size | default(_defaultSize) %}
-{% set transform = transform | default(_defaultTransform) %}
-{% set align = align in alignments ? align : _defaultAlignment %}
+{% set weight = weight | default(schema.properties.weight.default) %}
+{% set style = style | default(schema.properties.style.default) %}
+{% set type = type in types ? type : "text" %}
+{% set size = size | default(schema.properties.size.default) %}
+{% set align = align in alignments ? align : schema.properties.align.default %}
 
 {% set prefix = "c-bolt-" %}
 {% set baseClass = prefix ~ type %}

--- a/packages/components/bolt-headline/src/headline.twig
+++ b/packages/components/bolt-headline/src/headline.twig
@@ -1,5 +1,4 @@
 {% extends "@bolt/_typography.twig" %}
-{% set schema = bolt.data.components['@bolt-components-headline'].schema %}
 
 {% set type = "headline" %}
 

--- a/packages/components/bolt-headline/src/headline.twig
+++ b/packages/components/bolt-headline/src/headline.twig
@@ -1,4 +1,6 @@
 {% extends "@bolt/_typography.twig" %}
+{% set schema = bolt.data.components['@bolt-components-headline'].schema %}
+
 {% set type = "headline" %}
 
 {% set styles = ["normal", "italic"] %}

--- a/packages/core-php/src/TwigExtensions/BoltCore.php
+++ b/packages/core-php/src/TwigExtensions/BoltCore.php
@@ -98,7 +98,6 @@ class BoltCore extends \Twig_Extension implements \Twig_Extension_InitRuntimeInt
 
   public function getFilters() {
     return [
-      TwigTools\TwigFilters::remove_null(),
       Bolt\TwigFilters::json_decode(),
     ];
   }


### PR DESCRIPTION
This is addressing a few things that create silent errors (things that do not exit non-0, so Travis does not fail, nor do the tools show errors).

- Invalid JSON Schemas. This introduces validation of those via the JSON Schema Schema :)
- Invalid YAML. Adding Yaml Linting.
- Array to String notices that happen when one uses an array as a var in PL. I have added an error handler in PL for this.

Next up is fixing the invalid schemas:

- [x] `block-list.schema.yml`
- [x] `button.schema.yml`
- [x] `device-viewer.schema.yml`
- [x] `headline.schema.yml`