### PR TITLE
Feature: Update Default Navbar Icon Size

### DIFF
--- a/packages/components/bolt-navbar/navbar-brand.twig
+++ b/packages/components/bolt-navbar/navbar-brand.twig
@@ -2,7 +2,7 @@
   <div class="c-bolt-navbar__brand-item">
     {% include "@bolt/icon.twig" with {
       "name": icon.name,
-      "size": "large"
+      "size": "medium"
     } only %}
   </div>
 

--- a/packages/components/bolt-navbar/navbar.twig
+++ b/packages/components/bolt-navbar/navbar.twig
@@ -17,7 +17,7 @@
 
 
 <bolt-navbar>
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: vspacing,
     theme: theme,
     fullBleed: true
@@ -25,7 +25,7 @@
 
     {% block band_background %}
       {% if gradient == "true" %}
-        {% include "@bolt/background.twig" with {
+        {% include "@bolt-components-background/background.twig" with {
           "opacity": "light",
           "fill": "gradient",
           "focalPoint":


### PR DESCRIPTION
Updating the default icon size in the navbar brand subcomponent to go from being `large` to `medium` per [BDS-210 ](http://vjira2:8080/browse/BDS-210?filter=-1)

CC @charginghawk @joekarasek 