### PR TITLE
return "default" for spacing utility classes

### DIFF
--- a/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
+++ b/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
@@ -16,7 +16,7 @@ $bolt-spacing-stretched: 1.5;
 /// Bolt's definition of spacing scale
 /// @type Map
 $bolt-spacing-values: (
-  //'':        1,
+  '':        1,
   'xxsmall': 0.125,
   'xsmall':  0.25,
   'small':   0.5,
@@ -26,8 +26,6 @@ $bolt-spacing-values: (
   'xxlarge': 8
 );
 @include export-data('spacing/scale.bolt.json', $bolt-spacing-values);
-
-$bolt-spacing-sizes: ();
 
 $bolt-spacing-properties: (
   'padding',

--- a/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
+++ b/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
@@ -16,7 +16,7 @@ $bolt-spacing-stretched: 1.5;
 /// Bolt's definition of spacing scale
 /// @type Map
 $bolt-spacing-values: (
-  '':        1,
+  '':        1, // @todo: add deprecation warning once Sass tools are in. Remove in Bolt v2.0
   'xxsmall': 0.125,
   'xsmall':  0.25,
   'small':   0.5,


### PR DESCRIPTION
As requested from the Drupal team, [BDS-210](http://vjira2:8080/browse/BDS-201), utility spacing classes now have a "default" of medium size if a size in not included in the utility class name. 
`.u-bolt-magin-bottom` and `.u-bolt-margin-bottom-medium` are equivalent.