### PR TITLE
Video Enhancement - Collapse video when clicking away

### DIFF
--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -96,6 +96,8 @@ class BoltVideo extends withPreact(withComponent()) {
     // This binding is necessary to make `this` work in the callback
     this.handleClose = this.handleClose.bind(this);
 
+    this.collapseOnClickAway = this.collapseOnClickAway.bind(this);
+
     // BoltVideo.globalErrors.forEach(this.props.onError);
 
     this.defaultProps = {
@@ -354,11 +356,23 @@ class BoltVideo extends withPreact(withComponent()) {
     }
 
     window.addEventListener('optimizedResize', this._onWindowResize);
-  }
 
+    // If our video can expand/collapse we add the collapse listener
+    if (this.props.isBackgroundVideo) {
+      document.addEventListener('click', this.collapseOnClickAway);
+    }
+  }
 
   _onWindowResize(event) {
     this._calculateIdealVideoSize();
+  }
+
+  // If we click outside bolt-video we collapse
+  collapseOnClickAway(event) {
+    const videoTag = document.querySelector('bolt-video');
+    if (!videoTag.contains(event.target)) {
+      this.close();
+    }
   }
 
   // shouldUpdate(props, state) {

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -367,10 +367,10 @@ class BoltVideo extends withPreact(withComponent()) {
     this._calculateIdealVideoSize();
   }
 
-  // If we click outside bolt-video we collapse
+  // If we click outside the video wrapper div collapse the video
   collapseOnClickAway(event) {
-    const videoTag = this.querySelector('.c-bolt-video--background');
-    if (!videoTag.contains(event.target)) {
+    const videoWrapper = this.querySelector('.c-bolt-video--background');
+    if (!videoWrapper.contains(event.target)) {
       this.close();
     }
   }

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -369,7 +369,7 @@ class BoltVideo extends withPreact(withComponent()) {
 
   // If we click outside bolt-video we collapse
   collapseOnClickAway(event) {
-    const videoTag = document.querySelector('bolt-video');
+    const videoTag = this.querySelector('.c-bolt-video--background');
     if (!videoTag.contains(event.target)) {
       this.close();
     }


### PR DESCRIPTION
This works with multiple videos on the page and is cross-browser / device tested.

**Testing Instructions**
1. Boot up PL
1. Navigate to http://localhost:3000/pattern-lab/patterns/02-components-video-video--background-video-with-inline-script-and-external-controls/02-components-video-video--background-video-with-inline-script-and-external-controls.html
1. Click the button to launch video
1. Click anywhere outside bolt-video to see the video close