### PR TITLE
Chore: Normalize Font Weights

### DIFF
--- a/apps/pattern-lab/src/styles/_docs.scss
+++ b/apps/pattern-lab/src/styles/_docs.scss
@@ -171,7 +171,7 @@ pre {
 }
 
 .c-bolt-docs__lead {
-  @include bolt-font-weight(regular);
+  @include bolt-font-weight(normal);
   border: 1px dotted transparent;
   border-radius: 4px;
   color: bolt-color(black);

--- a/packages/components/bolt-headline/src/_tools.headlines.scss
+++ b/packages/components/bolt-headline/src/_tools.headlines.scss
@@ -36,7 +36,7 @@
   }
 
   &--regular {
-    @include bolt-font-weight(regular);
+    @include bolt-font-weight(normal);
   }
 
   &--bold {

--- a/packages/components/bolt-headline/src/headline.scss
+++ b/packages/components/bolt-headline/src/headline.scss
@@ -89,7 +89,7 @@ $bolt-headline--plus-letter-spacing: 0.05rem;
 .c-bolt-subheadline {
   @include bolt-margin-bottom(medium);
   @include bolt-font-family(heading);
-  @include bolt-font-weight(regular);
+  @include bolt-font-weight(normal);
 
   &:not([class*='c-bolt-subheadline--']) {
     @include bolt-font-size(large);

--- a/packages/core/styles/01-settings/settings-font-family/_settings-font-family.scss
+++ b/packages/core/styles/01-settings/settings-font-family/_settings-font-family.scss
@@ -27,7 +27,6 @@ $bolt-font-family--mono-fallback: monospace;
  * Custom web font stacks
  */
 $bolt-font-family--sans:  'Open Sans', 'Helvetica Neue', sans-serif;
-$bolt-font-family--sans-subset: 'OpenSansSubset', 'Helvetica Neue', sans-serif;
 $bolt-font-family--serif: 'Georgia', serif;
 $bolt-font-family--mono:  'Courier New', monospace;
 
@@ -44,11 +43,6 @@ $bolt-font-families: (
       fallback-font: $bolt-font-family--sans-fallback,
       custom-font:   $bolt-font-family--sans,
       loaded-class:  $bolt-fonts--loaded-class
-    ),
-    bodySubset: (
-      fallback-font: $bolt-font-family--sans-fallback,
-      custom-font: $bolt-font-family--sans-subset,
-      loaded-class: $bolt-fonts--subset-loaded-class
     ),
     heading: (
       fallback-font: $bolt-font-family--sans-fallback,

--- a/packages/core/styles/01-settings/settings-font-weight/_settings-font-weight.scss
+++ b/packages/core/styles/01-settings/settings-font-weight/_settings-font-weight.scss
@@ -36,7 +36,8 @@ $bolt-font-weights: (
   font-weights: (
     bold:     $bolt-font-weight--bold,
     semibold: $bolt-font-weight--semibold,
-    regular:  $bolt-font-weight--regular,
     normal:   $bolt-font-weight--regular
   )
 ) !default;
+
+@include export-data('typography/font-weights.bolt.json', $bolt-font-weights);

--- a/packages/core/styles/01-settings/settings-global/_settings-global.scss
+++ b/packages/core/styles/01-settings/settings-global/_settings-global.scss
@@ -14,7 +14,6 @@ $bolt-base-font-size--min: 15px;
 $bolt-base-font-size--max: 18px;
 
 // Async font loading classes.
-$bolt-fonts--subset-loaded-class: 'js-fonts-subset-loaded' !default;
 $bolt-fonts--loaded-class: 'js-fonts-loaded' !default;
 
 // @todo Salem, we should probably deprecate these so there is only one way to do shadows

--- a/packages/global/styles/04-elements/_elements-page.scss
+++ b/packages/global/styles/04-elements/_elements-page.scss
@@ -14,7 +14,6 @@ html {
 }
 
 body {
-  @include bolt-font-family(bodySubset);
   @include bolt-font-family(body);
   @include bolt-font-size(medium);
   width: 100%;


### PR DESCRIPTION
Removes the "regular" font weight option so the browser-specific `normal` config option gets used consistently across the board

CC @mikemai2awesome 