### PR TITLE
hotfix: revert removing z-index from video player CSS + disable `resizeManager` config in Brightcove

### DIFF
--- a/packages/components/bolt-video/src/_video-tag.twig
+++ b/packages/components/bolt-video/src/_video-tag.twig
@@ -18,7 +18,7 @@
 {% endif #}
 
 {# force HTML5 Only Rendering #}
-{% set attributes = attributes.setAttribute("data-setup", '{"techOrder": ["Html5"]}') %}
+{% set attributes = attributes.setAttribute("data-setup", '{"techOrder": ["Html5"], "resizeManager": false}') %}
 {% set showMeta = showMeta is null ? true : showMeta %}
 {% set showMetaTitle = showMeta is null ? false : showMetaTitle %}
 

--- a/packages/components/bolt-video/src/_video-tag.twig
+++ b/packages/components/bolt-video/src/_video-tag.twig
@@ -17,7 +17,8 @@
   {% endfor %}
 {% endif #}
 
-{# force HTML5 Only Rendering #}
+{# force HTML5 Only Rendering + disable resizeManager in Brightcove to fix ability to click overlapping elements on iOS: 
+https://github.com/videojs/video.js/blob/22fd327076cb044c135c747086b58b7be64a747a/src/js/resize-manager.js#L19 #}
 {% set attributes = attributes.setAttribute("data-setup", '{"techOrder": ["Html5"], "resizeManager": false}') %}
 {% set showMeta = showMeta is null ? true : showMeta %}
 {% set showMetaTitle = showMeta is null ? false : showMetaTitle %}

--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -27,7 +27,7 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
 
   &[is-background-video]{
     flex-grow: 1;
-    // note: defining a z-index here causes strange behavior in Safari for iOS with buttons no longer accepting click events as expected.
+    z-index: 20;
     transition: opacity .3s ease, min-height .3s ease;
     top: 0;
     right: 0;


### PR DESCRIPTION
Update the Bolt video player Twig config to manually disable the `resizeManager` option in Brightcove + revert CSS hotfix added yesterday.

This fixes the Safari for iOS issue encountered in production with background-embedded video players not allowing UI elements on top / in the same parent container (like a Band) to be interacted with due to the `<iframe>` element this new resizeManager functionality added in the Brightcove player.

CC @theSadowski @charginghawk @krlucas