### PR TITLE
Adding WebPack stats option to build tools

### DIFF
--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -36,6 +36,10 @@ async function updateConfig(options, programInstance) {
       ? config.openServerAtStart
       : options.open;
 
+    config.webpackStats = typeof options.webpackStats === 'undefined'
+      ? config.webpackStats
+      : options.webpackStats;
+
     config.webpackDevServer = typeof options.webpackDevServer === 'undefined'
       ? config.webpackDevServer
       : options.webpackDevServer;
@@ -74,8 +78,7 @@ log.intro();
 program
   .command('build')
   .description('Build it')
-  .option('-W, --watch', 'Watch and rebuild')
-  .option('-P, --parallel', 'Run build in parallel instead of a series. Faster, but some assets might not be ready in time.')
+  .option('--webpack-stats', configSchema.properties.webpackStats.description)
   .option('-Q, --quick', configSchema.properties.quick.description)
   .action(async (options) => {
     log.info(`Starting build (${options.parallel ? 'parallel' : 'serial'})`);
@@ -138,6 +141,7 @@ program
   .command('webpack')
   .alias('wp')
   .description('WebPack Compile')
+  .option('--webpack-stats', configSchema.properties.webpackStats.description)
   .action(async (options) => {
     await updateConfig(options, program);
     try {

--- a/packages/build-tools/tasks/webpack-tasks.js
+++ b/packages/build-tools/tasks/webpack-tasks.js
@@ -7,6 +7,10 @@ const events = require('../utils/events');
 const log = require('../utils/log');
 const { getConfig } = require('../utils/config-store');
 const ora = require('ora');
+const { promisify } = require('util');
+const fs = require('fs');
+const writeFile = promisify(fs.writeFile);
+const path = require('path');
 const timer = require('../utils/timer');
 
 const config = getConfig();
@@ -17,7 +21,11 @@ function compile() {
     const webpackSpinner = ora(chalk.blue('Building WebPack bundle...')).start();
     const startTime = timer.start();
     const spinFailed = () => webpackSpinner.fail(chalk.red('Building WebPack Failed'));
-    webpack(webpackConfig).run((err, stats) => {
+    if (config.webpackStats) {
+      webpackConfig.profile = true;
+      webpackConfig.parallelism = 1;
+    }
+    webpack(webpackConfig).run(async (err, stats) => {
       if (err) {
         spinFailed();
         return reject(err);
@@ -63,6 +71,12 @@ function compile() {
         console.log('---');
         console.log(output);
         console.log('===\n');
+      }
+
+      if (config.webpackStats) {
+        const statsFilePath = path.join(config.buildDir, 'webpack-stats.json');
+        await writeFile(statsFilePath, JSON.stringify(stats.toJson(), null, '  '));
+        log.info(`Wrote WebPack stats json file to "${path.relative(process.cwd(), statsFilePath)}"`);
       }
 
       // log.taskDone('build: webpack');

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -24,6 +24,7 @@ const defaultConfig = {
   webpackDevServer: configSchema.properties.webpackDevServer.default,
   prod: process.env.NODE_ENV === 'production',
   startPath: configSchema.properties.startPath.default,
+  webpackStats: configSchema.properties.webpackStats.default,
 };
 
 function getEnvVarsConfig() {

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -28,6 +28,11 @@
     srcDir:
       type: string
       title: Source Directory
+    webpackStats:
+      type: boolean
+      title: Write WebPack stats file
+      description: Creates a [WebPack Stats Data file](https://webpack.js.org/api/stats/) called `webpack-stats.json` inside `buildDir`.
+      default: false
     publicPath:
       type: string
       title: publicPath Directory

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -31,7 +31,7 @@
     webpackStats:
       type: boolean
       title: Write WebPack stats file
-      description: Creates a [WebPack Stats Data file](https://webpack.js.org/api/stats/) called `webpack-stats.json` inside `buildDir`.
+      description: Creates a [WebPack Stats Data file](https://webpack.js.org/api/stats/) called `webpack-stats.json` inside `buildDir`. Great for [this](http://webpack.github.io/analyse).
       default: false
     publicPath:
       type: string

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -31,7 +31,7 @@
     webpackStats:
       type: boolean
       title: Write WebPack stats file
-      description: Creates a [WebPack Stats Data file](https://webpack.js.org/api/stats/) called `webpack-stats.json` inside `buildDir`. Great for [this](http://webpack.github.io/analyse).
+      description: Creates a [WebPack Stats Data file](https://webpack.js.org/api/stats/) called `webpack-stats.json` inside `buildDir`. Great for [this](http://webpack.github.io/analyse). Should probably run with `--prod`.
       default: false
     publicPath:
       type: string


### PR DESCRIPTION
This allows one to pass `--webpack-stats` to either `bolt build` or `bolt webpack`, and will output `webpack-stats.json` in the `buildDir`. This is what most WebPack analyziation tools want, in particular the [official one](http://webpack.github.io/analyse/).