### PR TITLE
Refactor: Clean Up, Break Apart Bolt Shadow Mixin

### DIFF
--- a/packages/components/bolt-button/src/_button.mixins.scss
+++ b/packages/components/bolt-button/src/_button.mixins.scss
@@ -10,7 +10,7 @@
   &:not(.c-bolt-button--disabled):not(.c-bolt-button--text):not([disabled]) {
     &:hover,
     &.is-hover {
-      @include bolt-shadow('level-20', true);
+      @include bolt-animated-shadow('level-20', true);
     }
 
     &:hover:before,
@@ -36,7 +36,7 @@
   @include bolt-no-select;
   @include bolt-font-weight(semibold);
   @include bolt-button-raised;
-  @include bolt-shadow('level-20');
+  @include bolt-animated-shadow('level-20');
 
   display: inline-block;
   display: inline-flex;

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -21,7 +21,16 @@ bolt-navbar {
 
   display: block;
   overflow: visible;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+  @include bolt-shadow('level-10');
+
+  // If the navbar is in a darker theme or has a darker theme applied, bump the shadow level up a bit to ensure things are still visible.
+  // @todo: add this to the theme level when theming is refactored.
+  &.t-bolt-xdark,
+  &.t-bolt-dark,
+  .t-bolt-xdark &,
+  .t-bolt-dark & {
+    @include bolt-shadow('level-20');
+  }
 }
 
 .c-bolt-navbar {

--- a/packages/core/styles/02-tools/tools-shadow/_tools-shadow-animated.scss
+++ b/packages/core/styles/02-tools/tools-shadow/_tools-shadow-animated.scss
@@ -1,0 +1,38 @@
+/* ------------------------------------ *\
+  ANIMATED SHADOW MIXIN
+  see `_settings-shadow.scss`
+\* ------------------------------------ */
+
+@mixin bolt-animated-shadow($props...) {
+  $raised: null;
+  $important: null;
+
+  // Normalize the 'raised' value given an arglist of values passed in
+  @if map-get(keywords($props), 'raised'){
+    $raised: map-get(keywords($props), 'raised');
+  }  @else if (length($props) >= 2){
+    $raised: nth($props, 2);
+  }
+
+  // Normalize the 'important' value given an arglist of values passed in
+  @if map-get(keywords($props), 'important') {
+    $important: map-get(keywords($props), 'important');
+  } @else if (length($props) >= 4){
+    $important: nth($props, 4);
+  }
+
+  // set important to be '!important' if the prop was set when calling the mixin.
+  @if $important == true or $important == 'important' {
+    $important: !important;
+  } @else {
+    $important: null;
+  }
+
+  @if $raised {
+     transform: translateY(-2px) $important;
+   } @else {
+     transition: all 0.3s cubic-bezier(.25, .8, .25, 1) $important;
+   }
+
+   @include bolt-shadow($props...);
+}

--- a/packages/core/styles/02-tools/tools-shadow/_tools-shadow.scss
+++ b/packages/core/styles/02-tools/tools-shadow/_tools-shadow.scss
@@ -3,27 +3,30 @@
   see `_settings-shadow.scss`
 \* ------------------------------------ */
 
-@mixin bolt-shadow($key: 'G', $lifted: false, $base-color: false, $utility: false) {
+@mixin bolt-shadow(
+  $key: 'G',
+  $raised: false,
+  $base-color: false,
+  $important: null
+) {
   $shadows: map-get(bolt-get-shadows-map(), 'sets');
   @if $base-color {
     $shadows: map-get(bolt-get-shadows-map($base-color), 'sets');
   }
-  $important: '';
 
-  @if $utility {
-    $important: '!important';
+  @if $important == true or $important == 'important' {
+    $important: !important;
+  } @else {
+    $important: null;
   }
+
   @if not(map-has-key($shadows, $key)) {
     @error 'A value, #{$key}, was passed into @include bolt-shadow() that is not defined in $bolt-shadows';
   } @else {
-    @if $lifted {
-      transform: translateY(-2px) #{$important};
-      box-shadow: unquote(map-get(map-get($shadows, $key), 'raised')) #{$important};
+    @if $raised {
+      box-shadow: unquote(map-get(map-get($shadows, $key), 'raised')) $important;
     } @else {
-      transition: all 0.3s cubic-bezier(.25,.8,.25,1) #{$important};
-      box-shadow: unquote(map-get(map-get($shadows, $key), 'base')) #{$important};
+      box-shadow: unquote(map-get(map-get($shadows, $key), 'base')) $important;
     }
   }
 }
-
-

--- a/packages/global/styles/07-utilities/_utilities-shadow.scss
+++ b/packages/global/styles/07-utilities/_utilities-shadow.scss
@@ -8,12 +8,13 @@ $shadows: map-get($bolt-shadows, 'sets');
 @each $key, $value in $shadows {
   $prefix: map-get($bolt-shadows, 'utility-class-prefix');
   .#{$prefix}#{$key} {
-    @include bolt-shadow($key, $lifted: false, $utility: true);
+    @include bolt-shadow($key, $raised: false, $important: true);
   }
+
   .#{$prefix}#{$key}--hoverable {
-    @include bolt-shadow($key, $lifted: false, $utility: true);
+    @include bolt-animated-shadow($key, $raised: false, $important: true);
     &:hover {
-      @include bolt-shadow($key, $lifted: true, $utility: true);
+      @include bolt-animated-shadow($key, $raised: true, $important: true);
     }
   }
 }


### PR DESCRIPTION
The current iteration of our shadow mixin in Bolt isn't sticking to the single responsibility principle: right now it's too tightly tied in with the hover / interaction styles which reduces the amount of reuse we can get out of it + can result in unexpected behavior when physically using the tools we've created.

This PR directly addresses this by breaking apart the bolt-shadow mixin into two pieces: `bolt-shadow` (which ONLY deals with shadow styles) + `bolt-animated-shadow` which sets the transition and transform offset before calling the regular `bolt-shadow` mixin.

To round this out, I've also gone in and updated the utility classes, button, and navbar components to use the updated mixins accordingly. 