### PR TITLE
Hotfix: Dropdown CSS Var Fix + Fix for Copy to Clipboard

### DIFF
--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -16,6 +16,7 @@ export class BoltCopyToClipboard extends BoltComponent() {
 
   constructor() {
     super();
+    this.useShadow = false;
   }
 
   clickHandler(event) {

--- a/packages/components/bolt-dropdown/dropdown.scss
+++ b/packages/components/bolt-dropdown/dropdown.scss
@@ -571,7 +571,7 @@ bolt-dropdown {
 
 
 .c-bolt-dropdown__content:not(.c-bolt-dropdown__content--open):not(.c-bolt-dropdown__content--opened) {
-  --bolt-nav-indicator-transform: -100px !important;
+  --bolt-nav-indicator-transform: -100px;
 }
 
 // .c-bolt-dropdown__content--open:not(.c-bolt-dropdown__content--opened) {


### PR DESCRIPTION
- Workaround to fix copy to clipboard rendering
- Updating CSS rule to fix Travis build error (oddly not happening locally)