### PR TITLE
Fix background video not going fullscreen issue.

### DIFF
--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -48,7 +48,6 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
     }
 
     .video-js {
-      max-width: 1400px;
       margin: 0 auto;
       min-width: 0;
       width: 100%;
@@ -56,6 +55,10 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
       transition: all .4s ease;
       width: 100%;
       height: 100%;
+
+      &:not(.vjs-fullscreen) {
+        max-width: 1400px;
+      }
     }
   }
 }


### PR DESCRIPTION
When clicking the fullscreen button on a background video, it doesn't go fullscreen because of the max-width of 1400px.