### PR TITLE
Hotfix: Fix Headline Alignment Regression on Master

### DIFF
--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -25,7 +25,7 @@ properties:
   align:
     type: string
     description: Text alignment.
-    default: left
+    default: null
     enum:
       - left
       - center

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -32,7 +32,7 @@
   baseClass,
   quoted ? baseClass ~ "--" ~ "quoted" : "",
   weight in weights ? baseClass ~ "--" ~ weight : "",
-  align and align != "" ? baseClass ~ "--" ~ align : "",
+  align and align != null ? baseClass ~ "--" ~ align : "",
   style in styles and type == "text" ? baseClass ~ "--" ~ style : "",
   size in sizes and type != "eyebrow" ? baseClass ~ "--" ~ size : "",
   transform in transformProps and transform != "" ? baseClass ~ "--" ~ transform : "",


### PR DESCRIPTION
Updates the headline / sub headline / eyebrow / text component's "align" option in the schema to _not_ set a default value -- text alignment needs to be inherited by default unless the explicitly set to prevent visual regressions like the ones we're seeing on the live bolt-design-system.com site.

CC @joekarasek @EvanLovely @rockymountainhigh1943 @mikemai2awesome @theSadowski 