### PR TITLE
Tweaking how paragraphs display

### DIFF
--- a/apps/drupal-lab/config/sync/core.entity_form_display.node.page.default.yml
+++ b/apps/drupal-lab/config/sync/core.entity_form_display.node.page.default.yml
@@ -24,10 +24,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
     region: content
   promote:

--- a/apps/drupal-lab/config/sync/core.entity_form_display.paragraph.grid.default.yml
+++ b/apps/drupal-lab/config/sync/core.entity_form_display.paragraph.grid.default.yml
@@ -18,10 +18,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
     region: content
 hidden:

--- a/apps/drupal-lab/web/themes/flash/flash.info.yml
+++ b/apps/drupal-lab/web/themes/flash/flash.info.yml
@@ -2,7 +2,7 @@ name: Flash
 type: theme
 description: A theme that uses Bolt
 core: 8.x
-base theme: stable
+base theme: classy
 screenshot: screenshot.jpg
 libraries:
   - flash/global

--- a/apps/drupal-lab/web/themes/flash/templates/paragraph--headline.html.twig
+++ b/apps/drupal-lab/web/themes/flash/templates/paragraph--headline.html.twig
@@ -103,15 +103,15 @@
 
 <div style="border-bottom: 1px dotted;padding: 50px;">
   {% include '@bolt-components-headline/headline.twig' with headline only %}
-  {% if headline|length > 1 %}
-    <h4>Attributes</h4>
-    <ul>
-      {% for key, param in headline %}
-        {% if key != 'text' %}
-          {% set val = key != 'icon' ? param : param.name %}
-          <li><strong>{{ key }}:</strong> {{ val }}</li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-  {% endif %}
+  {#{% if headline|length > 1 %}#}
+    {#<h4>Attributes</h4>#}
+    {#<ul>#}
+      {#{% for key, param in headline %}#}
+        {#{% if key != 'text' %}#}
+          {#{% set val = key != 'icon' ? param : param.name %}#}
+          {#<li><strong>{{ key }}:</strong> {{ val }}</li>#}
+        {#{% endif %}#}
+      {#{% endfor %}#}
+    {#</ul>#}
+  {#{% endif %}#}
 </div>


### PR DESCRIPTION
- Shows the paragraph items as collapsed for easier re-ordering.
- Switching base theme from stable to classy, so we have nice display for basic Drupal things like "View, Edit" links