### PR TITLE
Close Button on Firefox

### DIFF
--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -40,6 +40,7 @@ bolt-icon {
   z-index: bolt-z-index('content');
   color: inherit;
   color: var(--bolt-theme-icon, inherit);
+  pointer-events: none;
 
   // The primary goal of this is to set the transition for icon color.  Perhaps it's a
   // bit heavy-handed, but it seems more robust than just applying this to, say, 'path' elements.


### PR DESCRIPTION
Very small icon on firefox would not fire event upon being clicked. Adding point-event:none addresses this.
In hotfix for immediate release in PR https://github.com/bolt-design-system/bolt/pull/685