### PR TITLE
Fix Block Object's Alignment Options

### DIFF
--- a/packages/global/styles/05-objects/objects-block/_objects-block.scss
+++ b/packages/global/styles/05-objects/objects-block/_objects-block.scss
@@ -14,7 +14,7 @@ $bolt-block-sizes: (
   'medium': medium,
   'large':  large
 );
-$bolt-block-alignments: ('left', 'center', 'right');
+$bolt-block-alignments: (left, center, right);
 
 
 


### PR DESCRIPTION
Fix the Sass output for the block object's align options (broken otherwise)