### PR TITLE
Feat: Restructure `@font-face` To Be Exportable

### DIFF
--- a/packages/core/styles/01-settings/settings-font-family/_settings-font-family.scss
+++ b/packages/core/styles/01-settings/settings-font-family/_settings-font-family.scss
@@ -62,3 +62,5 @@ $bolt-font-families: (
     )
   )
 );
+
+@include export-data('typography/font-families.bolt.json', $bolt-font-families);

--- a/packages/global/styles/03-generic/_generic-font-stacks.scss
+++ b/packages/global/styles/03-generic/_generic-font-stacks.scss
@@ -2,55 +2,80 @@
   GENERIC - FONT STACKS
 \* ------------------------------------ */
 
-@font-face {
-  font-family: OpenSansSubset;
-  src: url('../../fonts/opensans-subset.woff2') format('woff2'),
-  url('../../fonts/opensans-subset.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-  unicode-range: U+65-U+90, U+97-122;
+$bolt-font-stacks: (
+  openSansRegular: (
+    fontFamily: 'Open Sans',
+    style: normal,
+    weight: 400,
+    src: (
+      woff: '../../fonts/opensans-regular.woff',
+      woff2: '../../fonts/opensans-regular.woff2',
+    )
+  ),
+  openSansItalic: (
+    fontFamily: 'Open Sans',
+    style: italic,
+    weight: 400,
+    src: (
+      woff: '../../fonts/opensans-italic.woff',
+      woff2: '../../fonts/opensans-italic.woff2',
+    )
+  ),
+  openSansSemiBold: (
+    fontFamily: 'Open Sans',
+    style: normal,
+    weight: 600,
+    src: (
+      woff: '../../fonts/opensans-semibold.woff',
+      woff2: '../../fonts/opensans-semibold.woff2',
+    )
+  ),
+  openSansBoldItalic: (
+    fontFamily: 'Open Sans',
+    style: italic,
+    weight: 700,
+    src: (
+      woff: '../../fonts/opensans-bolditalic.woff',
+      woff2: '../../fonts/opensans-bolditalic.woff2',
+    )
+  ),
+  openSansExtraBold: (
+    fontFamily: 'Open Sans',
+    style: normal,
+    weight: 800,
+    src: (
+      woff: '../../fonts/opensans-extrabold.woff',
+      woff2: '../../fonts/opensans-extrabold.woff2',
+    )
+  ),
+  openSansExtraBoldItalic: (
+    fontFamily: 'Open Sans',
+    style: italic,
+    weight: 800,
+    src: (
+      woff: '../../fonts/opensans-extrabolditalic.woff',
+      woff2: '../../fonts/opensans-extrabolditalic.woff2',
+    )
+  )
+);
+
+
+
+@each $fontName, $fontValue in $bolt-font-stacks {
+  $fontSrc: null;
+  $fontSources: map-get($fontValue, 'src');
+
+  @each $ext, $path in $fontSources {
+    $fontSrc: append($fontSrc, url('#{$path}') format(quote($ext)), comma);
+  }
+
+  @font-face {
+    font-family: map-get($fontValue, 'fontFamily');
+    src: $fontSrc;
+    font-weight: map-get($fontValue, 'weight');
+    font-style: map-get($fontValue, 'style');
+  }
 }
 
-@font-face {
-  font-family: 'Open Sans';
-  src: url('../../fonts/opensans-regular.woff2') format('woff2'), url('../../fonts/opensans-regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-}
 
-@font-face {
-  font-family: 'Open Sans';
-  src: url('../../fonts/opensans-italic.woff2') format('woff2'), url('../../fonts/opensans-italic.woff') format('woff');
-  font-weight: 400;
-  font-style: italic;
-}
-
-
-@font-face {
-  font-family: 'Open Sans';
-  src: url('../../fonts/opensans-semibold.woff2') format('woff2'), url('../../fonts/opensans-semibold.woff') format('woff');
-  font-weight: 600;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Open Sans';
-  src: url('../../fonts/opensans-bolditalic.woff2') format('woff2'), url('../../fonts/opensans-bolditalic.woff') format('woff');
-  font-weight: 700;
-  font-style: italic;
-}
-
-
-@font-face {
-  font-family: 'Open Sans';
-  src: url('../../fonts/opensans-extrabold.woff2') format('woff2'), url('../../fonts/opensans-extrabold.woff') format('woff');
-  font-weight: 800;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Open Sans';
-  src: url('../../fonts/opensans-extrabolditalic.woff2') format('woff2'), url('../../fonts/opensans-extrabolditalic.woff') format('woff');
-  font-weight: 800;
-  font-style: italic;
-}
+@include export-data('typography/font-stacks.bolt.json', $bolt-font-stacks);


### PR DESCRIPTION
Refactors how we wire up `@font-face` font families to be exportable as JSON data -- part of the underlying work related to wiring up our font loader JS to the actual font families used in the design system.