### PR TITLE
fix: Fix nav indicator positioning in IE (WWWD-2150)

### DIFF
--- a/packages/components/bolt-nav/nav.scss
+++ b/packages/components/bolt-nav/nav.scss
@@ -48,7 +48,7 @@ bolt-nav {
   @include respond-to(small) {
     opacity: 1; // [Mai] This is interrelated with the dropdown component.
     bottom: 0; // [Mai] This is interrelated with the dropdown component.
-    left: auto; // [Mai] This is interrelated with the dropdown component.
+    left: 0; // [Mai] This is interrelated with the dropdown component.
   }
 
   .c-bolt-nav--xsmall & {


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/WWWD-2150

## Summary
This backs out the change introduced at 
https://github.com/bolt-design-system/bolt/commit/d25ec362#diff-5c1b2065daa942358746a52cf8077fc2L83.  It's unclear whether there was an important reason for that change-- everything _seems_ to still work as expected after removing it.

## Testing instructions
In IE, visit https://fix-WWWD-2150-navbar-indicator-positioning-IE.bolt-design-system.com/pattern-lab/patterns/02-components-sticky--15-sticky-with-content-example/02-components-sticky--15-sticky-with-content-example.html and click the navbar links.  The nav indicator underline should animate to the correct position under each link (as it currently does in other browsers).

Important note for @sghoweri: this does not fix the indicator positioning in IE for the nav when displayed inside the dropdown component (https://fix-WWWD-2150-navbar-indicator-positioning-IE.bolt-design-system.com/pattern-lab/?p=components-dropdown-collapse).  That appears to be broken both before and after this fix for a separate reason.