### PR TITLE
Headline Component Updates > xxxl fluid size & extra wrapper

### DIFF
--- a/packages/components/bolt-headline/src/_tools.headlines.scss
+++ b/packages/components/bolt-headline/src/_tools.headlines.scss
@@ -19,11 +19,18 @@
     @include bolt-margin-bottom(0);
   }
 
-
   // Headline + Icon and/or Icon + Headline Spacing
-  &__text ~ &__icon,
-  &__icon ~ &__text {
-    @include bolt-margin-left(xxsmall);
+  &--icon-position-before,
+  &--icon-position-left {
+    .c-bolt-headline__icon {
+      @include bolt-margin-right(xxsmall);
+    }
+  }
+  &--icon-position-after,
+  &--icon-position-right {
+    .c-bolt-headline__icon {
+      @include bolt-margin-left(xxsmall);
+    }
   }
 }
 

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -39,7 +39,8 @@
   style in styles and type == "text" ? baseClass ~ "--" ~ style : "",
   size in sizes and type != "eyebrow" ? longTitle and type == "headline" ? baseClass ~ "--" ~ size ~ "-min" : baseClass ~ "--" ~ size : "",
   transform in transformProps and transform != "" ? baseClass ~ "--" ~ transform : "",
-  url ? baseClass ~ "--link" : ""
+  url ? baseClass ~ "--link" : "",
+  iconPosition ? baseClass ~ "--icon-position-" ~ iconPosition : ""
 ] %}
 
 {% if url and icon is not defined %}
@@ -55,27 +56,25 @@
     </span>
   {% endif %}
 
-  <span class="{{ "#{baseClass}__text" }}">
-    {% if url %}
-      {% if type == "text" %}
-        {% include "@bolt/link.twig" with {
-          text: text,
-          icon: icon,
-          url: url,
-        } only %}
-      {% else %}
-        {# [Mai] This means only headlines/subheadlines/eyebrows would get the special link styles #}
-        {% include "@bolt/link.twig" with {
-          text: text,
-          icon: icon,
-          url: url,
-          isHeadline: true
-        } only %}
-      {% endif %}
+  {% if url %}
+    {% if type == "text" %}
+      {% include "@bolt/link.twig" with {
+        text: text,
+        icon: icon,
+        url: url,
+      } only %}
     {% else %}
-      {{ text }}
+      {# [Mai] This means only headlines/subheadlines/eyebrows would get the special link styles #}
+      {% include "@bolt/link.twig" with {
+        text: text,
+        icon: icon,
+        url: url,
+        isHeadline: true
+      } only %}
     {% endif %}
-  </span>
+  {% else %}
+    {{ text }}
+  {% endif %}
 
   {% if icon and not url and iconPosition != "before" %}
     <span class="{{ "#{baseClass}__icon" }}">

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -27,7 +27,7 @@
 {% set attributes = create_attribute(attributes|default({})) %}
 
 {% if (size == "xxxlarge") and (text|length >= 60) %}
-  {% set size = "xxlarge" %}
+  {% set longTitle = true %}
 {% endif %}
 
 
@@ -37,7 +37,7 @@
   weight in weights ? baseClass ~ "--" ~ weight : "",
   align in alignments and align != null ? baseClass ~ "--" ~ align : "",
   style in styles and type == "text" ? baseClass ~ "--" ~ style : "",
-  size in sizes and type != "eyebrow" ? baseClass ~ "--" ~ size : "",
+  size in sizes and type != "eyebrow" ? longTitle and type == "headline" ? baseClass ~ "--" ~ size ~ "-min" : baseClass ~ "--" ~ size : "",
   transform in transformProps and transform != "" ? baseClass ~ "--" ~ transform : "",
   url ? baseClass ~ "--link" : ""
 ] %}

--- a/packages/components/bolt-headline/src/headline.scss
+++ b/packages/components/bolt-headline/src/headline.scss
@@ -136,6 +136,11 @@ $bolt-headline--plus-letter-spacing: 0.05rem;
   @include bolt-font-size(xxxlarge);
 }
 
+// When headline is 60+ chars long
+.c-bolt-headline--xxxlarge-min {
+  font-size: $bolt-font-size--xxxlarge--min;
+}
+
 .c-bolt-text--xxlarge,
 .c-bolt-subheadline--xxlarge,
 .c-bolt-headline--xxlarge {


### PR DESCRIPTION
This simple PR fixes an issue where the xxxl font size larger than 60 characters long was being switched to xxl font size. With these adjustments made we'll now be setting the font size to `$bolt-font-size--xxxlarge--min` rather than dropping down one full size.

This PR also removes an necessary wrapper when including an icon.