### PR TITLE
Refactor of Headline Align Regression

### DIFF
--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -24,12 +24,11 @@ properties:
       - div
   align:
     description: Text alignment.
-    default: null
+    type: string
     enum:
       - left
       - center
       - right
-      - null
   weight:
     type: string
     description: Font weights.

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -17,7 +17,6 @@
 {% set style = style | default(schema.properties.style.default) %}
 {% set type = type in types ? type : "text" %}
 {% set size = size | default(schema.properties.size.default) %}
-{% set align = align in alignments ? align : schema.properties.align.default %}
 
 {% set prefix = "c-bolt-" %}
 {% set baseClass = prefix ~ type %}
@@ -32,7 +31,7 @@
   baseClass,
   quoted ? baseClass ~ "--" ~ "quoted" : "",
   weight in weights ? baseClass ~ "--" ~ weight : "",
-  align and align != null ? baseClass ~ "--" ~ align : "",
+  align in alignments and align != null ? baseClass ~ "--" ~ align : "",
   style in styles and type == "text" ? baseClass ~ "--" ~ style : "",
   size in sizes and type != "eyebrow" ? baseClass ~ "--" ~ size : "",
   transform in transformProps and transform != "" ? baseClass ~ "--" ~ transform : "",


### PR DESCRIPTION
@sghoweri Saw that you fixed a regression in Headline with the alignment prop...

Didn't feel good seeing null back in the schema, as this causes issues elsewhere. And the type was dropped. So here is a slightly different approach. If `align` is not passed in by the user, it remains undefined and nothing happens with it.  This seems simpler than saying it can be undefined, null, or a string, and that undefined will be transformed into null internally.

I also feel like this is a spot where we should have a consistent solution. There is nothing special about the align prop, so it shouldn't need a different schema pattern from the rest of the props that can be omitted. 

Thoughts?