### PR TITLE
Fix: remove z-index on blockquote image

### DIFF
--- a/packages/components/bolt-blockquote/src/blockquote.scss
+++ b/packages/components/bolt-blockquote/src/blockquote.scss
@@ -119,16 +119,9 @@ bolt-blockquote {
 }
 
 
-/**
- * 1. Workaround to address weird Safari bug w/ overflow + border radius
- *    https://gist.github.com/adamcbrewer/5859738#gistcomment-2008691
- */
-
 // Attribution
 .c-bolt-blockquote__image {
   display: inline-block;
-  position: relative; /* [1] */
-  z-index: bolt-z-index('backgroundTop'); /* [1] */
   width: $bolt-blockquote-image-size;
   height: $bolt-blockquote-image-size;
   border-width: $bolt-blockquote-image-border-width;


### PR DESCRIPTION
z-index on the blockquote image is creating undesired results (ie, covering up things that has lower z-index). It was intended to be a fix for Safari where border radius and overflow are not cropping the image, but that is not true anymore, tested in all versions of Safari to confirm.

So z-index and position relative has been removed. 

See demo: https://fix-wwwd-2149-blockquote-image-z-index-remove.bolt-design-system.com/pattern-lab/?p=components-blockquote-alignItems-variation