### PR TITLE
refactor: Move schema validation to top of twig files (BDS-341)

### DIFF
--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -35,6 +35,9 @@
   } only %}
 #}
 
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-action-blocks'].schema, _self) | raw }}
+{% endif %}
 
 {% set prefix = "c-bolt-" %}
 
@@ -83,6 +86,3 @@
 </bolt-{{ componentName }}>
 
 
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-action-blocks'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-background-shapes/src/background-shapes.twig
+++ b/packages/components/bolt-background-shapes/src/background-shapes.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-background'].schema, _self) | raw }}
+{% endif %}
+
 {% set prefix = "c-bolt-" %}
 {% set componentName = "background-shapes" %}
 {% set baseClass = prefix ~ componentName %}
@@ -96,8 +100,3 @@
     </div>
   </div>
 </bolt-{{ componentName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-background'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-background/src/background.twig
+++ b/packages/components/bolt-background/src/background.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-background'].schema, _self) | raw }}
+{% endif %}
+
 {% set prefix = "c-bolt-" %}
 {% set componentName = "background" %}
 {% set baseClass = prefix ~ componentName %}
@@ -75,7 +79,3 @@
     </div>
   </div>
 </bolt-background>
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-background'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-band/src/band.twig
+++ b/packages/components/bolt-band/src/band.twig
@@ -1,3 +1,8 @@
+{# @todo: uncomment below when the strange validation issue relating to Bands (specifically, 'no schema found to verify against') is resolved. #}
+{# {% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-band'].schema, _self) | raw }}
+{% endif %} #}
+
 {% set prefix = "c-bolt-" %}
 {% set contentTags = ["div", "article", "section", "header", "footer", "nav", "figcaption"] %} {# Available content container tags #}
 {% set fullBleedOptions = [true, false] %}
@@ -61,9 +66,3 @@
     content: renderedBandContent
   } only %}
 </bolt-{{ componentName }}>
-
-
-{# @todo: uncomment below when the strange validation issue relating to Bands (specifically, 'no schema found to verify against') is resolved. #}
-{# {% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-band'].schema, _self) | raw }}
-{% endif %} #}

--- a/packages/components/bolt-block-list/src/block-list.twig
+++ b/packages/components/bolt-block-list/src/block-list.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-block-list'].schema, _self) | raw }}
+{% endif %}
+
 {% set prefix = "c-bolt-" %}
 {% set attributes = create_attribute(attributes|default({})) %}
 
@@ -19,8 +23,3 @@
     {% endfor %}
   </ul>
 </bolt-block-list>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-block-list'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-blockquote/src/blockquote.twig
+++ b/packages/components/bolt-blockquote/src/blockquote.twig
@@ -31,6 +31,9 @@
   } only %}
 #}
 
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-blockquote'].schema, _self) | raw }}
+{% endif %}
 
 {% set prefix = "c-bolt-" %}
 
@@ -121,8 +124,3 @@
     {% endif %}
   </blockquote>
 </bolt-{{ componentName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-blockquote'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-breadcrumb/src/breadcrumb.twig
+++ b/packages/components/bolt-breadcrumb/src/breadcrumb.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-breadcrumb'].schema, _self) | raw }}
+{% endif %}
+
 {% set prefix = "c-bolt-" %}
 {% set attributes = create_attribute(attributes|default({})) %}
 {% set componentName = "breadcrumb" %}
@@ -18,8 +22,3 @@
     </ol>
   </nav>
 </bolt-{{ componentName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-breadcrumb'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-button-group/src/button-group.twig
+++ b/packages/components/bolt-button-group/src/button-group.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-button-group'].schema, _self) | raw }}
+{% endif %}
+
 {% set tags = ["ul", "ol"] %} {# Available Headline Types #}
 {% set prefix = "c-bolt-" %}
 
@@ -34,8 +38,3 @@
   {% endif %}
 {% endblock button_group_content %}
 </bolt-button-group>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-button-group'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -1,5 +1,9 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
 {# Defaults for a vanilla `Button` component #}
 {% set prefix = "c-bolt-" %}
 {% set componentName = "button" %}
@@ -134,8 +138,3 @@
 
   </{{ tag }}>
 </bolt-button>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-button'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-card/src/card.twig
+++ b/packages/components/bolt-card/src/card.twig
@@ -1,5 +1,9 @@
 {% set schema = bolt.data.components['@bolt-components-card'].schema %}
 
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
 {% set tags = ["div", "article", "section", "figure"] %} {# Available overall container tags #}
 {% set contentTags = ["div", "article", "section", "figcaption"] %} {# Available content container tags #}
 {% set themes = ["xlight", "light", "dark", "xdark"] %}
@@ -177,8 +181,3 @@
     {% endif %}
   </{{ tag }}>
 </bolt-card>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-card'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-chip-list/chip-list.twig
+++ b/packages/components/bolt-chip-list/chip-list.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-chip-list'].schema, _self) | raw }}
+{% endif %}
+
 {% if contentItems %}
   {% set chipParams = {} %}
   {% set inlineListItems = [] %}
@@ -20,9 +24,4 @@
 
   {% include "@bolt/inline-list.twig" with chipParams only %}
 
-{% endif %}
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-chip-list'].schema, _self) | raw }}
 {% endif %}

--- a/packages/components/bolt-chip/src/chip.twig
+++ b/packages/components/bolt-chip/src/chip.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-chip'].schema, _self) | raw }}
+{% endif %}
+
 {% set tags = ["span", "a"] %} {# Available Chip Tags #}
 {% set prefix = "c-bolt-" %}
 
@@ -29,8 +33,3 @@
     <span class="{{ "#{baseClass}__item-text" }}">{{ text }}</span>
   </{{ tag }}>
 </bolt-chip>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-chip'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-code-snippet/src/code-snippet.twig
+++ b/packages/components/bolt-code-snippet/src/code-snippet.twig
@@ -1,5 +1,10 @@
 {% set schema = bolt.data.components['@bolt-components-code-snippet'].schema %}
 
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
+
 {% set prefix = "c-bolt-" %}
 {% set componentName = "code-snippet" %}
 {% set baseClass = prefix ~ componentName %}
@@ -37,10 +42,3 @@
     <pre {{ attributes.addClass(classes) }}>{{ codeContent }}</pre>
   {% endif %}
 </bolt-{{ componentName }}>
-
-
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema('@bolt-components-code-snippet/code-snippet.schema.yml', _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-copy-to-clipboard'].schema, _self) | raw }}
+{% endif %}
+
 {% set prefix = "c-bolt-" %}
 {% set componentName = "copy-to-clipboard" %} {# @todo: refactor to custom web component ASAP #}
 {% set baseClass = prefix ~ componentName %}
@@ -67,8 +71,3 @@
     </span>
   </div>
 </bolt-copy-to-clipboard>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-copy-to-clipboard'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-device-viewer/src/device-viewer.twig
+++ b/packages/components/bolt-device-viewer/src/device-viewer.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-device-viewer'].schema, _self) | raw }}
+{% endif %}
+
 {% set colors = [
   "silver",
   "black",
@@ -78,8 +82,3 @@
     </div>
   </div>
 </bolt-device-viewer>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-device-viewer'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-dropdown/dropdown.twig
+++ b/packages/components/bolt-dropdown/dropdown.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-dropdown'].schema, _self) | raw }}
+{% endif %}
+
 {% set collapse = collapse | default(false) %}
 {% set _content = block('content') | default(content) %}
 
@@ -19,8 +23,3 @@
     {% endif %}
   {% endblock %}
 </bolt-dropdown>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-dropdown'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -1,8 +1,9 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-figure'].schema, _self) | raw }}
+{% endif %}
+
 {% set prefix = "c-bolt-" %}
-
 {% set attributes = create_attribute(attributes|default({})) %}
-
-
 {% set componentName = "figure" %}
 {% set baseClass = prefix ~ componentName %}
 
@@ -27,8 +28,3 @@
     {% endif %}
   </figure>
 </bolt-{{ componentName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-figure'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -1,6 +1,10 @@
 {% set schema = bolt.data.components['@bolt-components-headline'].schema %}
-{% set types = ["headline", "subheadline", "eyebrow", "text"] %} {# Pre-defined types #}
 
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
+{% set types = ["headline", "subheadline", "eyebrow", "text"] %} {# Pre-defined types #}
 {% set tags = schema.properties.tag.enum %}
 {% set weights = schema.properties.weight.enum %}
 {% set styles = schema.properties.style.enum %}
@@ -82,8 +86,3 @@
     </span>
   {% endif %}
 </{{ tag }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-headline'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-icon/src/icon.twig
+++ b/packages/components/bolt-icon/src/icon.twig
@@ -1,7 +1,10 @@
 <!-- Icon JS + twig integration -->
 
-{% set attributes = create_attribute(attributes | default({})) %}
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-icon'].schema, _self) | raw }}
+{% endif %}
 
+{% set attributes = create_attribute(attributes | default({})) %}
 
 {% set attributes = attributes
   .setAttribute("name", name)
@@ -11,8 +14,3 @@
 %}
 
 <bolt-icon {{ attributes }}></bolt-icon>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-icon'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-image/src/image.twig
+++ b/packages/components/bolt-image/src/image.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-image'].schema, _self) | raw }}
+{% endif %}
+
 {% set imageDataBolt = bolt.data.images[src] %} {# Data from Bolt Manifest #}
 {% set imageDataTwig = getImageData(src)  %} {# Data from processing image file #}
 
@@ -98,8 +102,3 @@
     {% endif %}
   {% endblock %}
 </bolt-image>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-image'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-link/src/link.twig
+++ b/packages/components/bolt-link/src/link.twig
@@ -10,6 +10,11 @@
  *
  */
 #}
+
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-link'].schema, _self) | raw }}
+{% endif %}
+
 {% spaceless %}
 
   {% set link_classes = [
@@ -43,8 +48,3 @@
     {% endif %}
   </a>
 {% endspaceless %}
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-link'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-logo/src/logo.twig
+++ b/packages/components/bolt-logo/src/logo.twig
@@ -1,8 +1,7 @@
-<bolt-logo {% if invert %} class="c-bolt-logo--invert" {% endif %}>
-  {{ include('@bolt-components-image/image.twig', with_context = true) }}
-</bolt-logo>
-
-
 {% if enable_json_schema_validation %}
   {{ validate_data_schema(bolt.data.components['@bolt-components-logo'].schema, _self) | raw }}
 {% endif %}
+
+<bolt-logo {% if invert %} class="c-bolt-logo--invert" {% endif %}>
+  {{ include('@bolt-components-image/image.twig', with_context = true) }}
+</bolt-logo>

--- a/packages/components/bolt-nav-priority/nav-priority.twig
+++ b/packages/components/bolt-nav-priority/nav-priority.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-nav-priority'].schema, _self) | raw }}
+{% endif %}
+
 <bolt-nav-priority more-text="{{ moreText | default("More") }}">
   <nav class="c-bolt-priority-nav">
     <bolt-nav-indicator>
@@ -11,10 +15,3 @@
     </bolt-nav-indicator>
   </nav>
 </bolt-nav-priority>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-nav-priority'].schema, _self) | raw }}
-{% endif %}
-
-

--- a/packages/components/bolt-navbar/src/navbar.twig
+++ b/packages/components/bolt-navbar/src/navbar.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-navbar'].schema, _self) | raw }}
+{% endif %}
+
 {% set schema = bolt.data.components["@bolt-components-navbar"].schema %}
 
 {% set themeOptions = schema.properties.theme.enum %}
@@ -15,8 +19,3 @@
     {% include "@bolt-components-nav-priority/nav-priority.twig" %}
   </nav>
 </bolt-navbar>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-navbar'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-navlink/navlink.twig
+++ b/packages/components/bolt-navlink/navlink.twig
@@ -1,3 +1,8 @@
+{# todo: uncomment when JSON schema added for navlink #}
+{# {% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-navlink'].schema, _self) | raw }}
+{% endif %} #}
+
 {% set attributes = create_attribute(attributes | default({})) %}
 {% set attributes = attributes.addClass("c-bolt-navlink").setAttribute("href", url) %}
 
@@ -7,10 +12,3 @@
     {{ text }}
   </a>
 </bolt-navlink>
-
-
-
-{# todo: uncomment when JSON schema added for navlink #}
-{# {% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-navlink'].schema, _self) | raw }}
-{% endif %} #}

--- a/packages/components/bolt-ordered-list/ordered-list.twig
+++ b/packages/components/bolt-ordered-list/ordered-list.twig
@@ -1,5 +1,8 @@
-{% set prefix = "c-bolt-" %}
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-ordered-list'].schema, _self) | raw }}
+{% endif %}
 
+{% set prefix = "c-bolt-" %}
 {% set attributes = create_attribute(attributes|default({})) %}
 
 {% set componentName = "ordered-list" %}
@@ -25,8 +28,3 @@
     {% endfor %}
   </ol>
 </bolt-{{ componentName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-ordered-list'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-placeholder/placeholder.twig
+++ b/packages/components/bolt-placeholder/placeholder.twig
@@ -1,5 +1,9 @@
 {% set schema = bolt.data.components['@bolt-components-placeholder'].schema %}
 
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
 {# Defaults for a vanilla `Placeholder` component #}
 {% set prefix = "c-bolt-" %}
 {% set componentName = "placeholder" %}
@@ -48,8 +52,3 @@
     </replace-with-children>
   </replace-with-children>
 </bolt-placeholder>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-placeholder'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-share'].schema, _self) | raw }}
+{% endif %}
+
 {% set copyShare = copy is sameas(false) ? false : (copy is null ? true : copy) %}
 {% set visible = visibility is sameas(false) ? false : (visibility is null ? true : visibility) %}
 {% set isFlat = inline is sameas(false) ? false : (inline is null ? false : inline) %}
@@ -92,8 +96,3 @@
     {% endif %}
   </div>
 </bolt-share>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-share'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-sticky/src/sticky.twig
+++ b/packages/components/bolt-sticky/src/sticky.twig
@@ -1,8 +1,9 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-ordered-list'].schema, _self) | raw }}
+{% endif %}
+
 {% set prefix = "c-bolt-" %}
-
-
 {% set attributes = create_attribute(attributes|default({})) %}
-
 
 {% set componentName = "sticky" %}
 {% set baseClass = prefix ~ componentName %}
@@ -19,8 +20,3 @@
     {{ content }}
   {% endblock sticky_content %}
 </bolt-{{ componentName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-ordered-list'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-teaser'].schema, _self) | raw }}
+{% endif %}
+
 <bolt-teaser>
   {% if eyebrow %}
     {% include "@bolt/eyebrow.twig" with eyebrow only %}
@@ -34,8 +38,3 @@
     } only %}
   {% endif %}
 </bolt-teaser>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-teaser'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-text/src/text.twig
+++ b/packages/components/bolt-text/src/text.twig
@@ -1,8 +1,9 @@
+{% set schema = bolt.data.components['@bolt-components-text'].schema %}
+
 {% if enable_json_schema_validation %}
-  {{ validate_data_schema('@bolt-components-text/text.schema.yml', _self) | raw }}
+  {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
-{% set schema = bolt.data.components['@bolt-components-text'].schema %}
 {% set attributes = create_attribute(attributes|default({})) %}
 
 {# check if the value set to a prop is allowed or defined. if not, default to the default value specified in the component's schema (if one exists) #}

--- a/packages/components/bolt-tooltip/src/tooltip.twig
+++ b/packages/components/bolt-tooltip/src/tooltip.twig
@@ -1,5 +1,8 @@
-{% set attributes = create_attribute(attributes|default({})) %}
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-tooltip'].schema, _self) | raw }}
+{% endif %}
 
+{% set attributes = create_attribute(attributes|default({})) %}
 {% set componentName = "tooltip" %}
 
 {% if trigger %}
@@ -47,8 +50,3 @@
 {% set customElementName = customElementName | default('bolt-' ~ componentName) %}
 
 <{{ customElementName }} {{ attributes }}></{{ customElementName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-tooltip'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-unordered-list/src/unordered-list.twig
+++ b/packages/components/bolt-unordered-list/src/unordered-list.twig
@@ -1,5 +1,8 @@
-{% set prefix = "c-bolt-" %}
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-unordered-list'].schema, _self) | raw }}
+{% endif %}
 
+{% set prefix = "c-bolt-" %}
 {% set attributes = create_attribute(attributes|default({})) %}
 
 {% set componentName = "unordered-list" %}
@@ -26,8 +29,3 @@
     {% endfor %}
   </ul>
 </bolt-{{ componentName }}>
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-unordered-list'].schema, _self) | raw }}
-{% endif %}

--- a/packages/components/bolt-video/src/video.twig
+++ b/packages/components/bolt-video/src/video.twig
@@ -1,3 +1,7 @@
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-video'].schema, _self) | raw }}
+{% endif %}
+
 {% set videoUuid = videoUuid | default("js-bolt-video-uuid--" ~ random()) %}
 
 {% set attributes = create_attribute(attributes|default({})) %}
@@ -27,9 +31,4 @@
   } only %}
 {% else %}
   {{ videoTag }}
-{% endif %}
-
-
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-video'].schema, _self) | raw }}
 {% endif %}


### PR DESCRIPTION
Hopefully a straightforward change.

Note that this _does_ affect functionality since it validates incoming variables before the twig file has made any changes to them.  Doesn't make a big difference in most components, but it is more correct when it does.