### PR TITLE
Hotfix / Refactor: Consolidate Background Video Player Logic + Fix Aspect Ratio Regression

### DIFF
--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
@@ -171,7 +171,8 @@
         "videoId": "5609376179001",
         "accountId": "1900410236",
         "playerId": "r1CAdLzTW",
-        "videoUuid": videoUuid1
+        "videoUuid": videoUuid1,
+        "showMeta": false,
       }
     ]
   },
@@ -357,10 +358,15 @@
       tag: "h3"
     } only %}
 
+    {{ parent() }}
+
     {% include "@bolt/button.twig" with {
       text: "Toggle video",
       tag: "button",
       attributes: {
+        class: [
+          "u-bolt-margin-top-large",
+        ],
         "on-click": "toggle",
         "on-click-target": videoUuid1
       }
@@ -368,7 +374,7 @@
 
     <br><br><br>
 
-    {{ parent() }}
+
   {% endblock band_content %}
 {% endembed %}
 
@@ -444,7 +450,8 @@
         "videoId": "5453299964001",
         "accountId": "1900410236",
         "playerId": "r1CAdLzTW",
-        "videoUuid": videoUuid2
+        "videoUuid": videoUuid2,
+        "showMeta": false,
       }
     ]
   }

--- a/packages/components/bolt-band/src/band.scss
+++ b/packages/components/bolt-band/src/band.scss
@@ -44,7 +44,7 @@ bolt-band {
   display: block;
   display: flex; // So children increase in height
   width: 100%;
-  transition: all 0.3s ease;
+  transition: min-height 0.3s ease;
   max-height: none;
   min-height: 0;
   transform: translate3d(0, 0, 0);

--- a/packages/components/bolt-band/src/band.standalone.js
+++ b/packages/components/bolt-band/src/band.standalone.js
@@ -17,9 +17,6 @@ import {
 
 // ShadyCSS will rename classes as needed to ensure style scoping.
 
-
-
-
 @define
 export class BoltBand extends BoltComponent() {
   static is = 'bolt-band';
@@ -52,14 +49,16 @@ export class BoltBand extends BoltComponent() {
       this.classList.add('is-ready');
     }
 
-    if (this.expandedHeight === null) {
-      this.expandedHeight = '56.25vh';
-    }
+    if (this.querySelector('bolt-video[is-background-video]')){
+      if (this.expandedHeight === null) {
+        this.expandedHeight = '56.25vh';
+      }
 
-    if (this.expanded) {
-      this.expand();
-    } else {
-      this.collapse();
+      if (this.expanded) {
+        this.expand();
+      } else {
+        this.collapse();
+      }
     }
 
     // Shim Shadow DOM styles. This needs to be run in `connectedCallback()`
@@ -108,30 +107,33 @@ export class BoltBand extends BoltComponent() {
 
 
   collapse() {
-    const startingHeight = this.getBoundingClientRect().height;
-    const endingHeight = this.startingHeight ? this.startingHeight : 0;
+    const endingHeight = this.startingHeight ? this.startingHeight : '0px';
+    const elem = this;
 
-    this.style.transition = 'min-height 0s';
-    this.style.minHeight = `${startingHeight}px`;
+    this.lastRAF && cancelAnimationFrame(this.lastRAF);
+    this.lastRAF = requestAnimationFrame(() => {
+      this.lastRAF = requestAnimationFrame(() => {
+        this.style.minHeight = `${endingHeight}px`;
+        this.lastRAF = null;
+      });
 
-    requestAnimationFrame(() => {
-      this.style.transition = 'min-height 0.3s ease';
-      this.style.minHeight = `${endingHeight}px`;;
     });
 
     this.expanded = false;
+
+    // clean up inline CSS after waiting just a bit
+    setTimeout(function () {
+      elem.removeAttribute('style', 'minHeight');
+    }, 100);
   }
 
   expand() {
-    this.startingHeight = this.getBoundingClientRect().height;
-    const endingHeight = parseInt(this.expandedHeight) > parseInt(this.startingHeight) ? this.expandedHeight : `${this.startingHeight}px`;
-
-    this.style.transition = 'min-height 0s';
-    this.style.minHeight = `${this.startingHeight}px`;
-
-    requestAnimationFrame(() => {
-      this.style.transition = 'min-height 0.3s ease';
-      this.style.minHeight = this.expandedHeight;
+    this.lastRAF && cancelAnimationFrame(this.lastRAF);
+    this.lastRAF = requestAnimationFrame(() => {
+      this.lastRAF = requestAnimationFrame(() => {
+        this.style.minHeight = this.expandedHeight;
+        this.lastRAF = null;
+      });
     });
 
     this.expanded = true;
@@ -156,8 +158,12 @@ export class BoltBand extends BoltComponent() {
       this.expandedHeight = videoHeight;
 
       if (this.expanded){
-        requestAnimationFrame(() => {
-          this.style.minHeight = parseInt(this.expandedHeight) > parseInt(this.startingHeight) ? this.expandedHeight : `${this.startingHeight}px`;
+        this.lastRAF && cancelAnimationFrame(this.lastRAF);
+        this.lastRAF = requestAnimationFrame(() => {
+          this.lastRAF = requestAnimationFrame(() => {
+            this.style.minHeight = this.expandedHeight;
+            this.lastRAF = null;
+          });
         });
       }
     }

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -72,9 +72,8 @@
 }
 
 .video-js {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  width: 100%;
+  height: 100%;
 }
 
 .video-js .vjs-modal-dialog {

--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -6,6 +6,8 @@
 
 // Same as max-width of wrapper container
 $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
+$bolt-video-background-color: rgba(22, 26, 60, .8);
+$bolt-video-background-max-height: 50.625vw;
 
 
 #{$bolt-namespace}-video {
@@ -29,18 +31,19 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
     flex-grow: 1;
     z-index: 20;
     transition: opacity .3s ease, min-height .3s ease;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    margin-left: auto;
-    margin-right: auto;
-    position: absolute;
     min-width: 100%;
     max-width: none;
-    background-color: rgba(22, 26, 60, .8);
+    background-color: $bolt-video-background-color;
     pointer-events: none;
     opacity: 0;
+
+    height: calc((90vw * (9 / 16)) - 4rem);
+    max-width: 100vh;
+    max-height: 56.25vh;
+
+    @media (max-width: (bolt-breakpoint(small) - 1px)) {
+      min-height: calc(#{$bolt-video-background-max-height} + 2.5rem);
+    }
 
     .is-expanded & {
       opacity: 1;
@@ -52,9 +55,14 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
       min-width: 0;
       width: 100%;
       background-color: transparent;
-      transition: all .4s ease;
       width: 100%;
       height: 100%;
+      position: relative;
+      pointer-events: none;
+
+      .is-expanded & {
+        pointer-events: auto;
+      }
 
       &:not(.vjs-fullscreen) {
         max-width: 1400px;
@@ -70,21 +78,11 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
   * on Windows
   */
 .c-#{$bolt-namespace}-video {
-
   width: 100%;
   max-width: none;
   z-index: bolt-z-index('tooltip');
   transition: transform .4s cubic-bezier(.645, 0, .355, 1);
 
-  .video-js {
-    width: 100%;
-    height: 100%;
-  }
-
-  // Higher specificity required to prevent override from Hapyak's CSS loaded
-  .video-js.video-js.video-js {
-    position: absolute;
-  }
 
   &.c-#{$bolt-namespace}-video--background {
     display: block;
@@ -92,18 +90,17 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
     max-width: calc(100% - #{bolt-spacing(large)});
     max-height: 100%;
     margin: 0 auto;
-    height: 100%;
+    height: $bolt-video-background-max-height;
 
     @media (max-width: (bolt-breakpoint(small) - 1px)) {
-      max-height: calc(100% - 40px);
+      max-width: calc(100vw - 40px);
     }
 
     @include respond-to(small){
-      max-width: calc(100vw - #{bolt-spacing(large) * 2});
-    }
-
-    @media screen and (min-width: 1400px){
-      max-width: calc(1400px - #{bolt-spacing(large) * 2});
+      max-width: 100vh;
+      max-height: 56.25vh;
+      width: calc(90vw - 7rem);
+      height: calc((90vw * (9 / 16)) - 4rem);
     }
   }
 }
@@ -147,10 +144,12 @@ $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
 
 .c-#{$bolt-namespace}-video__close-button--icon-to-text {
   @media (max-width: (bolt-breakpoint(small) - 1px)) {
+    @include bolt-padding(xsmall 0);
+    top: 0;
     display: block;
     position: relative;
     right: 0;
-    text-align: right;
+    float: right;
     .c-#{$bolt-namespace}-video__close-button-icon {
       display: none;
     }


### PR DESCRIPTION
1. Update homepage w/ background video player example to test use case of video player + button trigger being in different locations.

2. Consolidate and clean up video player and band logic to only listen to window resize events / video player events when videos are embedded as backgrounds. This update is meant to speed up initial bootup times and help reduce some delays seen in older devices.

3. Update video player aspect ratio CSS to re-implement expected behavior on smaller / shorter screen sizes. Note: CSS being removed here is no longer required based on current behavior / functionality expected.

4. Clean up video player animation logic to address rendering issues seen when resizing / animating / playing in different combinations.

CC @theSadowski @krlucas @charginghawk @remydenton @mikemai2awesome 