### PR TITLE
Hotfix: Global Fix for Broken CSS Vars Theming

### DIFF
--- a/packages/components/bolt-device-viewer/src/device-viewer.scss
+++ b/packages/components/bolt-device-viewer/src/device-viewer.scss
@@ -207,9 +207,10 @@ $bolt-magnifier-size: 350px;
 
 .c-bolt-image-zoom__overlay-icon {
   @include bolt-shadow('level-60');
-
-  --bolt-theme-icon-background-opacity: 0.5;
-  --bolt-theme-icon-background-color: bolt-color(black);
+  @include bolt-css-vars((
+    --bolt-theme-icon-background-opacity: 0.5,
+    --bolt-theme-icon-background-color: bolt-color(black),
+  ));
 
   position: absolute;
   top: 50%;

--- a/packages/components/bolt-dropdown/dropdown.scss
+++ b/packages/components/bolt-dropdown/dropdown.scss
@@ -4,15 +4,19 @@
 bolt-dropdown {
   display: block;
 
-  --bolt-nav-item-opacity: 0;
-  --bolt-nav-item-transform: translateY(bolt-spacing(large) * -1);
-  --bolt-nav-indicator-opacity: 0;
+  @include bolt-css-vars((
+    --bolt-nav-item-opacity: 0,
+    --bolt-nav-item-transform: translateY(bolt-spacing(large) * -1),
+    --bolt-nav-indicator-opacity: 0,
+  ));
 
   &[collapse]{
     @include respond-to(small) {
-      --bolt-nav-item-opacity: 1;
-      --bolt-nav-item-transform: none;
-      --bolt-nav-indicator-opacity: 1;
+      @include bolt-css-vars((
+        --bolt-nav-item-opacity: 1,
+        --bolt-nav-item-transform: none,
+        --bolt-nav-indicator-opacity: 1
+      ));
     }
   }
 }
@@ -551,9 +555,10 @@ bolt-dropdown {
 .c-bolt-dropdown__content--opened .c-bolt-nav__item {
   // opacity: 1;
   // transform: none;
-
-  --bolt-nav-item-opacity: 1;
-  --bolt-nav-item-transform: none;
+  @include bolt-css-vars((
+    --bolt-nav-item-opacity: 1,
+    --bolt-nav-item-transform: none,
+  ));
 }
 
 .c-bolt-dropdown__state:target + .c-bolt-dropdown .c-bolt-nav__indicator,
@@ -564,14 +569,18 @@ bolt-dropdown {
 
 
 .c-bolt-dropdown__content--opened {
-  --bolt-nav-item-opacity: 1;
-  --bolt-nav-item-transform: none;
-  --bolt-nav-indicator-opacity: 1;
+  @include bolt-css-vars((
+    --bolt-nav-item-opacity: 1,
+    --bolt-nav-item-transform: none,
+    --bolt-nav-indicator-opacity: 1,
+  ));
 }
 
 
 .c-bolt-dropdown__content:not(.c-bolt-dropdown__content--open):not(.c-bolt-dropdown__content--opened) {
-  --bolt-nav-indicator-transform: -100px;
+  @include bolt-css-vars((
+    --bolt-nav-indicator-transform: -100px,
+  ));
 }
 
 // .c-bolt-dropdown__content--open:not(.c-bolt-dropdown__content--opened) {

--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -396,7 +396,9 @@ $bolt-input-transition: $bolt-transition;
 .c-bolt-custom-input.is-active {
   & ~ .c-bolt-input-icons {
     color: $bolt-input-icon-color--active;
-    --bolt-theme-icon: $bolt-input-icon-color--active;
+    @include bolt-css-vars((
+      --bolt-theme-icon: $bolt-input-icon-color--active,
+    ));
   }
 }
 
@@ -418,7 +420,9 @@ $bolt-input-transition: $bolt-transition;
 .c-bolt-input-icon--invalid {
   display: none; // The invalid icon will always be present and simply un-hidden when a field becomes invalid
   color: $bolt-input-icon-color--invalid;
-  --bolt-theme-icon: $bolt-input-icon-color--invalid;
+  @include bolt-css-vars((
+    --bolt-theme-icon: $bolt-input-icon-color--invalid,
+  ));
 }
 
 .c-bolt-input.is-invalid ~ .c-bolt-input-icons,

--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -116,18 +116,22 @@ bolt-icon[size='xlarge'],
   $brand-color: bolt-color(teal);
   $contrast-color: bolt-text-contrast($brand-color);
 
-  --bolt-theme-icon: $contrast-color;
-  --bolt-theme-icon-background: $brand-color;
-  --bolt-theme-icon-background-opacity: 1;
+  @include bolt-css-vars((
+    --bolt-theme-icon: $contrast-color,
+    --bolt-theme-icon-background: $brand-color,
+    --bolt-theme-icon-background-opacity: 1,
+  ));
 }
 
 .c-bolt-icon--blue {
   $brand-color: bolt-color(blue);
   color: $brand-color;
-  --bolt-theme-icon: $brand-color;
-  --bolt-theme-icon-background: bolt-text-contrast($brand-color);
-  --bolt-theme-icon-background-opacity: 1;
 
+  @include bolt-css-vars((
+    --bolt-theme-icon: $brand-color,
+    --bolt-theme-icon-background: bolt-text-contrast($brand-color),
+    --bolt-theme-icon-background-opacity: 1,
+  ));
 }
 
 .c-bolt-icon__background {

--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -109,7 +109,9 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
 
 .c-#{$bolt-namespace}-video__close-button {
   color: bolt-color(orange);
-  --#{$bolt-namespace}-theme-icon: bolt-color(orange);
+  @include bolt-css-vars((
+    --#{$bolt-namespace}-theme-icon: bolt-color(orange),
+  ));
   position: absolute;
   z-index: bolt-z-index('tooltip');
   top: bolt-spacing(xsmall);

--- a/packages/core/styles/02-tools/tools-css-vars/_tools-css-vars.scss
+++ b/packages/core/styles/02-tools/tools-css-vars/_tools-css-vars.scss
@@ -1,0 +1,126 @@
+//// VARIABLES ////
+
+// global map to be filled via variables
+$bolt-css-variables: ();
+
+// the variable may be set to "true" anywhere in the code,
+// so native CSS custom properties will be used instead of the Sass global map
+$bolt-css-vars-use-native: true !default;
+
+// enables the output of debug messages
+$bolt-css-vars-debug-log: false !default;
+
+//// FUNCTIONS ////
+
+///
+// Assigns a variable to the global map
+///
+@function bolt-css-vars-assign($name: null, $value: null) {
+  // CHECK PARAMS
+  @if ($name==null) {
+    @error "Variable name is expected, instead got: null";
+  }
+  @if ($value == null) {
+    @error "Variable value is expected, instead got: null";
+  }
+  // assign to the global map
+  @if ($bolt-css-vars-debug-log and map-get($bolt-css-variables, $name)) {
+    @debug "'#{$name}' variable is reassigned";
+  }
+  @return map-merge($bolt-css-variables, ($name: $value));
+}
+///
+// Emulates var() CSS native function behavior
+//
+// $args[0] {String} "--" + variable name
+// [$args[1]] Optional default value if variable is not assigned yet
+//
+// E.G.:
+// color: var(--main-color);
+// background: var(--main-bg, green);
+///
+@function var($args...) { /* stylelint-disable-line */
+  // CHECK PARAMS
+  @if (length($args)==0) {
+    @error "Variable name is expected to be passed to the var() function";
+  }
+  @if (str-length(nth($args, 1)) < 2 or str-slice(nth($args, 1), 0, 2) != '--') {
+    @error "Variable name is expected to start from '--'";
+  }
+  // PROCESS
+  $name: nth($args, 1);
+  $value: map-get($bolt-css-variables, $name);
+
+  @if ($bolt-css-vars-debug-log or not $bolt-css-vars-use-native) { // Sass or debug
+    @if ($value==null) { // variable is not provided so far
+      @if (length($args)==2) { // the default value is passed
+        @if ($bolt-css-vars-debug-log) {
+          @debug "Provided default value is used for the variable: '#{$name}'";
+        }
+        $value: nth($args, 2);
+      } @else if ($bolt-css-vars-debug-log) {
+        @debug "Variable '#{$name}' is not assigned";
+        @if (not $bolt-css-vars-use-native) {
+          @debug "The 'var(#{$name}...)' usage will be skipped in the output CSS";
+        }
+      }
+    }
+  }
+  @if ($bolt-css-vars-use-native) { // CSS variables
+    // Native CSS: don't process function in case of native
+    @return unquote('var(' + $args + ')');
+  } @else {
+    // Sass: return value from the map
+    @return $value;
+  }
+}
+//// MIXIN ////
+///
+// CSS mixin to provide variables
+// E.G.:
+// @include css-vars((
+//    --color: rebeccapurple,
+//    --height: 68px,
+//    --margin-top: calc(2vh + 20px)
+// ));
+///
+
+// Root: output at the root?
+@mixin bolt-css-vars($varMap: null, $root: false) {
+  // CHECK PARAMS
+  @if ($varMap==null) {
+    @error "Map of variables is expected, instead got: null";
+  }
+  @if (type_of($varMap)!=map) {
+    @error "Map of variables is expected, instead got another type passed: #{type_of($varMap)}";
+  }
+  // PROCESS
+  @if ($bolt-css-vars-debug-log or not $bolt-css-vars-use-native) { // Sass or debug
+    // merge variables and values to the global map (provides no output)
+    @each $name, $value in $varMap {
+      $bolt-css-vars: bolt-css-vars-assign($name, $value) !global; // store in global variable
+    }
+  }
+  @if ($bolt-css-vars-use-native) { // CSS variables
+    // Native CSS: assign CSS custom properties to the global scope
+    @if $root == true {
+      @at-root :root {
+        @each $name, $value in $varMap {
+          @if (type_of($value)==string) {
+            #{$name}: $value // to prevent quotes interpolation
+          } @else {
+            #{$name}: #{$value}
+          }
+        }
+      }
+    } @else {
+      @each $name, $value in $varMap {
+        @if (type_of($value)==string) {
+          #{$name}: $value // to prevent quotes interpolation
+        } @else {
+          #{$name}: #{$value}
+        }
+      }
+    }
+  }
+}

--- a/packages/global/styles/05-objects/objects-ratio/ratio.scss
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.scss
@@ -13,8 +13,10 @@
   font-size: 0; // Workaround to IE 11 adding extra whitespace
   overflow: hidden; // Hide placeholder blurred images from leaking through
 
-  --aspect-ratio-width: 1;
-  --aspect-ratio-height: 1;
+  @include bolt-css-vars((
+    --aspect-ratio-width: 1,
+    --aspect-ratio-height: 1,
+  ));
 
   @supports (--custom:property) {
     padding-top: calc( var(--aspect-ratio-height, 1) / var(--aspect-ratio-width, 1) * 100%);

--- a/packages/global/styles/05-objects/objects-ratio/ratio.scss
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.scss
@@ -2,6 +2,8 @@
    #BOLT RATIO OBJECT
    ========================================================================== */
 
+@import '@bolt/core';
+
 .o-#{$bolt-namespace}-ratio,
 #{$bolt-namespace}-ratio {
   display: inline-block;

--- a/packages/global/styles/05-objects/objects-ui-list/_objects-ui-list.scss
+++ b/packages/global/styles/05-objects/objects-ui-list/_objects-ui-list.scss
@@ -85,7 +85,9 @@ $bolt-ui-list-border-color: var(--bolt-theme-border, currentColor);
 
 .o-bolt-ui-list--borderless > .o-bolt-ui-list__item:after {
   opacity: 0;
-  --bolt-ui-border-color: transparent;
+  @include bolt-css-vars((
+    --bolt-ui-border-color: transparent,
+  ));
 }
 
 .o-bolt-ui-list--small > .o-bolt-ui-list__item {

--- a/packages/global/styles/06-themes/themes-general/_themes-dark.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-dark.scss
@@ -54,46 +54,45 @@ $bolt-theme-contrast-filter:   grayscale(100%) invert(100%) brightness(150%);
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-
-  --bolt-theme-background:   $bolt-theme-background;
-  --bolt-theme-primary:      $bolt-theme-primary;
-  --bolt-theme-secondary:    $bolt-theme-secondary;
-  --bolt-theme-heading:      $bolt-theme-heading;
-  --bolt-theme-link:         $bolt-theme-link;
-  --bolt-theme-text:         $bolt-theme-text;
-  --bolt-theme-heading-link: $bolt-theme-heading-link;
-  --bolt-theme-border:       $bolt-theme-border;
-
-
-  --bolt-theme-link-default: $bolt-theme-link-default;
-  --bolt-theme-link-hover: $bolt-theme-link-hover;
-  --bolt-theme-link-active: $bolt-theme-link-active;
-  --bolt-theme-link-visited: $bolt-theme-link-visited;
+  --bolt-theme-background:   #{$bolt-theme-background};
+  --bolt-theme-primary:      #{$bolt-theme-primary};
+  --bolt-theme-secondary:    #{$bolt-theme-secondary};
+  --bolt-theme-heading:      #{$bolt-theme-heading};
+  --bolt-theme-link:         #{$bolt-theme-link};
+  --bolt-theme-text:         #{$bolt-theme-text};
+  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
+  --bolt-theme-border:       #{$bolt-theme-border};
 
 
-  --bolt-theme-heading-link-default: $bolt-theme-heading-link-default;
-  --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover;
-  --bolt-theme-heading-link-active: $bolt-theme-heading-link-active;
-  --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited;
+  --bolt-theme-link-default: #{$bolt-theme-link-default};
+  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
+  --bolt-theme-link-active: #{$bolt-theme-link-active};
+  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
 
 
-  --bolt-theme-primary-background-default: $bolt-theme-primary-background-default;
-  --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default;
-  --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default;
+  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
+  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
+  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
+  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
 
-  --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover;
-  --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover;
-  --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover;
+  
+  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
+  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
+  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
 
-  --bolt-theme-primary-background-active: $bolt-theme-primary-background-active;
-  --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active;
-  --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active;
+  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
+  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
+  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
 
-  --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus;
-  --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus;
-  --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus;
+  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
+  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
+  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
 
-  --bolt-theme-contrast-filter: $bolt-theme-contrast-filter;
+  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
+  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
+  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
+
+  --bolt-theme-contrast-filter: #{$bolt-theme-contrast-filter};
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;

--- a/packages/global/styles/06-themes/themes-general/_themes-dark.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-dark.scss
@@ -54,45 +54,44 @@ $bolt-theme-contrast-filter:   grayscale(100%) invert(100%) brightness(150%);
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-  --bolt-theme-background:   #{$bolt-theme-background};
-  --bolt-theme-primary:      #{$bolt-theme-primary};
-  --bolt-theme-secondary:    #{$bolt-theme-secondary};
-  --bolt-theme-heading:      #{$bolt-theme-heading};
-  --bolt-theme-link:         #{$bolt-theme-link};
-  --bolt-theme-text:         #{$bolt-theme-text};
-  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
-  --bolt-theme-border:       #{$bolt-theme-border};
+  @include bolt-css-vars((
+    --bolt-theme-background:   $bolt-theme-background,
+    --bolt-theme-primary:      $bolt-theme-primary,
+    --bolt-theme-secondary:    $bolt-theme-secondary,
+    --bolt-theme-heading:      $bolt-theme-heading,
+    --bolt-theme-link:         $bolt-theme-link,
+    --bolt-theme-text:         $bolt-theme-text,
+    --bolt-theme-heading-link: $bolt-theme-heading-link,
+    --bolt-theme-border:       $bolt-theme-border,
 
+    --bolt-theme-link-default: $bolt-theme-link-default,
+    --bolt-theme-link-hover: $bolt-theme-link-hover,
+    --bolt-theme-link-active: $bolt-theme-link-active,
+    --bolt-theme-link-visited: $bolt-theme-link-visited,
 
-  --bolt-theme-link-default: #{$bolt-theme-link-default};
-  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
-  --bolt-theme-link-active: #{$bolt-theme-link-active};
-  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
+    --bolt-theme-heading-link-default: $bolt-theme-heading-link-default,
+    --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover,
+    --bolt-theme-heading-link-active: $bolt-theme-heading-link-active,
+    --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited,
+    
+    --bolt-theme-primary-background-default: $bolt-theme-primary-background-default,
+    --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default,
+    --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default,
 
+    --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover,
+    --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover,
+    --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover,
 
-  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
-  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
-  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
-  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
+    --bolt-theme-primary-background-active: $bolt-theme-primary-background-active,
+    --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active,
+    --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active,
 
-  
-  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
-  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
-  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
+    --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus,
+    --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus,
+    --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus,
 
-  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
-  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
-  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
-
-  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
-  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
-  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
-
-  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
-  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
-  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
-
-  --bolt-theme-contrast-filter: #{$bolt-theme-contrast-filter};
+    --bolt-theme-contrast-filter: $bolt-theme-contrast-filter,
+  ));
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;

--- a/packages/global/styles/06-themes/themes-general/_themes-light.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-light.scss
@@ -52,56 +52,43 @@ $bolt-theme-light-border:       rgba($bolt-theme-light-heading, $bolt-global-bor
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
   
 
-  --bolt-theme-background:   #{$bolt-theme-background};
-  --bolt-theme-primary:      #{$bolt-theme-primary};
-  --bolt-theme-secondary:    #{$bolt-theme-secondary};
-  --bolt-theme-heading:      #{$bolt-theme-heading};
-  --bolt-theme-link:         #{$bolt-theme-link};
-  --bolt-theme-text:         #{$bolt-theme-text};
-  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
-  --bolt-theme-border:       #{$bolt-theme-border};
+  @include bolt-css-vars((
+    --bolt-theme-background:   $bolt-theme-background,
+    --bolt-theme-primary:      $bolt-theme-primary,
+    --bolt-theme-secondary:    $bolt-theme-secondary,
+    --bolt-theme-heading:      $bolt-theme-heading,
+    --bolt-theme-link:         $bolt-theme-link,
+    --bolt-theme-text:         $bolt-theme-text,
+    --bolt-theme-heading-link: $bolt-theme-heading-link,
+    --bolt-theme-border:       $bolt-theme-border,
 
+    --bolt-theme-link-default: $bolt-theme-link-default,
+    --bolt-theme-link-hover: $bolt-theme-link-hover,
+    --bolt-theme-link-active: $bolt-theme-link-active,
+    --bolt-theme-link-visited: $bolt-theme-link-visited,
 
-  --bolt-theme-link-default: #{$bolt-theme-link-default};
-  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
-  --bolt-theme-link-active: #{$bolt-theme-link-active};
-  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
+    --bolt-theme-heading-link-default: $bolt-theme-heading-link-default,
+    --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover,
+    --bolt-theme-heading-link-active: $bolt-theme-heading-link-active,
+    --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited,
+    
+    --bolt-theme-primary-background-default: $bolt-theme-primary-background-default,
+    --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default,
+    --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default,
 
+    --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover,
+    --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover,
+    --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover,
 
-  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
-  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
-  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
-  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
+    --bolt-theme-primary-background-active: $bolt-theme-primary-background-active,
+    --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active,
+    --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active,
 
-  
-  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
-  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
-  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
-
-  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
-  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
-  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
-
-  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
-  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
-  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
-
-  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
-  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
-  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
+    --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus,
+    --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus,
+    --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus,
+  ));
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;
-  // --bolt-theme-chip-text
-  // --bolt-theme-card-border
-  // --bolt-theme-card-background
-  // --bolt-theme-blockquote-border
-  // --bolt-theme-blockquote-text
-  // --bolt-theme-background-gradient-secondary
-  // --bolt-theme-background-gradient-primary
-  // --bolt-theme-background-fill
-  // --bolt-theme-action-block-text
-  // --bolt-theme-link-default
-  // --bolt-theme-link
-  // --bolt-theme-link-visited
 }

--- a/packages/global/styles/06-themes/themes-general/_themes-light.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-light.scss
@@ -52,44 +52,43 @@ $bolt-theme-light-border:       rgba($bolt-theme-light-heading, $bolt-global-bor
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
   
 
-
-  --bolt-theme-background:   $bolt-theme-background;
-  --bolt-theme-primary:      $bolt-theme-primary;
-  --bolt-theme-secondary:    $bolt-theme-secondary;
-  --bolt-theme-heading:      $bolt-theme-heading;
-  --bolt-theme-link:         $bolt-theme-link;
-  --bolt-theme-text:         $bolt-theme-text;
-  --bolt-theme-heading-link: $bolt-theme-heading-link;
-  --bolt-theme-border:       $bolt-theme-border;
-
-
-  --bolt-theme-link-default: $bolt-theme-link-default;
-  --bolt-theme-link-hover: $bolt-theme-link-hover;
-  --bolt-theme-link-active: $bolt-theme-link-active;
-  --bolt-theme-link-visited: $bolt-theme-link-visited;
+  --bolt-theme-background:   #{$bolt-theme-background};
+  --bolt-theme-primary:      #{$bolt-theme-primary};
+  --bolt-theme-secondary:    #{$bolt-theme-secondary};
+  --bolt-theme-heading:      #{$bolt-theme-heading};
+  --bolt-theme-link:         #{$bolt-theme-link};
+  --bolt-theme-text:         #{$bolt-theme-text};
+  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
+  --bolt-theme-border:       #{$bolt-theme-border};
 
 
-  --bolt-theme-heading-link-default: $bolt-theme-heading-link-default;
-  --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover;
-  --bolt-theme-heading-link-active: $bolt-theme-heading-link-active;
-  --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited;
+  --bolt-theme-link-default: #{$bolt-theme-link-default};
+  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
+  --bolt-theme-link-active: #{$bolt-theme-link-active};
+  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
+
+
+  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
+  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
+  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
+  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
 
   
-  --bolt-theme-primary-background-default: $bolt-theme-primary-background-default;
-  --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default;
-  --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default;
+  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
+  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
+  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
 
-  --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover;
-  --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover;
-  --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover;
+  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
+  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
+  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
 
-  --bolt-theme-primary-background-active: $bolt-theme-primary-background-active;
-  --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active;
-  --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active;
+  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
+  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
+  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
 
-  --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus;
-  --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus;
-  --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus;
+  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
+  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
+  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;

--- a/packages/global/styles/06-themes/themes-general/_themes-medium.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-medium.scss
@@ -54,46 +54,45 @@ $bolt-theme-contrast-filter:   grayscale(100%) invert(100%) brightness(150%);
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-
-  --bolt-theme-background:   $bolt-theme-background;
-  --bolt-theme-primary:      $bolt-theme-primary;
-  --bolt-theme-secondary:    $bolt-theme-secondary;
-  --bolt-theme-heading:      $bolt-theme-heading;
-  --bolt-theme-link:         $bolt-theme-link;
-  --bolt-theme-text:         $bolt-theme-text;
-  --bolt-theme-heading-link: $bolt-theme-heading-link;
-  --bolt-theme-border:       $bolt-theme-border;
-
-
-  --bolt-theme-link-default: $bolt-theme-link-default;
-  --bolt-theme-link-hover: $bolt-theme-link-hover;
-  --bolt-theme-link-active: $bolt-theme-link-active;
-  --bolt-theme-link-visited: $bolt-theme-link-visited;
+  --bolt-theme-background:   #{$bolt-theme-background};
+  --bolt-theme-primary:      #{$bolt-theme-primary};
+  --bolt-theme-secondary:    #{$bolt-theme-secondary};
+  --bolt-theme-heading:      #{$bolt-theme-heading};
+  --bolt-theme-link:         #{$bolt-theme-link};
+  --bolt-theme-text:         #{$bolt-theme-text};
+  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
+  --bolt-theme-border:       #{$bolt-theme-border};
 
 
-  --bolt-theme-heading-link-default: $bolt-theme-heading-link-default;
-  --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover;
-  --bolt-theme-heading-link-active: $bolt-theme-heading-link-active;
-  --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited;
+  --bolt-theme-link-default: #{$bolt-theme-link-default};
+  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
+  --bolt-theme-link-active: #{$bolt-theme-link-active};
+  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
 
 
-  --bolt-theme-primary-background-default: $bolt-theme-primary-background-default;
-  --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default;
-  --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default;
+  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
+  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
+  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
+  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
 
-  --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover;
-  --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover;
-  --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover;
+  
+  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
+  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
+  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
 
-  --bolt-theme-primary-background-active: $bolt-theme-primary-background-active;
-  --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active;
-  --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active;
+  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
+  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
+  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
 
-  --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus;
-  --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus;
-  --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus;
+  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
+  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
+  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
 
-  --bolt-theme-contrast-filter: $bolt-theme-contrast-filter;
+  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
+  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
+  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
+
+  --bolt-theme-contrast-filter: #{$bolt-theme-contrast-filter};
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;

--- a/packages/global/styles/06-themes/themes-general/_themes-medium.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-medium.scss
@@ -54,45 +54,44 @@ $bolt-theme-contrast-filter:   grayscale(100%) invert(100%) brightness(150%);
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-  --bolt-theme-background:   #{$bolt-theme-background};
-  --bolt-theme-primary:      #{$bolt-theme-primary};
-  --bolt-theme-secondary:    #{$bolt-theme-secondary};
-  --bolt-theme-heading:      #{$bolt-theme-heading};
-  --bolt-theme-link:         #{$bolt-theme-link};
-  --bolt-theme-text:         #{$bolt-theme-text};
-  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
-  --bolt-theme-border:       #{$bolt-theme-border};
+  @include bolt-css-vars((
+    --bolt-theme-background:   $bolt-theme-background,
+    --bolt-theme-primary:      $bolt-theme-primary,
+    --bolt-theme-secondary:    $bolt-theme-secondary,
+    --bolt-theme-heading:      $bolt-theme-heading,
+    --bolt-theme-link:         $bolt-theme-link,
+    --bolt-theme-text:         $bolt-theme-text,
+    --bolt-theme-heading-link: $bolt-theme-heading-link,
+    --bolt-theme-border:       $bolt-theme-border,
 
+    --bolt-theme-link-default: $bolt-theme-link-default,
+    --bolt-theme-link-hover: $bolt-theme-link-hover,
+    --bolt-theme-link-active: $bolt-theme-link-active,
+    --bolt-theme-link-visited: $bolt-theme-link-visited,
 
-  --bolt-theme-link-default: #{$bolt-theme-link-default};
-  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
-  --bolt-theme-link-active: #{$bolt-theme-link-active};
-  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
+    --bolt-theme-heading-link-default: $bolt-theme-heading-link-default,
+    --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover,
+    --bolt-theme-heading-link-active: $bolt-theme-heading-link-active,
+    --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited,
+    
+    --bolt-theme-primary-background-default: $bolt-theme-primary-background-default,
+    --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default,
+    --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default,
 
+    --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover,
+    --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover,
+    --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover,
 
-  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
-  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
-  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
-  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
+    --bolt-theme-primary-background-active: $bolt-theme-primary-background-active,
+    --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active,
+    --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active,
 
-  
-  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
-  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
-  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
+    --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus,
+    --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus,
+    --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus,
 
-  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
-  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
-  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
-
-  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
-  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
-  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
-
-  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
-  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
-  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
-
-  --bolt-theme-contrast-filter: #{$bolt-theme-contrast-filter};
+    --bolt-theme-contrast-filter: $bolt-theme-contrast-filter,
+  ));
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;

--- a/packages/global/styles/06-themes/themes-general/_themes-xdark.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-xdark.scss
@@ -53,46 +53,45 @@ $bolt-theme-contrast-filter:    grayscale(100%) invert(100%) brightness(150%);
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-
-  --bolt-theme-background:   $bolt-theme-background;
-  --bolt-theme-primary:      $bolt-theme-primary;
-  --bolt-theme-secondary:    $bolt-theme-secondary;
-  --bolt-theme-heading:      $bolt-theme-heading;
-  --bolt-theme-link:         $bolt-theme-link;
-  --bolt-theme-text:         $bolt-theme-text;
-  --bolt-theme-heading-link: $bolt-theme-heading-link;
-  --bolt-theme-border:       $bolt-theme-border;
-
-
-  --bolt-theme-link-default: $bolt-theme-link-default;
-  --bolt-theme-link-hover: $bolt-theme-link-hover;
-  --bolt-theme-link-active: $bolt-theme-link-active;
-  --bolt-theme-link-visited: $bolt-theme-link-visited;
+  --bolt-theme-background:   #{$bolt-theme-background};
+  --bolt-theme-primary:      #{$bolt-theme-primary};
+  --bolt-theme-secondary:    #{$bolt-theme-secondary};
+  --bolt-theme-heading:      #{$bolt-theme-heading};
+  --bolt-theme-link:         #{$bolt-theme-link};
+  --bolt-theme-text:         #{$bolt-theme-text};
+  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
+  --bolt-theme-border:       #{$bolt-theme-border};
 
 
-  --bolt-theme-heading-link-default: $bolt-theme-heading-link-default;
-  --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover;
-  --bolt-theme-heading-link-active: $bolt-theme-heading-link-active;
-  --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited;
+  --bolt-theme-link-default: #{$bolt-theme-link-default};
+  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
+  --bolt-theme-link-active: #{$bolt-theme-link-active};
+  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
 
 
-  --bolt-theme-primary-background-default: $bolt-theme-primary-background-default;
-  --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default;
-  --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default;
+  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
+  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
+  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
+  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
 
-  --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover;
-  --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover;
-  --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover;
+  
+  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
+  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
+  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
 
-  --bolt-theme-primary-background-active: $bolt-theme-primary-background-active;
-  --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active;
-  --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active;
+  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
+  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
+  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
 
-  --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus;
-  --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus;
-  --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus;
+  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
+  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
+  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
 
-  --bolt-theme-contrast-filter: $bolt-theme-contrast-filter;
+  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
+  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
+  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
+
+  --bolt-theme-contrast-filter: #{$bolt-theme-contrast-filter};
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;

--- a/packages/global/styles/06-themes/themes-general/_themes-xdark.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-xdark.scss
@@ -53,45 +53,46 @@ $bolt-theme-contrast-filter:    grayscale(100%) invert(100%) brightness(150%);
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-  --bolt-theme-background:   #{$bolt-theme-background};
-  --bolt-theme-primary:      #{$bolt-theme-primary};
-  --bolt-theme-secondary:    #{$bolt-theme-secondary};
-  --bolt-theme-heading:      #{$bolt-theme-heading};
-  --bolt-theme-link:         #{$bolt-theme-link};
-  --bolt-theme-text:         #{$bolt-theme-text};
-  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
-  --bolt-theme-border:       #{$bolt-theme-border};
+  @include bolt-css-vars((
+    --bolt-theme-background:   $bolt-theme-background,
+    --bolt-theme-primary:      $bolt-theme-primary,
+    --bolt-theme-secondary:    $bolt-theme-secondary,
+    --bolt-theme-heading:      $bolt-theme-heading,
+    --bolt-theme-link:         $bolt-theme-link,
+    --bolt-theme-text:         $bolt-theme-text,
+    --bolt-theme-heading-link: $bolt-theme-heading-link,
+    --bolt-theme-border:       $bolt-theme-border,
 
+    --bolt-theme-link-default: $bolt-theme-link-default,
+    --bolt-theme-link-hover: $bolt-theme-link-hover,
+    --bolt-theme-link-active: $bolt-theme-link-active,
+    --bolt-theme-link-visited: $bolt-theme-link-visited,
 
-  --bolt-theme-link-default: #{$bolt-theme-link-default};
-  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
-  --bolt-theme-link-active: #{$bolt-theme-link-active};
-  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
+    --bolt-theme-heading-link-default: $bolt-theme-heading-link-default,
+    --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover,
+    --bolt-theme-heading-link-active: $bolt-theme-heading-link-active,
+    --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited,
+    
+    --bolt-theme-primary-background-default: $bolt-theme-primary-background-default,
+    --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default,
+    --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default,
 
+    --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover,
+    --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover,
+    --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover,
 
-  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
-  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
-  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
-  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
+    --bolt-theme-primary-background-active: $bolt-theme-primary-background-active,
+    --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active,
+    --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active,
+
+    --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus,
+    --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus,
+    --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus,
+
+    --bolt-theme-contrast-filter: $bolt-theme-contrast-filter,
+  ));
 
   
-  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
-  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
-  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
-
-  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
-  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
-  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
-
-  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
-  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
-  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
-
-  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
-  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
-  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
-
-  --bolt-theme-contrast-filter: #{$bolt-theme-contrast-filter};
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;

--- a/packages/global/styles/06-themes/themes-general/_themes-xlight.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-xlight.scss
@@ -57,56 +57,44 @@ $bolt-theme-xlight-border:       rgba($bolt-theme-xlight-heading, $bolt-global-b
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-  --bolt-theme-background:   #{$bolt-theme-background};
-  --bolt-theme-primary:      #{$bolt-theme-primary};
-  --bolt-theme-secondary:    #{$bolt-theme-secondary};
-  --bolt-theme-heading:      #{$bolt-theme-heading};
-  --bolt-theme-link:         #{$bolt-theme-link};
-  --bolt-theme-text:         #{$bolt-theme-text};
-  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
-  --bolt-theme-border:       #{$bolt-theme-border};
+  @include bolt-css-vars((
+    --bolt-theme-background:   $bolt-theme-background,
+    --bolt-theme-primary:      $bolt-theme-primary,
+    --bolt-theme-secondary:    $bolt-theme-secondary,
+    --bolt-theme-heading:      $bolt-theme-heading,
+    --bolt-theme-link:         $bolt-theme-link,
+    --bolt-theme-text:         $bolt-theme-text,
+    --bolt-theme-heading-link: $bolt-theme-heading-link,
+    --bolt-theme-border:       $bolt-theme-border,
 
+    --bolt-theme-link-default: $bolt-theme-link-default,
+    --bolt-theme-link-hover: $bolt-theme-link-hover,
+    --bolt-theme-link-active: $bolt-theme-link-active,
+    --bolt-theme-link-visited: $bolt-theme-link-visited,
 
-  --bolt-theme-link-default: #{$bolt-theme-link-default};
-  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
-  --bolt-theme-link-active: #{$bolt-theme-link-active};
-  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
+    --bolt-theme-heading-link-default: $bolt-theme-heading-link-default,
+    --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover,
+    --bolt-theme-heading-link-active: $bolt-theme-heading-link-active,
+    --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited,
+    
+    --bolt-theme-primary-background-default: $bolt-theme-primary-background-default,
+    --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default,
+    --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default,
 
+    --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover,
+    --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover,
+    --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover,
 
-  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
-  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
-  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
-  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
+    --bolt-theme-primary-background-active: $bolt-theme-primary-background-active,
+    --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active,
+    --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active,
 
-  
-  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
-  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
-  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
+    --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus,
+    --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus,
+    --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus,
+  ));
 
-  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
-  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
-  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
-
-  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
-  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
-  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
-
-  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
-  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
-  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
-
+ 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;
-  // --bolt-theme-chip-text
-  // --bolt-theme-card-border
-  // --bolt-theme-card-background
-  // --bolt-theme-blockquote-border
-  // --bolt-theme-blockquote-text
-  // --bolt-theme-background-gradient-secondary
-  // --bolt-theme-background-gradient-primary
-  // --bolt-theme-background-fill
-  // --bolt-theme-action-block-text
-  // --bolt-theme-link-default
-  // --bolt-theme-link
-  // --bolt-theme-link-visited
 }

--- a/packages/global/styles/06-themes/themes-general/_themes-xlight.scss
+++ b/packages/global/styles/06-themes/themes-general/_themes-xlight.scss
@@ -57,44 +57,43 @@ $bolt-theme-xlight-border:       rgba($bolt-theme-xlight-heading, $bolt-global-b
   $bolt-theme-primary-border-focus:     $bolt-theme-primary-background-focus;
 
 
-
-  --bolt-theme-background:   $bolt-theme-background;
-  --bolt-theme-primary:      $bolt-theme-primary;
-  --bolt-theme-secondary:    $bolt-theme-secondary;
-  --bolt-theme-heading:      $bolt-theme-heading;
-  --bolt-theme-link:         $bolt-theme-link;
-  --bolt-theme-text:         $bolt-theme-text;
-  --bolt-theme-heading-link: $bolt-theme-heading-link;
-  --bolt-theme-border:       $bolt-theme-border;
-
-
-  --bolt-theme-link-default: $bolt-theme-link-default;
-  --bolt-theme-link-hover: $bolt-theme-link-hover;
-  --bolt-theme-link-active: $bolt-theme-link-active;
-  --bolt-theme-link-visited: $bolt-theme-link-visited;
+  --bolt-theme-background:   #{$bolt-theme-background};
+  --bolt-theme-primary:      #{$bolt-theme-primary};
+  --bolt-theme-secondary:    #{$bolt-theme-secondary};
+  --bolt-theme-heading:      #{$bolt-theme-heading};
+  --bolt-theme-link:         #{$bolt-theme-link};
+  --bolt-theme-text:         #{$bolt-theme-text};
+  --bolt-theme-heading-link: #{$bolt-theme-heading-link};
+  --bolt-theme-border:       #{$bolt-theme-border};
 
 
-  --bolt-theme-heading-link-default: $bolt-theme-heading-link-default;
-  --bolt-theme-heading-link-hover: $bolt-theme-heading-link-hover;
-  --bolt-theme-heading-link-active: $bolt-theme-heading-link-active;
-  --bolt-theme-heading-link-visited: $bolt-theme-heading-link-visited;
+  --bolt-theme-link-default: #{$bolt-theme-link-default};
+  --bolt-theme-link-hover: #{$bolt-theme-link-hover};
+  --bolt-theme-link-active: #{$bolt-theme-link-active};
+  --bolt-theme-link-visited: #{$bolt-theme-link-visited};
 
 
-  --bolt-theme-primary-background-default: $bolt-theme-primary-background-default;
-  --bolt-theme-primary-text-default:       $bolt-theme-primary-text-default;
-  --bolt-theme-primary-border-default:     $bolt-theme-primary-border-default;
+  --bolt-theme-heading-link-default: #{$bolt-theme-heading-link-default};
+  --bolt-theme-heading-link-hover: #{$bolt-theme-heading-link-hover};
+  --bolt-theme-heading-link-active: #{$bolt-theme-heading-link-active};
+  --bolt-theme-heading-link-visited: #{$bolt-theme-heading-link-visited};
 
-  --bolt-theme-primary-background-hover: $bolt-theme-primary-background-hover;
-  --bolt-theme-primary-text-hover:       $bolt-theme-primary-text-hover;
-  --bolt-theme-primary-border-hover:     $bolt-theme-primary-border-hover;
+  
+  --bolt-theme-primary-background-default: #{$bolt-theme-primary-background-default};
+  --bolt-theme-primary-text-default:       #{$bolt-theme-primary-text-default};
+  --bolt-theme-primary-border-default:     #{$bolt-theme-primary-border-default};
 
-  --bolt-theme-primary-background-active: $bolt-theme-primary-background-active;
-  --bolt-theme-primary-text-active:       $bolt-theme-primary-text-active;
-  --bolt-theme-primary-border-active:     $bolt-theme-primary-border-active;
+  --bolt-theme-primary-background-hover: #{$bolt-theme-primary-background-hover};
+  --bolt-theme-primary-text-hover:       #{$bolt-theme-primary-text-hover};
+  --bolt-theme-primary-border-hover:     #{$bolt-theme-primary-border-hover};
 
-  --bolt-theme-primary-background-focus: $bolt-theme-primary-background-focus;
-  --bolt-theme-primary-text-focus:       $bolt-theme-primary-text-focus;
-  --bolt-theme-primary-border-focus:     $bolt-theme-primary-border-focus;
+  --bolt-theme-primary-background-active: #{$bolt-theme-primary-background-active};
+  --bolt-theme-primary-text-active:       #{$bolt-theme-primary-text-active};
+  --bolt-theme-primary-border-active:     #{$bolt-theme-primary-border-active};
+
+  --bolt-theme-primary-background-focus: #{$bolt-theme-primary-background-focus};
+  --bolt-theme-primary-text-focus:       #{$bolt-theme-primary-text-focus};
+  --bolt-theme-primary-border-focus:     #{$bolt-theme-primary-border-focus};
 
   background-color: $bolt-theme-background;
   color: $bolt-theme-text;


### PR DESCRIPTION
Across the board hotfix for all CSS custom property-based theming disappearing on the built Bolt site (locally and on prod) due to some recent change with how CSS vars no longer permit Sass functions / variables to be used as CSS var property values without interpolation (similar to https://github.com/jgthms/bulma/issues/1283#issue-264285920)

Haven't been able to pinpoint the exact breaking change on this with the build tools dependencies or why we haven't gotten any warnings / errors on this but I can confirm this fixes the problem locally. My suspicion is that a dependency change downstream is ultimately what's causing this (unconfirmed)


CC @mikemai2awesome @theSadowski @EvanLovely @rockymountainhigh1943 @joekarasek @charginghawk 