### PR TITLE
BDS-187 Replace foreach method on NodeList object

### DIFF
--- a/apps/pattern-lab/src/scripts/pl.js
+++ b/apps/pattern-lab/src/scripts/pl.js
@@ -26,7 +26,8 @@ document.addEventListener('DOMContentLoaded', () => {
    * Make sure all external facing links open in a new tab in PL.
    * Important as external links can behave strangely within the iframe setup of PL.
    */
-  document.querySelectorAll('a').forEach((item) => {
+  const linksNodeList = document.querySelectorAll('a');
+  Array.prototype.forEach.call(linksNodeList, function (item) {
     const href = item.getAttribute('href');
     if (href){
       if (href.startsWith('http')) {


### PR DESCRIPTION
NodeLists can't be iterated on using forEach() in older browsers.
See https://developer.mozilla.org/en-US/docs/Web/API/NodeList for details.