### PR TITLE
Fix Bolt Site Version Referenced - use version from `lerna.json`, not `@bolt/built-tools`

### DIFF
--- a/packages/build-tools/utils/manifest.js
+++ b/packages/build-tools/utils/manifest.js
@@ -8,10 +8,11 @@ const { validateSchemaSchema } = require('./schemas');
 const path = require('path');
 const config = require('./config-store').getConfig();
 const pkg = require('../package.json');
+const lernaPkg = require('../../../lerna.json'); // Use the pkg version in lerna.json vs the pkg version for `@bolt/build-tools`
 
 let boltManifest = {
   name: 'Bolt Manifest',
-  version: pkg.version,
+  version: lernaPkg.version,
   components: {
     global: [],
     individual: [],


### PR DESCRIPTION
Tweaks how the `@bolt/build-tools` manifest figures out which version of Bolt should get displayed on the site by directly referencing the `lerna.json` version number in the root of the repo vs expecting the `@bolt/build-tools` version to always be set to the same version number (which isn't always the case)