### PR TITLE
Button Regression Fix

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/button/15-button-styles.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/15-button-styles.twig
@@ -1,5 +1,11 @@
 {% set schema = bolt.data.components['@bolt-components-button'].schema %}
 
+{#
+  This page exists ONLY for creating our demos.
+  DO NOT use "is-hover", "is-focus", or "is-active" classes for implementation.
+  Strictly for demo purposes.
+#}
+
 {% for style in schema.properties.style.enum %}
   <p>{{ style|capitalize }} Button States</p>
 
@@ -18,9 +24,8 @@
     "text": "Button (Hover)",
     attributes: {
       class: [
-        "c-bolt-button--hover"
-      ],
-      "is-hover": true
+        "is-hover"
+      ]
     },
     style: style
   } only %}
@@ -29,9 +34,8 @@
     "text": "Button (Focus)",
     attributes: {
       class: [
-        "c-bolt-button--focus"
-      ],
-      "is-focus": true
+        "is-focus"
+      ]
     },
     style: style
   } only %}
@@ -40,9 +44,8 @@
     "text": "Button (Active)",
     attributes: {
       class: [
-        "c-bolt-button--active"
-      ],
-      "is-active": true
+        "is-active"
+      ]
     },
     style: style
   } only %}

--- a/packages/components/bolt-button/src/_button.mixins.scss
+++ b/packages/components/bolt-button/src/_button.mixins.scss
@@ -9,22 +9,22 @@
 @mixin bolt-button-raised() {
   &:not(.c-bolt-button--disabled):not(.c-bolt-button--text):not([disabled]) {
     &:hover,
-    &.c-bolt-button--hover {
+    &.is-hover {
       @include bolt-shadow('level-20', true);
     }
 
     &:hover:before,
-    &.c-bolt-button--hover:before {
+    &.is-hover:before {
       opacity: 1;
     }
 
     &:active,
-    &.c-bolt-button--active {
+    &.is-active {
       transform: $bolt-button-translate--active;
     }
 
     &:active:before,
-    &.c-bolt-button--active:before {
+    &.is-active:before {
       opacity: 0;
     }
   }
@@ -112,7 +112,7 @@
   }
 
   &:hover,
-  &.c-bolt-button--hover {
+  &.is-hover {
     border-color: $primary-background-hover;
     border-color: var(--bolt-theme-primary-border-hover, $primary-background-hover);
     color: bolt-text-contrast($primary-background-default);
@@ -122,7 +122,7 @@
   }
 
   &:focus,
-  &.c-bolt-button--focus {
+  &.is-focus {
     border-color: $primary-background-hover;
     border-color: var(--bolt-theme-primary-border-hover, $primary-background-hover);
     color: bolt-text-contrast($primary-background-default);
@@ -136,7 +136,7 @@
   }
 
   &:active,
-  &.c-bolt-button--active {
+  &.is-active {
     border-color: $primary-background-active;
     border-color: var(--bolt-theme-primary-border-active, $primary-background-active);
 
@@ -166,7 +166,7 @@
     background-color: var(--bolt-theme-secondary-background-default, $secondary-background-default);
   }
 
-  &.c-bolt-button--hover,
+  &.is-hover,
   &:hover {
     border-color: $secondary-background-hover;
     border-color: var(--bolt-theme-secondary-border-hover, $secondary-background-hover);
@@ -177,7 +177,7 @@
   }
 
   &:focus,
-  &.c-bolt-button--focus {
+  &.is-focus {
     border-color: $secondary-background-hover;
     border-color: var(--bolt-theme-secondary-border-hover, $secondary-background-hover);
     color: bolt-text-contrast($secondary-background-default);
@@ -189,7 +189,7 @@
     outline-color: rgb(59, 153, 252); // Default browser outline styles
   }
 
-  &.c-bolt-button--active,
+  &.is-active,
   &:active {
     border-color: $secondary-background-active;
     border-color: var(--bolt-theme-secondary-border-active, $secondary-background-active);

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -112,9 +112,9 @@ class BoltButton extends BoltComponent() {
       this.props.disabled ? 'c-bolt-button--disabled' : '',
 
       // Test out psuedo states via prop values
-      this.props.isHover ? 'c-bolt-button--hover' : '',
-      this.props.isActive ? 'c-bolt-button--active' : '',
-      this.props.isFocus ? 'c-bolt-button--focus' : '',
+      // this.props.isHover ? 'is-hover' : '',
+      // this.props.isActive ? 'is-active' : '',
+      // this.props.isFocus ? 'is-focus' : '',
     );
 
     /**


### PR DESCRIPTION
This pull request adds a fix for the broken button demo page. The logic to make this happen is a little cumbersome and might need to be refactored in another ticket.

The issue arose because `sanitizeBoltClasses()` function strips out all `c-bolt-` classes. This makes it so classes being passed, like `c-bolt-button--hover`, never make it onto the button.

**Steps to fix this issue were:**
1. Update PL demo page to use simplified classes that wont be stripped out (e.g. `is-hover`) and removed the "is" attributes
1. Update our button mixin to catch the new class names