### PR TITLE
Feature: Add Support for Async Loaded Critical Fonts in Fully Encapsulated Web Components

### DIFF
--- a/packages/core/styles/02-tools/tools-font-family/_tools-font-family.scss
+++ b/packages/core/styles/02-tools/tools-font-family/_tools-font-family.scss
@@ -18,14 +18,19 @@
   $fonts-loaded-class: map-get-deep($bolt-font-families, 'font-families', $type, 'loaded-class');
 
   font-family: $fallback-font-family;
+  font-family: var(--bolt-font-family);
 
   @if $is_root == false {
     .#{$fonts-loaded-class} & {
       font-family: $custom-font-family;
+      font-family: var(--bolt-font-family);
     }
   }
   @else {
+    --bolt-font-family: #{$fallback-font-family};
+
     &.#{$fonts-loaded-class} {
+      --bolt-font-family: #{$custom-font-family};
       font-family: $custom-font-family;
     }
   }

--- a/packages/global/styles/04-elements/_elements-page.scss
+++ b/packages/global/styles/04-elements/_elements-page.scss
@@ -11,10 +11,10 @@ $bolt-base-font-sizes: (
 
 html {
   @include bolt-poly-fluid-sizing('font-size', $bolt-base-font-sizes);
+  @include bolt-font-family(body, true);
 }
 
 body {
-  @include bolt-font-family(bodySubset);
   @include bolt-font-family(body);
   @include bolt-font-size(medium);
   width: 100%;


### PR DESCRIPTION
Updates our global `@bolt-font-family` Sass mixin to now output the font family stacks as CSS variables on the root (html) element + tell components using the mixin to automatically include the `font-family: var(--bolt-font-family);` styles. 

^ this specifically is the thing that lets fully encapsulated components (like the Text component) be automatically wired up to styling and configs outside of the component itself since this is the "official way" to precisely customize Web Components from the outside while keeping most of the styles encapsulated and consistent.

Before fonts async load:
![image](https://user-images.githubusercontent.com/1617209/41128338-ce301b98-6a7b-11e8-8cf0-0594ee4e6134.png)

After fonts async load:
![image](https://user-images.githubusercontent.com/1617209/41128346-d56d6348-6a7b-11e8-9426-de6baf2024c4.png)
