### PR TITLE
Hotfix: remove background video z-index being set

### DIFF
--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -27,6 +27,7 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
 
   &[is-background-video]{
     flex-grow: 1;
+    // note: defining a z-index here causes strange behavior in Safari for iOS with buttons no longer accepting click events as expected.
     transition: opacity .3s ease, min-height .3s ease;
     top: 0;
     right: 0;

--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -27,7 +27,6 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
 
   &[is-background-video]{
     flex-grow: 1;
-    z-index: 20;
     transition: opacity .3s ease, min-height .3s ease;
     top: 0;
     right: 0;


### PR DESCRIPTION
Removes a single CSS line put in place ~2 months ago without any context.

This fixes a Safari for iOS issue w/ the video player + layered content on bands behaving unexpectedly (ex. not triggering click events as expected). Tested this out locally in Chrome, Safari, Firefox, IE 11, and Safari for iOS (iPhone) doesn't appear to reveal any apparent regressions.

CC @krlucas @charginghawk @theSadowski @remydenton 