### PR TITLE
Add @bolt/core dependencies to the few packages that lacked such.

### DIFF
--- a/packages/components/bolt-chip-list/package.json
+++ b/packages/components/bolt-chip-list/package.json
@@ -30,6 +30,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@bolt/core": "^1.3.0",
     "@bolt/components-chip": "^1.3.0",
     "@bolt/global": "^1.3.0"
   },

--- a/packages/components/bolt-chip-list/package.json
+++ b/packages/components/bolt-chip-list/package.json
@@ -31,8 +31,7 @@
   },
   "dependencies": {
     "@bolt/core": "^1.3.0",
-    "@bolt/components-chip": "^1.3.0",
-    "@bolt/global": "^1.3.0"
+    "@bolt/components-chip": "^1.3.0"
   },
   "schema": "chip-list.schema.yml"
 }

--- a/packages/components/bolt-link/package.json
+++ b/packages/components/bolt-link/package.json
@@ -19,5 +19,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@bolt/core": "^1.3.0"
+  },
   "schema": "link.schema.yml"
 }

--- a/packages/components/bolt-page-footer/package.json
+++ b/packages/components/bolt-page-footer/package.json
@@ -5,6 +5,9 @@
   "sourceFilesFrom": "0.9.0",
   "license": "MIT",
   "private": true,
+  "dependencies": {
+    "@bolt/core": "^1.3.0"
+  },
   "style": "page-footer.scss",
   "schema": "page-footer.schema.yml",
   "bugs": "https://github.com/bolt-design-system/bolt/issues",

--- a/packages/components/bolt-site/package.json
+++ b/packages/components/bolt-site/package.json
@@ -18,5 +18,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@bolt/core": "^1.3.0"
+  },
   "style": "site.scss"
 }

--- a/packages/components/bolt-smooth-scroll/package.json
+++ b/packages/components/bolt-smooth-scroll/package.json
@@ -35,6 +35,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@bolt/core": "^1.3.0",
     "smooth-scroll": "^12.1.5"
   }
 }

--- a/packages/components/bolt-sticky/package.json
+++ b/packages/components/bolt-sticky/package.json
@@ -37,6 +37,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@bolt/core": "^1.3.0",
     "stickyfilljs": "^2.0.3"
   },
   "schema": "sticky.schema.yml"


### PR DESCRIPTION
When Bolt undergoes an update (eg recently to 1.3), there's consistently a few packages that get left behind due to lacking a @bolt/core dependency. For instance, here's the current version of all packages:

```
@bolt/components-placeholder       v1.3.0
@bolt/components-action-blocks     v1.3.0
@bolt/components-background-shapes v1.3.0
@bolt/components-background        v1.3.0
@bolt/components-band              v1.3.0
@bolt/components-block-list        v1.3.0
@bolt/components-blockquote        v1.3.0
@bolt/components-breadcrumb        v1.3.0
@bolt/components-button-group      v1.3.0
@bolt/components-button            v1.3.0
@bolt/components-card              v1.3.0
@bolt/components-dropdown          v1.3.0
@bolt/components-chip-list         v1.3.0
@bolt/components-chip              v1.3.0
@bolt/components-copy-to-clipboard v1.3.0
@bolt/components-critical-fonts    v1.3.0
@bolt/components-device-viewer     v1.3.0
@bolt/components-figure            v1.3.0
@bolt/components-form              v1.3.0
@bolt/components-headline          v1.3.0
@bolt/components-icon              v1.3.0
@bolt/components-icons             v1.3.0
@bolt/components-image             v1.3.0
@bolt/components-link              v1.1.2
@bolt/components-logo              v1.3.0
@bolt/components-navbar            v1.3.0
@bolt/components-nav               v1.3.0
@bolt/components-navlink           v1.3.0
@bolt/components-ordered-list      v1.3.0
@bolt/components-page-header       v1.3.0
@bolt/components-share             v1.3.0
@bolt/components-site              v1.1.2
@bolt/components-smooth-scroll     v1.2.4
@bolt/components-sticky            v1.2.0
@bolt/components-teaser            v1.3.0
@bolt/components-tooltip           v1.3.0
@bolt/components-unordered-list    v1.3.0
@bolt/components-video             v1.3.0
@bolt/core                         v1.3.0
@bolt/global                       v1.3.0
```

You can spot the outliers. This PR gets the stragglers back in the fold.