### PR TITLE
Hotfix: Fix HyperHTML Renderer Imports

### DIFF
--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -4,15 +4,14 @@ import {
   withComponent,
   css,
   hasNativeShadowDomSupport,
-  withPreact,
-  withHyperHTML,
+  BoltComponent,
   sanitizeBoltClasses,
 } from '@bolt/core';
 
 import ClipboardJS from 'clipboard';
 
 @define
-export class BoltCopyToClipboard extends withHyperHTML() {
+export class BoltCopyToClipboard extends BoltComponent() {
   static is = 'bolt-copy-to-clipboard';
 
   constructor() {

--- a/packages/components/bolt-nav-bar/src/nav-bar.standalone.js
+++ b/packages/components/bolt-nav-bar/src/nav-bar.standalone.js
@@ -4,8 +4,7 @@ import {
   define,
   props,
   withComponent,
-  withHyperHTML,
-  withPreact,
+  BoltComponent,
   css,
   spacingSizes,
   hasNativeShadowDomSupport,
@@ -62,7 +61,7 @@ let gumshoeStateModule = (function () {
 
 
 @define
-export class BoltNavList extends withHyperHTML(withComponent()) {
+export class BoltNavList extends BoltComponent() {
   static is = 'bolt-nav-list';
 
   // Behavior for `<bolt-nav-list>` parent container
@@ -214,7 +213,7 @@ export class BoltNavList extends withHyperHTML(withComponent()) {
 
 
 @define
-export class BoltNavLink extends withHyperHTML(withComponent()) { // Behavior for `<bolt-nav-link>` children
+export class BoltNavLink extends BoltComponent() { // Behavior for `<bolt-nav-link>` children
 
   static is = 'bolt-nav-link';
 

--- a/packages/components/bolt-share/src/share.standalone.js
+++ b/packages/components/bolt-share/src/share.standalone.js
@@ -4,13 +4,12 @@ import {
   withComponent,
   css,
   hasNativeShadowDomSupport,
-  withPreact,
-  withHyperHTML,
+  BoltComponent,
   sanitizeBoltClasses,
 } from '@bolt/core';
 
 @define
-export class BoltShare extends withHyperHTML() {
+export class BoltShare extends BoltComponent {
   static is = 'bolt-share';
 
   constructor() {


### PR DESCRIPTION
Updates a few JS components referencing the HyperHTML renderer to point at the newer BoltComponent renderer (which is still powered by HyperHTML under the hood) to fix errors thrown by Webpack