### PR TITLE
feature: remove blue outline from Firefox button focus state (BDS-325)

### DIFF
--- a/packages/components/bolt-button/src/_button.mixins.scss
+++ b/packages/components/bolt-button/src/_button.mixins.scss
@@ -129,10 +129,6 @@
     color: var(--bolt-theme-primary-text-default, bolt-text-contrast($primary-background-default));
     background-color: $primary-background-hover;
     background-color: var(--bolt-theme-primary-background-hover, $primary-background-hover);
-
-    outline-width: 5px; // Default browser outline styles
-    outline-style: auto; // Default browser outline styles
-    outline-color: rgb(59, 153, 252); // Default browser outline styles
   }
 
   &:active,
@@ -184,9 +180,6 @@
     color: var(--bolt-theme-secondary-text-default, bolt-text-contrast($secondary-background-default));
     background-color: $secondary-background-hover;
     background-color: var(--bolt-theme-secondary-background-hover, $secondary-background-hover);
-    outline-width: 5px; // Default browser outline styles
-    outline-style: auto; // Default browser outline styles
-    outline-color: rgb(59, 153, 252); // Default browser outline styles
   }
 
   &.c-bolt-button--active,


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-325

For reference, the styles I'm removing were originally added in 33846bbdb1d