### PR TITLE
Unordered List - wrong sematic tag

### DIFF
--- a/packages/components/bolt-dropdown/dropdown.scss
+++ b/packages/components/bolt-dropdown/dropdown.scss
@@ -571,7 +571,7 @@ bolt-dropdown {
 
 
 .c-bolt-dropdown__content:not(.c-bolt-dropdown__content--open):not(.c-bolt-dropdown__content--opened) {
-  --bolt-nav-indicator-transform: -100px !important;
+  --bolt-nav-indicator-transform: -100px;
 }
 
 // .c-bolt-dropdown__content--open:not(.c-bolt-dropdown__content--opened) {

--- a/packages/components/bolt-unordered-list/src/unordered-list.twig
+++ b/packages/components/bolt-unordered-list/src/unordered-list.twig
@@ -29,7 +29,7 @@
 
 
 <bolt-{{ componentName }} bolt-component>
-  <ol {{ attributes.addClass(classes) }}>
+  <ul {{ attributes.addClass(classes) }}>
     {% for listItem in contentItems %}
       <li class="{{ "#{baseClass}__item" }}">
         {% if listItem.text %}
@@ -41,5 +41,5 @@
         {% endif %}
       </li>
     {% endfor %}
-  </ol>
+  </ul>
 </bolt-{{ componentName }}>


### PR DESCRIPTION
Looks like someone snuck in and ordered this list. I've returned it to an unordered state. 