### PR TITLE
Fix/wwwd 2183 chevron logic fix

### DIFF
--- a/apps/pattern-lab/src/_includes/utils/docs.twig
+++ b/apps/pattern-lab/src/_includes/utils/docs.twig
@@ -16,7 +16,7 @@
           tag: "h2",
           url: "#getting-started",
           text: "Getting Started",
-          icon: false,
+          icon: "none",
           attributes: {
             class: [
               "u-bolt-margin-bottom-xsmall",
@@ -37,7 +37,7 @@
         tag: "h2",
         url: "#usage",
         text: "Usage",
-        icon: false,
+        icon: "none",
         attributes: {
           class: [
             "u-bolt-margin-bottom-xsmall",
@@ -56,7 +56,7 @@
         tag: "h2",
         url: "#schema",
         text: "Schema",
-        icon: false,
+        icon: "none",
         attributes: {
           class: [
             "u-bolt-margin-bottom-xsmall",
@@ -77,7 +77,7 @@
         tag: "h2",
         url: "#helpful-links",
         text: "Helpful Links",
-        icon: false,
+        icon: "none",
         attributes: {
           class: [
             "u-bolt-margin-bottom-xsmall",
@@ -105,7 +105,7 @@
                 ],
                 'data-scroll-offset': 70
               },
-              icon: false,
+              icon: "none",
             } only %}
           </li>
         {% endfor %}
@@ -141,7 +141,7 @@
                     "u-bolt-margin-bottom-none"
                   ]
                 },
-                icon: false,
+                icon: "none",
               } only %}
             </li>
           {% endif %}
@@ -169,7 +169,7 @@
                     "u-bolt-margin-bottom-none"
                   ]
                 },
-                icon: false,
+                icon: "none",
               } only %}
             </li>
           {% endif %}
@@ -198,7 +198,7 @@
                     "u-bolt-margin-bottom-none"
                   ]
                 },
-                icon: false,
+                icon: "none",
               } only %}
             </li>
           {% endif %}
@@ -227,7 +227,7 @@
                     "u-bolt-margin-bottom-none"
                   ]
                 },
-                icon: false,
+                icon: "none",
               } only %}
             </li>
           {% endif %}

--- a/apps/pattern-lab/src/_patterns/02-components/headline/25-headline-icon-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/headline/25-headline-icon-variations.twig
@@ -23,10 +23,20 @@
 <h3>Headline w/ Default Icon Position</h3>
 {% include "@bolt-components-headline/headline.twig" with {
   text: "What we do at Pega is brilliant!",
+  icon: "chevron-right",
+} only %}
+<br><br>
+
+
+<h3>Headline w/ Icon Options</h3>
+{% include "@bolt-components-headline/headline.twig" with {
+  text: "What we do at Pega is brilliant!",
   icon: {
-    name: "chevron-right"
+    name: "energy",
+    color: "blue"
   }
 } only %}
+
 <br><br><br><br>
 
 <hr>

--- a/apps/pattern-lab/src/_patterns/02-components/headline/30-headline-link-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/headline/30-headline-link-variations.twig
@@ -4,21 +4,13 @@
 } only %}
 
 {% include "@bolt-components-headline/headline.twig" with {
-  text: "This headline is also a link, still with Default Icon",
-  url: "https://www.google.com",
-  icon: null
-} only %}
-
-{% include "@bolt-components-headline/headline.twig" with {
   text: "This headline is also a link, with Defined Icon",
   url: "https://www.google.com",
-  icon: {
-    name: "search"
-  }
+  icon: "search"
 } only %}
 
 {% include "@bolt-components-headline/headline.twig" with {
   text: "This headline is also a link, without an Icon",
   url: "https://www.google.com",
-  icon: false
+  icon: "none"
 } only %}

--- a/apps/pattern-lab/src/_patterns/02-components/headline/30-headline-link-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/headline/30-headline-link-variations.twig
@@ -4,6 +4,12 @@
 } only %}
 
 {% include "@bolt-components-headline/headline.twig" with {
+  text: "This headline is also a link, still with Default Icon",
+  url: "https://www.google.com",
+  icon: null
+} only %}
+
+{% include "@bolt-components-headline/headline.twig" with {
   text: "This headline is also a link, with Defined Icon",
   url: "https://www.google.com",
   icon: {

--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -67,13 +67,15 @@ properties:
     type: string
     description: If provided, turns headline into a link to given url.
   icon:
-    description: Bolt icon. Accepts the same options as Bolt Icon Component `@bolt-components-icon`.  If url is set, this will default to a right chevron unless you pass "false" or an alternate icon.
+    description: Bolt icon. Accepts either 1) an icon name as a string 2) an icon object as expected by `@bolt-components-icon` or 3) the string "none" to explicitly remove default icons
     anyOf:
