### PR TITLE
Refactor: Add `@pl` Twig Namespace + Update Internal-only Templates to Differentiate "Bolt" vs "Pattern Lab"

### DIFF
--- a/apps/pattern-lab/.boltrc.js
+++ b/apps/pattern-lab/.boltrc.js
@@ -12,11 +12,6 @@ module.exports = {
   extraTwigNamespaces: {
     'bolt': {
       recursive: true,
-      paths: [
-        // './src',
-        /* Example of including additional component paths to include in the main @bolt namespace */
-        // path.relative(process.cwd(), path.dirname(require.resolve('@bolt/components-sticky/package.json'))),
-      ],
     },
     'pl': {
       recursive: true,

--- a/apps/pattern-lab/.boltrc.js
+++ b/apps/pattern-lab/.boltrc.js
@@ -13,6 +13,14 @@ module.exports = {
     'bolt': {
       recursive: true,
       paths: [
+        // './src',
+        /* Example of including additional component paths to include in the main @bolt namespace */
+        // path.relative(process.cwd(), path.dirname(require.resolve('@bolt/components-sticky/package.json'))),
+      ],
+    },
+    'pl': {
+      recursive: true,
+      paths: [
         './src',
         /* Example of including additional component paths to include in the main @bolt namespace */
         // path.relative(process.cwd(), path.dirname(require.resolve('@bolt/components-sticky/package.json'))),

--- a/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-00-homepage.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-00-homepage.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/_page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-01-homepage-w-background-video.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-01-homepage-w-background-video.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/_page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-00-resource-details-page.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-00-resource-details-page.twig
@@ -1,1 +1,1 @@
-{% include "@bolt/_resource-details-page.twig" only %}
+{% include "@pl/_resource-details-page.twig" only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-10-resource-details-page--long-title.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-10-resource-details-page--long-title.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/_resource-details-page.twig" with {
+{% include "@pl/_resource-details-page.twig" with {
   feature_band: {
     title: "PegaWORLD 2012 Video: Using Technology to Address Gaps in Care, Increase Medication Adherence and Improve Health Outcomes at Alere Health"
   }

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-11-resource-details-page--long-title-2.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-11-resource-details-page--long-title-2.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/_resource-details-page.twig" with {
+{% include "@pl/_resource-details-page.twig" with {
   feature_band: {
     title: "CSAA Insurance Group: Transforming the Customer Experience"
   }

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-12-resource-details-page--long-title-3.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-12-resource-details-page--long-title-3.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/_resource-details-page.twig" with {
+{% include "@pl/_resource-details-page.twig" with {
   feature_band: {
     title: "A Comparison of Pega Sales Automation & The Salesforce.com Sales Cloud"
   }

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-20-resource-details-page--short-title.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-20-resource-details-page--short-title.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/_resource-details-page.twig" with {
+{% include "@pl/_resource-details-page.twig" with {
   feature_band: {
     title: "New ways to engage your customers"
   }

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-21-resource-details-page--short-title-2.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-21-resource-details-page--short-title-2.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/_resource-details-page.twig" with {
+{% include "@pl/_resource-details-page.twig" with {
   feature_band: {
     title: "Customer Service for Retail Banking"
   }

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-22-resource-details-page--short-title-3.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-22-resource-details-page--short-title-3.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/_resource-details-page.twig" with {
+{% include "@pl/_resource-details-page.twig" with {
   feature_band: {
     title: "Pega Operations Overview"
   }

--- a/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-23-resource-details-page--short-title-4.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-resource-details-pages/-23-resource-details-page--short-title-4.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/_resource-details-page.twig" with {
+{% include "@pl/_resource-details-page.twig" with {
   feature_band: {
     title: "PegaWorld2017: Future Empowered (Video)"
   }

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-landing-page.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-landing-page.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/_page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t2-page.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t2-page.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/_page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3-extra-videos.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3-extra-videos.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/_page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t4.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t4.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-01-full-page-theming--xlight.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-01-full-page-theming--xlight.twig
@@ -1,3 +1,3 @@
-{% include "@bolt/_full-page-theming.twig" with {
+{% include "@pl/_full-page-theming.twig" with {
   qaTheme: "xlight"
 } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-02-full-page-theming--light.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-02-full-page-theming--light.twig
@@ -1,3 +1,3 @@
-{% include "@bolt/_full-page-theming.twig" with {
+{% include "@pl/_full-page-theming.twig" with {
   qaTheme: "light"
 } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-03-full-page-theming--dark.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-03-full-page-theming--dark.twig
@@ -1,3 +1,3 @@
-{% include "@bolt/_full-page-theming.twig" with {
+{% include "@pl/_full-page-theming.twig" with {
   qaTheme: "dark"
 } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-04-full-page-theming--xdark.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-04-full-page-theming--xdark.twig
@@ -1,3 +1,3 @@
-{% include "@bolt/_full-page-theming.twig" with {
+{% include "@pl/_full-page-theming.twig" with {
   qaTheme: "xdark"
 } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-05-full-page-theming--none.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/-05-full-page-theming--none.twig
@@ -1,3 +1,3 @@
-{% include "@bolt/_full-page-theming.twig" with {
+{% include "@pl/_full-page-theming.twig" with {
   qaTheme: "xlight"
 } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% macro link(text, href, attributes) %}
   {% include "@bolt/link.twig" with {

--- a/apps/pattern-lab/src/_patterns/04-pages/50-d8-campaign-landing/-05-d8-breadcrumbs.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/50-d8-campaign-landing/-05-d8-breadcrumbs.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block main_content %}
 

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-05-d8-homepage.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-05-d8-homepage.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-10-d8-homepage-alt.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-10-d8-homepage-alt.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block main_content %}
 

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-20-d8-homepage-video-test.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-20-d8-homepage-video-test.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block main_content %}
 

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-25-band-with-video-test.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-25-band-with-video-test.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block main_content %}
 

--- a/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail--aflac.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail--aflac.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/-agenda-manager-detail.twig" with {
+{% include "@pl/-agenda-manager-detail.twig" with {
   pageTitle: "What Aflac is Learning About Consumer Expectations Through Monitoring Tech Disruptions",
   thumbnailPath: "logos/logo-aflac.png"
 } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail--alan-keynote.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail--alan-keynote.twig
@@ -1,4 +1,4 @@
-{% include "@bolt/-agenda-manager-detail.twig" with {
+{% include "@pl/-agenda-manager-detail.twig" with {
   pageTitle: "Alan's keynote",
   thumbnailPath: "portraits/thumbnail-alan.png"
 } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% embed "@bolt/band.twig" with {

--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/event-detail.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/event-detail.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/_page-header.twig" %}

--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/event-landing.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/event-landing.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/default-template.twig" %}
+{% extends "@pl/default-template.twig" %}
 
 {% block global_header %}
   {% include "@bolt/_page-header.twig" %}

--- a/packages/build-tools/utils/manifest.js
+++ b/packages/build-tools/utils/manifest.js
@@ -236,13 +236,17 @@ async function writeTwigNamespaceFile(relativeFrom, extraNamespaces = {}) {
   if (extraNamespaces) {
     Object.keys(extraNamespaces).forEach((namespace) => {
       const settings = extraNamespaces[namespace];
-      if (namespaceConfigFile[namespace]) {
+      if (namespaceConfigFile[namespace] &&
+        settings.paths !== undefined // make sure the paths config is defined before trying to merge
+      ) {
         // merging the two, making sure the paths from `extraNamespaces` go first
         namespaceConfigFile[namespace].paths = [
           ...settings.paths,
           ...namespaceConfigFile[namespace].paths,
         ];
-      } else {
+
+      // don't add a new namespace key if the paths config option wasn't defined. prevents PHP errors if a namespace key was defined but no paths specified.
+      } else if (settings.paths !== undefined) {
         namespaceConfigFile[namespace] = settings;
       }
     });


### PR DESCRIPTION
Globally updates all internal Pattern Lab template references to use the `@pl` Twig namespace if the template / pattern exclusively lives in Pattern Lab.

Basically this fixes our naming convention in Twig to have two clear buckets moving forward:

`@bolt` Twig Namespace = Template is an official Bolt template and is published to NPM. (ie. Components and Objects).

`@pl` Twig Namespace = Internal Pattern Lab-only template (component demos, page references, prototypes, etc) and is NOT published to NPM.


CC @rockymountainhigh1943 @mikemai2awesome @theSadowski @remydenton 