### PR TITLE
Fix: Update Polyfill Loader, Link Unpublished Footer in PL

### DIFF
--- a/apps/pattern-lab/package.json
+++ b/apps/pattern-lab/package.json
@@ -46,7 +46,7 @@
     "@bolt/components-navbar": "^1.2.2",
     "@bolt/components-navlink": "^1.2.2",
     "@bolt/components-ordered-list": "^1.2.2",
-    "@bolt/components-page-footer": "^1.1.2",
+    "@bolt/components-page-footer": "file:../../packages/components/bolt-page-footer",
     "@bolt/components-page-header": "^1.2.2",
     "@bolt/components-placeholder": "^1.2.2",
     "@bolt/components-share": "^1.2.2",

--- a/packages/core/polyfills/polyfill-loader.js
+++ b/packages/core/polyfills/polyfill-loader.js
@@ -66,12 +66,11 @@ export const polyfillLoader = new Promise((resolve) => {
         throw new Error(`Could not load ${webComponentPolyfillPath}. Error: ${error}`);
       });
   } else {
-    import(/* webpackChunkName: "custom-elements-es5-adapter" */
-      '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js').then(() => {
+    import('document-register-element').then(() => {
         resolve();
       })
       .catch((error) => {
-        throw new Error(`Could not load @webcomponents/webcomponentsjs/custom-elements-es5-adapter.js.
+        throw new Error(`Could not load document-register-element.
         Error: ${error}`);
       });
   }

--- a/packages/core/polyfills/polyfill-loader.js
+++ b/packages/core/polyfills/polyfill-loader.js
@@ -67,11 +67,11 @@ export const polyfillLoader = new Promise((resolve) => {
       });
   } else {
     import('document-register-element').then(() => {
-        resolve();
-      })
+      resolve();
+    })
       .catch((error) => {
         throw new Error(`Could not load document-register-element.
-        Error: ${error}`);
+      Error: ${error}`);
       });
   }
 }).catch((error) => {


### PR DESCRIPTION
- Updates the `@bolt/core` polyfill loader to always use the `document-register-element` instead of the es5 custom element adapter to avoid load order issues depending on if a component is lazy loaded or loaded immediately

- Update the unpublished footer component referenced in PL to get locally referenced to make local testing / installs work