-      -
-        type: object
+      - type: object
         ref: '@bolt-components-icon/icon.schema.yml'
-      -
-        type: boolean
+      - type: string
+        enum:
+          - none
+      - type: string
+        ref: '@bolt-components-icon/icon.schema.yml#/properties/name'
   quoted:
     type: boolean
     description: Adds quoted styling to text.

--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -67,7 +67,7 @@ properties:
     type: string
     description: If provided, turns headline into a link to given url.
   icon:
-    description: Bolt icon. Excepts the same options as Bolt Icon Component `@bolt-components-icon`
+    description: Bolt icon. Accepts the same options as Bolt Icon Component `@bolt-components-icon`.  If url is set, this will default to a right chevron unless you pass "false" or an alternate icon.
     anyOf:
       -
         type: object

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -43,7 +43,12 @@
   iconPosition ? baseClass ~ "--icon-position-" ~ iconPosition : ""
 ] %}
 
-{% if url and icon is not defined %}
+{#
+  If this is a link, add a right chevron icon by default.  There are only two ways to opt out:
+  - Set 'icon: false' to explicitly have no icon
+  - Set a different icon to use instead of the default
+#}
+{% if url and icon is not sameas(false) and icon.name is empty %}
   {% set icon = icon | default({}) | merge({
     name: "chevron-right"
   }) %}

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -21,10 +21,36 @@
 {% set style = style | default(schema.properties.style.default) %}
 {% set type = type in types ? type : "text" %}
 {% set size = size | default(schema.properties.size.default) %}
-{% if icon %}
-  {# Covers backward compatibility with use of both left and before to describe icon position #}
-  {% set iconPosition = icon.position == "left" ? "before" : icon.position  %}
+
+
+{# For backwards compatibility only, setting icon to exactly 'false' is the same as specifying 'none'.  Deprecated. #}
+{% if icon is sameas(false) %}
+  {% set icon = "none" %}
 {% endif %}
+
+{# If this is a link, use a chevron-right icon unless explicitly requested otherwise. #}
+{% set fallbackIconName = url ? "chevron-right" : "none" %}
+
+{# iconName is a string representing the name of the icon or "none" if no icon should be shown. #}
+{% set iconName = icon is iterable ? icon.name : icon | default(fallbackIconName)%}
+
+{# Validate iconName.  If invalid, we'll use the default #}
+{#{% set iconSchema = bolt.data.components['@bolt-components-icon'].schema %}#}
+{#{% if iconName not in iconSchema.properties.name.enum and iconName != "none" %}#}
+  {#{% set iconName = fallbackIconName %}#}
+{#{% endif %}#}
+
+{# If icon was a string, initialize it as an empty object. #}
+{% set icon = icon is iterable ? icon : {} %}
+
+{% if iconName == "none" %}
+  {% set icon = false %}
+{% else %}
+  {% set icon = icon | merge({ name: iconName }) %}
+{% endif %}
+
+{# Covers backward compatibility with use of both left and before to describe icon position #}
+{% set iconPosition = icon.position == "left" ? "before" : icon.position  %}
 
 {% set prefix = "c-bolt-" %}
 {% set baseClass = prefix ~ type %}
@@ -46,17 +72,6 @@
   url ? baseClass ~ "--link" : "",
   iconPosition ? baseClass ~ "--icon-position-" ~ iconPosition : ""
 ] %}
-
-{#
-  If this is a link, add a right chevron icon by default.  There are only two ways to opt out:
-  - Set 'icon: false' to explicitly have no icon
-  - Set a different icon to use instead of the default
-#}
-{% if url and icon is not sameas(false) and icon.name is empty %}
-  {% set icon = icon | default({}) | merge({
-    name: "chevron-right"
-  }) %}
-{% endif %}
 
 <{{ tag }} {{ attributes.addClass(classes) }}>
   {% if icon and not url and iconPosition == "before" %}

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema('@bolt-components-headline/headline.schema.yml', _self) | raw }}
+{% endif %}
+
 {% set schema = bolt.data.components['@bolt-components-headline'].schema %}
 {% set types = ["headline", "subheadline", "eyebrow", "text"] %} {# Pre-defined types #}
 
@@ -87,7 +91,3 @@
     </span>
   {% endif %}
 </{{ tag }}>
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema('@bolt-components-headline/headline.schema.yml', _self) | raw }}
-{% endif %}


### PR DESCRIPTION
This PR updates the particularly troublesome logic for when to add the default right chevron icon to a linked headline.  See the inline comment I added to _typography.twig for an explanation of how it now works.

For context, this line has been changed multiple times in Bolt 1.x attempting to fix this very issue:
dabb904
79d012dd
139e41e