### PR TITLE
Adding yaml-loader

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -276,6 +276,13 @@ function createConfig(config) {
             name: '[name].[ext]',
           },
         },
+        {
+          test: [/\.yml$/, /\.yaml$/],
+          use: [
+            { loader: 'json-loader' },
+            { loader: 'yaml-loader' },
+          ],
+        },
       ],
     },
     plugins: [

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -62,7 +62,8 @@
     "uglifyjs-webpack-plugin": "^1.2.0",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0",
-    "webpack-manifest-plugin": "^2.0.0-rc.1"
+    "webpack-manifest-plugin": "^2.0.0-rc.1",
+    "yaml-loader": "^0.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7354,7 +7354,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0, js-yaml@^3.8.3, js-yaml@^3.9.0:
+js-yaml@^3.10.0, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.5.2, js-yaml@^3.7.0, js-yaml@^3.8.3, js-yaml@^3.9.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
@@ -13654,6 +13654,12 @@ yaml-lint@^1.2.2:
     lodash.merge "^4.6.1"
     lodash.snakecase "^4.1.1"
     nconf "^0.10.0"
+
+yaml-loader@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/yaml-loader/-/yaml-loader-0.5.0.tgz#86b1982d84a8e429e6647d93de9a0169e1c15827"
+  dependencies:
+    js-yaml "^3.5.2"
 
 yargs-parser@^4.1.0, yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
This allows the ability to `import` or `require` yaml files in JS and get a JS object back. This will be useful for JS files that want to get access to their schema, like so:

```js
import schema from '../button.schema.yml';
// or
const schema = require('../button.schema.yml');
```