### PR TITLE
Feature/bds 291 fix schema variable type issues

### DIFF
--- a/apps/pattern-lab/src/_includes/utils/schema-docs.twig
+++ b/apps/pattern-lab/src/_includes/utils/schema-docs.twig
@@ -73,7 +73,7 @@
       <li>
         <code>{{ key }}</code>
         {{ macros.titleAndDescription(prop.title, prop.description, prop.minimum, prop.maximum) }}
-        {% if isRef %}<br />Type: {{ prop.type }}{% endif %}
+        {% if isRef %}<br />Type: {{ prop.type is iterable ? prop.type|join(' OR ') : prop.type }} {% endif %}
         {{ macros.schemaProps(prop) }}
       </li>
     {% endfor %}
@@ -126,15 +126,16 @@
             <td class="c-bolt-docs-table__col">{{ macros.titleAndDescription(prop.title, prop.description, prop.minimum, prop.maximum) }}</td>
 
             <td class="c-bolt-docs-table__col">
-              <code>
-                {% if prop.default == false %}
-                  False
-                {% elseif prop.default == 'true' %}
-                  True
+
+                {% if prop.default is sameas(false) %}
+                  <code>False</code>
+                {% elseif prop.default is sameas(true) %}
+                  <code>True</code>
+                {% elseif prop.default is empty %}
+                  (None)
                 {% else %}
-                  {{ prop.default }}
+                  <code>{{ prop.default }}</code>
                 {% endif %}
-              </code>
             </td>
           </tr>
         {% endfor %}

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/15-action-blocks-max-items-per-row-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/15-action-blocks-max-items-per-row-variation.twig
@@ -3,7 +3,7 @@
 {% for max in maxRows %}
   <p>Max items per row: {{ max }}</p>
     {% include "@bolt-components-action-blocks/action-blocks.twig" with {
-      align: center,
+      align: "center",
       maxItemsPerRow: max,
       contentItems: [
         {

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/20-action-blocks-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/20-action-blocks-theme-variation.twig
@@ -6,7 +6,7 @@
     {% block demo_content %}
       {% include "@bolt-components-action-blocks/action-blocks.twig" with {
         theme: theme,
-        align: center,
+        align: "center",
         maxItemsPerRow: 4,
         contentItems: [
           {

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/20-action-blocks-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/20-action-blocks-theme-variation.twig
@@ -1,6 +1,4 @@
-{% set schema = bolt.data.components['@bolt-components-action-blocks'].schema %}
-
-{% for theme in schema.properties.theme.enum %}
+{% for theme in ["xlight", "light", "dark", "xdark"] %}
   <p>Theme: {{ theme }}</p>
   {% embed "@utils/theme-demo.twig" %}
     {% block demo_content %}

--- a/apps/pattern-lab/src/_patterns/02-components/band/15-band-size-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/band/15-band-size-variation.twig
@@ -1,9 +1,9 @@
-{% set exampleSizes = ["xsmall", "small", "medium", "large"] %}
+{% set schema = bolt.data.components['@bolt-components-band'].schema %}
 
-{% for size in exampleSizes %}
+{% for size in schema.properties.size.enum %}
   <p>Size: {{ size }}</p>
   {% include "@bolt-components-band/band.twig" with {
-    content: "This band is "~size,
+    content: "This band is size "~size,
     size: size,
   } only %}
 {% endfor %}

--- a/apps/pattern-lab/src/_patterns/02-components/band/25-band-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/band/25-band-theme-variation.twig
@@ -1,12 +1,6 @@
-{% set exampleThemes = [
-  "xlight",
-  "light",
-  "medium",
-  "dark",
-  "xdark"
-] %}
+{% set schema = bolt.data.components['@bolt-components-band'].schema %}
 
-{% for theme in exampleThemes %}
+{% for theme in schema.properties.theme.enum %}
   <p>Theme: {{ theme }}</p>
   {% include '@bolt-components-band/band--flag.twig' with {
     theme: theme,

--- a/apps/pattern-lab/src/_patterns/02-components/blockquote/10-blockquote-alignItems-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/blockquote/10-blockquote-alignItems-variation.twig
@@ -5,7 +5,7 @@
   {% include "@bolt-components-blockquote/blockquote.twig" with {
     alignItems: alignItems,
     logo: {
-      invert: "true",
+      invert: true,
       src: "/pattern-lab/images/content/logos/logo-paypal.svg"
     },
     content: "<p>The greater danger for most of us lies not in setting our aim too high and falling short; but in setting our aim too low, and achieving our mark.</p>",

--- a/apps/pattern-lab/src/_patterns/02-components/blockquote/15-blockquote-indent-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/blockquote/15-blockquote-indent-variation.twig
@@ -1,9 +1,20 @@
 {% set schema = bolt.data.components['@bolt-components-blockquote'].schema %}
+{% set booleans = [
+    {
+      label: "True",
+      value: true
+    },
+    {
+      label: "False",
+      value: false
+    }
+  ]
+%}
 
-{% for indent in schema.properties.indent.enum %}
-  <p>Indent: {{ indent }}</p>
+{% for boolean in booleans %}
+  <p>Indent: {{ boolean.label }}</p>
   {% include '@bolt-components-blockquote/blockquote.twig' with {
-    indent: indent == 'true',
+    indent: boolean.value,
     author: {
       name: "Michelangelo di Lodovico Buonarroti Simoni",
       title: "Renaissance Artist"

--- a/apps/pattern-lab/src/_patterns/02-components/blockquote/30-blockquote-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/blockquote/30-blockquote-theme-variation.twig
@@ -11,7 +11,7 @@
         "border": "horizontal",
         "fullBleed": true,
         "logo": {
-          "invert": "true",
+          "invert": true,
           "src": "/pattern-lab/images/content/logos/logo-paypal.svg"
         },
         "content": "<p>The greater danger for most of us lies not in setting our aim too high and falling short; but in setting our aim too low, and achieving our mark.</p>",

--- a/apps/pattern-lab/src/_patterns/02-components/blockquote/30-blockquote-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/blockquote/30-blockquote-theme-variation.twig
@@ -1,6 +1,4 @@
-{% set schema = bolt.data.components['@bolt-components-blockquote'].schema %}
-
-{% for theme in schema.properties.theme.enum %}
+{% for theme in ["xlight", "light", "dark", "xdark"] %}
   <p>theme: {{ theme }}</p>
   {% embed "@utils/theme-demo.twig" %}
     {% block demo_content %}

--- a/apps/pattern-lab/src/_patterns/02-components/button/40-button-with-icon.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/40-button-with-icon.twig
@@ -4,7 +4,6 @@
 <h3>Button w/ Icon Position <code>before</code></h3>
 {% include "@bolt-components-button/button.twig" with {
   text: "Button w/ Icon `before` Text",
-  width: full,
   icon: {
     name: "arrow-left",
     position: "before"
@@ -15,7 +14,6 @@
 <h3>Button w/ Icon Position <code>after</code></h3>
 {% include "@bolt-components-button/button.twig" with {
   text: "Button w/ Icon `after` Text",
-  width: full,
   icon: {
     name: "chevron-right",
     position: "after"
@@ -26,7 +24,6 @@
 <h3>Button w/ Default Icon Position</h3>
 {% include "@bolt-components-button/button.twig" with {
   text: "Button w/ Icon `after` Text - Without Specifying",
-  width: full,
   icon: {
     name: "chevron-right"
   }
@@ -38,7 +35,6 @@
 <h3>Button w/ <code>Left</code> Icon Position (Deprecated)</h3>
 {% include "@bolt-components-button/button.twig" with {
   text: "Button w/ Icon Position `left` of Text (deprecated)",
-  width: full,
   icon: {
     name: "arrow-left",
     position: "left"
@@ -49,7 +45,6 @@
 <h3>Button w/ <code>Right</code> Icon Position (Deprecated)</h3>
 {% include "@bolt-components-button/button.twig" with {
   text: "Button w/ Icon Position `Right` of Text (deprecated)",
-  width: full,
   icon: {
     name: "chevron-right",
     position: "right"

--- a/apps/pattern-lab/src/_patterns/02-components/icon/15-icon-theme-background-shape-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/icon/15-icon-theme-background-shape-variations.twig
@@ -16,12 +16,17 @@
       {% for background in exampleBackgrounds %}
         {% for color in exampleColors %}
           <li>
-            {% include "@bolt-components-icon/icon.twig" with {
+            {% set iconVars = {
               name: "add-open",
               background: background,
-              size: "xlarge",
-              color: color
-            } only %}
+              size: "xlarge"
+            } %}
+
+            {% if color %}
+              {% set iconVars = iconVars | merge({color: color}) %}
+            {% endif %}
+
+            {% include "@bolt-components-icon/icon.twig" with iconVars only %}
             <br />{{ background ? "Background: " ~ background : '' }}
             <br />{{ color ? "Color: " ~ color : '' }}
           </li>
@@ -51,12 +56,17 @@ size: 'xlarge'
       {% for background in exampleBackgrounds %}
         {% for color in exampleColors %}
           <li>
-            {% include "@bolt-components-icon/icon.twig" with {
-            name: "add-open",
-            background: background,
-            size: "xlarge",
-            color: color
-            } only %}
+            {% set iconVars = {
+              name: "add-open",
+              background: background,
+              size: "xlarge"
+            } %}
+
+            {% if color %}
+              {% set iconVars = iconVars | merge({color: color}) %}
+            {% endif %}
+
+            {% include "@bolt-components-icon/icon.twig" with iconVars only %}
             <br />{{ background ? "Background: " ~ background : '' }}
             <br />{{ color ? "Color: " ~ color : '' }}
           </li>

--- a/apps/pattern-lab/src/_patterns/02-components/icon/15-icon-theme-background-shape-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/icon/15-icon-theme-background-shape-variations.twig
@@ -5,8 +5,7 @@
   size: "small"
 } only %}
 {% embed '@bolt-components-band/band.twig' with {
-  theme: theme,
-  size: 'xlarge'
+  theme: theme
 } only %}
   {% block band_content %}
     {% set exampleBackgrounds = ["circle", "square"] %}
@@ -45,8 +44,7 @@ text: "Theme: " ~ theme,
 size: "small"
 } only %}
 {% embed '@bolt-components-band/band.twig' with {
-theme: theme,
-size: 'xlarge'
+theme: theme
 } only %}
   {% block band_content %}
     {% set exampleBackgrounds = ["circle", "square"] %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/30-navbar-transparent.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/30-navbar-transparent.twig
@@ -4,8 +4,7 @@
 } only %}
 
 {% include "@bolt-components-navbar/navbar.twig" with {
-  "theme": "false",
-  "gradient": "false",
+  "theme": "none",
   "title": {
     "tag": "h2",
     "text": "Title Text",

--- a/apps/pattern-lab/src/_patterns/02-components/unordered-list/10-unordered-list-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/unordered-list/10-unordered-list-theme-variation.twig
@@ -1,11 +1,8 @@
-{% set schema = bolt.data.components['@bolt-components-unordered-list'].schema %}
-
-{% for theme in schema.properties.theme.enum %}
+{% for theme in ["xlight", "light", "dark", "xdark"] %}
   <p>Theme: {{ theme }}</p>
   {% embed "@utils/theme-demo.twig" %}
     {% block demo_content %}
       {% include "@bolt-components-unordered-list/unordered-list.twig" with {
-        "theme": theme,
         "contentItems" : [
           {
             "text": "Do not include any data or information in your posts that are confidential!"
@@ -25,4 +22,3 @@
   {% endembed %}
   <br>
 {% endfor %}
-

--- a/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-00-homepage.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-00-homepage.twig
@@ -137,7 +137,6 @@
       {% cell "u-bolt-width-1/1@only-small" %}
         {% include "@bolt/button.twig" with {
           text: "Learn More",
-          style: "flat",
           width: "full",
           size: "medium"
         } only %}
@@ -289,7 +288,7 @@
               {% include "@bolt/button.twig" with {
                 text: "Get Real",
                 style: "primary",
-                size: small
+                size: "small"
               } only %}
 
             {% endcell %}

--- a/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-01-homepage-w-background-video.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-01-homepage-w-background-video.twig
@@ -137,7 +137,6 @@
       {% cell "u-bolt-width-1/1@only-small" %}
         {% include "@bolt/button.twig" with {
           text: "Learn More",
-          style: "flat",
           width: "full",
           size: "medium"
         } only %}
@@ -340,7 +339,7 @@
               {% include "@bolt/button.twig" with {
                 text: "Get Real",
                 style: "primary",
-                size: small
+                size: "small"
               } only %}
 
             {% endcell %}

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
@@ -264,7 +264,7 @@
       ]
     }
   ]
-} %}
+} only %}
   {% block band_content %}
     {% include "@bolt/headline.twig" with {
       text: "What's Trending",

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
@@ -141,7 +141,6 @@
       {% cell "u-bolt-width-1/1@only-small" %}
         {% include "@bolt/button.twig" with {
           text: "Learn More",
-          style: "flat",
           width: "full",
           size: "medium"
         } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-05-d8-homepage.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-05-d8-homepage.twig
@@ -136,7 +136,6 @@
       {% cell "u-bolt-width-1/1@only-small" %}
         {% include "@bolt/button.twig" with {
           text: "Learn More",
-          style: "flat",
           width: "full",
           size: "medium"
         } only %}
@@ -290,7 +289,7 @@
               {% include "@bolt/button.twig" with {
                 text: "Get Real",
                 style: "primary",
-                size: small
+                size: "small"
               } only %}
 
             {% endcell %}

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-20-d8-homepage-video-test.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-20-d8-homepage-video-test.twig
@@ -155,7 +155,6 @@
       {% cell "u-bolt-width-1/1@only-small" %}
         {% include "@bolt/button.twig" with {
           text: "Learn More",
-          style: "flat",
           width: "full",
           size: "medium"
         } only %}
@@ -309,7 +308,7 @@
               {% include "@bolt/button.twig" with {
                 text: "Get Real",
                 style: "primary",
-                size: small
+                size: "small"
               } only %}
 
             {% endcell %}

--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/event-landing.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/event-landing.twig
@@ -293,7 +293,7 @@
             {% for i in 1..6 %}
               {% cell "u-bolt-width-1/1" %}
                 {% embed "@bolt/card.twig" with {
-                  theme: "x-light"
+                  theme: "xlight"
                 } only %}
 
                   {% block card_media %}

--- a/packages/components/bolt-action-blocks/action-blocks.schema.yml
+++ b/packages/components/bolt-action-blocks/action-blocks.schema.yml
@@ -2,17 +2,9 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Action blocks
 type: object
 properties:
-  theme:
-    type: string
-    description: A color theme.
-    default: false
-    enum:
-      - xlight
-      - light
-      - dark
-      - xdark
-      - medium
-      - 'false'
+  attributes:
+    type: object
+    description: A Drupal-style attributes object with extra attributes to append to this component.
   maxItemsPerRow:
     type: number
     description: Number of items to place in a row before beginning a new row.

--- a/packages/components/bolt-action-blocks/action-blocks.schema.yml
+++ b/packages/components/bolt-action-blocks/action-blocks.schema.yml
@@ -40,12 +40,9 @@ properties:
       - center
       - bottom
   border:
-    type: string
+    type: boolean
     description: Display a border around the action blocks.
     default: true
-    enum:
-      - 'true'
-      - 'false'
   contentItems:
     type: array
     description: Content items to populate the action blocks.

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -60,14 +60,14 @@
 {% set itemClass = prefix ~ componentItemName %}
 {% set maxItemsPerRow = maxItemsPerRow >= minItems and maxItemsPerRow <= maxItems ? maxItemsPerRow : defaultItems %}
 {% set align = align | default("top") %}
-{% set border = border == false and border is not null ? "false" : "true" %}
+{% set border = border is sameas(false) ? false : true %}
 
 
 {% set classes = [
   baseClass,
   maxItemsPerRow ? baseClass ~ "--item-max-" ~ maxItemsPerRow : "",
   align in alignments|keys ? baseClass ~ "--vertical-align-" ~ alignments[align],
-  border == "true" ? baseClass ~ "--bordered" : baseClass ~ "--borderless"
+  border ? baseClass ~ "--bordered" : baseClass ~ "--borderless"
 ] %}
 
 

--- a/packages/components/bolt-band/band.schema.yml
+++ b/packages/components/bolt-band/band.schema.yml
@@ -4,6 +4,9 @@ category: layout
 type: object
 format: grid
 properties:
+  attributes:
+    type: object
+    description: A Drupal-style attributes object with extra attributes to append to this component.
   fullBleed:
     type: boolean
     description: If set to true, the band will take the full width of the page.

--- a/packages/components/bolt-band/band.schema.yml
+++ b/packages/components/bolt-band/band.schema.yml
@@ -10,11 +10,13 @@ properties:
   size:
     type: string
     description: Height of the band.
+    default: medium
     enum:
       - xsmall
       - small
       - medium
       - large
+      - none
   contentTag:
     type: string
     description: Html tag to use for the band's content.
@@ -29,10 +31,11 @@ properties:
   theme:
     type: string
     description: Bolt theme.
+    default: dark
     enum:
       - xlight
       - light
       - medium
       - dark
       - xdark
-
+      - none

--- a/packages/components/bolt-band/src/band--flag.twig
+++ b/packages/components/bolt-band/src/band--flag.twig
@@ -1,36 +1,32 @@
-{% embed "@bolt/band.twig" with {
-  size: size | default("large"),
-  theme: theme | default("dark")
-} %}
-  {% block band_content %}
+{% extends "@bolt/band.twig" %}
 
-    {% grid "o-bolt-grid--flex o-bolt-grid--middle o-bolt-grid--matrix" %}
-      {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-flex-grow" %}
-        {% grid %}
-          {% cell "u-bolt-width-1/1 u-bolt-width-3/4@small" %}
-            {% if eyebrow %}
-              {% include "@bolt/eyebrow.twig" with eyebrow only %}
-            {% endif %}
-          
-            {% if headline %}
-              {% include "@bolt/headline.twig" with headline only %}
-            {% endif %}
+{% set size = size | default("large") %}
 
-            {{ content }}
-          {% endcell %}
-        {% endgrid %}
-      {% endcell %}
+{% block band_content %}
 
-      {# TODO: only allow max of 2 buttons #}
-      {% if buttons %}
-        {% cell "u-bolt-width-1/1@only-small" %}
-          {{ include('@bolt/button-group.twig', { buttons: buttons }, with_context = false) }}
+  {% grid "o-bolt-grid--flex o-bolt-grid--middle o-bolt-grid--matrix" %}
+    {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-flex-grow" %}
+      {% grid %}
+        {% cell "u-bolt-width-1/1 u-bolt-width-3/4@small" %}
+          {% if eyebrow %}
+            {% include "@bolt/eyebrow.twig" with eyebrow only %}
+          {% endif %}
+
+          {% if headline %}
+            {% include "@bolt/headline.twig" with headline only %}
+          {% endif %}
+
+          {{ content }}
         {% endcell %}
-      {% endif %}
-    {% endgrid %}
+      {% endgrid %}
+    {% endcell %}
 
-  {% endblock band_content %}
-{% endembed %}
+    {# TODO: only allow max of 2 buttons #}
+    {% if buttons %}
+      {% cell "u-bolt-width-1/1@only-small" %}
+        {{ include('@bolt/button-group.twig', { buttons: buttons }, with_context = false) }}
+      {% endcell %}
+    {% endif %}
+  {% endgrid %}
 
-
-
+{% endblock band_content %}

--- a/packages/components/bolt-band/src/band.twig
+++ b/packages/components/bolt-band/src/band.twig
@@ -1,7 +1,6 @@
-{# @todo: uncomment below when the strange validation issue relating to Bands (specifically, 'no schema found to verify against') is resolved. #}
-{# {% if enable_json_schema_validation %}
+{% if enable_json_schema_validation %}
   {{ validate_data_schema(bolt.data.components['@bolt-components-band'].schema, _self) | raw }}
-{% endif %} #}
+{% endif %}
 
 {% set prefix = "c-bolt-" %}
 {% set contentTags = ["div", "article", "section", "header", "footer", "nav", "figcaption"] %} {# Available content container tags #}

--- a/packages/components/bolt-band/src/band.twig
+++ b/packages/components/bolt-band/src/band.twig
@@ -1,23 +1,11 @@
+{% set schema = bolt.data.components['@bolt-components-band'].schema %}
 {% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-band'].schema, _self) | raw }}
+  {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
 {% set prefix = "c-bolt-" %}
 {% set contentTags = ["div", "article", "section", "header", "footer", "nav", "figcaption"] %} {# Available content container tags #}
 {% set fullBleedOptions = [true, false] %}
-{% set sizes = [
-  "xsmall",
-  "small",
-  "medium",
-  "large"
-] %}
-{% set themes = [
-  "xlight",
-  "light",
-  "medium",
-  "dark",
-  "xdark"
-] %}
 
 {% set attributes = create_attribute(attributes|default({})) %}
 
@@ -28,24 +16,22 @@
 {% set fullBleed = fullBleed == false and fullBleed is not null ? false : true %}
 
 {# set fullBleed = fullBleed in fullBleedOptions ? fullBleed | default(false) #}
-{% if size != "none" %}
-  {% set size = size | default("medium") %}
-{% endif %}
-{% if theme != "none" %}
-  {% set theme = theme | default("dark") %}
-{% endif %}
 
+{% set size = size in schema.properties.size.enum ? size : schema.properties.size.default %}
+{% set size = size == "none" ? false : size %}
+{% set theme = theme in schema.properties.theme.enum ? theme : schema.properties.theme.default %}
+{% set theme = theme == "none" ? false : theme %}
 
 {% set classes = [
   baseClass,
   fullBleed == true ? baseClass ~ "--" ~ "full" : "",
-  size in sizes ? baseClass ~ "--" ~ size : "",
-  theme in themes ? "t-bolt-" ~ theme : ""
+  size ? baseClass ~ "--" ~ size : "",
+  theme ? "t-bolt-" ~ theme : ""
 ] %}
 
 <bolt-{{ componentName }}
-  size="{{ size }}"
-  theme="{{ theme }}"
+  {% if size %} size="{{ size }}" {% endif %}
+  {% if theme %} theme="{{ theme }}" {% endif %}
   bolt-component {{ attributes.addClass(classes) }}>
   {% set renderedBandContent %}
     {% block band_background %}

--- a/packages/components/bolt-blockquote/blockquote.schema.yml
+++ b/packages/components/bolt-blockquote/blockquote.schema.yml
@@ -4,17 +4,9 @@ type: object
 required:
   - content
 properties:
-  theme:
-      type: string
-      description: Color theme. Can be set to false for a transparent background.
-      default: false
-      enum:
-        - xlight
-        - light
-        - dark
-        - xdark
-        - medium
-        - 'false'
+  attributes:
+    type: object
+    description: A Drupal-style attributes object with extra attributes to append to this component.
   content:
     description: Text to appear in blockquote.
     type: string

--- a/packages/components/bolt-blockquote/blockquote.schema.yml
+++ b/packages/components/bolt-blockquote/blockquote.schema.yml
@@ -45,17 +45,11 @@ properties:
   indent:
     description: Indent text.
     default: false
-    type: string
-    enum:
-      - 'true'
-      - 'false'
+    type: boolean
   fullBleed:
-      description: Width of the brower window.
-      default: false
-      type: string
-      enum:
-        - 'true'
-        - 'false'
+    description: Width of the brower window.
+    default: false
+    type: boolean
   logo:
       description: Add a logo component.
       type: object

--- a/packages/components/bolt-blockquote/src/blockquote.twig
+++ b/packages/components/bolt-blockquote/src/blockquote.twig
@@ -63,7 +63,6 @@
 {% set size = size == false and size is null ? "xlarge" : size | default("xlarge") %}
 {% set alignItems = alignItems == false and alignItems is null ? "left" : alignItems | default("left") %}
 {% set border = border == false and border is null ? "vertical" : border | default("vertical") %}
-{% set indent = indent == false and indent is null ? "false" : "true" %}
 {% set fullBleed = fullBleed == false and fullBleed is null ? "false" : "true" %}
 
 
@@ -72,7 +71,7 @@
   size in sizeOptions ? baseClass ~ "--" ~ size : "",
   alignItems in alignItemsOptions|keys ? baseClass ~ "--align-items-" ~ alignItemsOptions[alignItems],
   border in borderOptions|keys ? baseClass ~ "--" ~ borderOptions[border],
-  indent == "true" ? baseClass ~ "--indented" : "",
+  indent ? baseClass ~ "--indented" : "",
   fullBleed == "true" ? baseClass ~ "--full" : ""
 ] %}
 

--- a/packages/components/bolt-card/src/card-w-teaser.twig
+++ b/packages/components/bolt-card/src/card-w-teaser.twig
@@ -13,7 +13,7 @@
     {% set cardBodyContent = teaser %}
     {% if teaser.buttons %}
       {% set cardBodyContent = cardBodyContent|merge({
-        buttons: null
+        buttons: []
        }) %}
     {% endif %}
 

--- a/packages/components/bolt-card/src/card.twig
+++ b/packages/components/bolt-card/src/card.twig
@@ -54,7 +54,7 @@
         {% endfor %}
 
         {% set item = item | merge({
-          "buttons": null
+          "buttons": []
         }) %}
       {% endif %}
 
@@ -72,7 +72,7 @@
         {% set button = button | merge({ "pattern": "button" }) %}
         {% set _items = _items | merge([button]) %}
       {% endfor %}
-      {% set item = item | merge({ "buttons": null }) %}
+      {% set item = item | merge({ "buttons": [] }) %}
     {% endif %}
   {% endif %}
 

--- a/packages/components/bolt-code-snippet/code-snippet.schema.yml
+++ b/packages/components/bolt-code-snippet/code-snippet.schema.yml
@@ -2,10 +2,6 @@ $schema: http://json-schema.org/draft-04/schema#
 title: 'Code Snippet'
 description: 'Monospace Font Styles for Code Text'
 type: object
-required:
-  - display
-  - lang
-  - syntax
 properties:
   display:
     type: string

--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -5,8 +5,8 @@ required:
   - text
 properties:
   text:
-    type: string
-    description: Text content of the headline.
+    type: [string, object, array]
+    description: Renderable text content of the headline.
   tag:
     type: string
     description: Html tag.

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -85,21 +85,12 @@
   {% endif %}
 
   {% if url %}
-    {% if type == "text" %}
-      {% include "@bolt/link.twig" with {
-        text: text,
-        icon: icon,
-        url: url,
-      } only %}
-    {% else %}
-      {# [Mai] This means only headlines/subheadlines/eyebrows would get the special link styles #}
-      {% include "@bolt/link.twig" with {
-        text: text,
-        icon: icon,
-        url: url,
-        isHeadline: true
-      } only %}
-    {% endif %}
+    {% include "@bolt/link.twig" with {
+      text: text,
+      icon: icon,
+      url: url,
+      isHeadline: (type == "text")
+    } only %}
   {% else %}
     {{ text }}
   {% endif %}

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -85,12 +85,17 @@
   {% endif %}
 
   {% if url %}
-    {% include "@bolt/link.twig" with {
+    {% set linkVars = {
       text: text,
-      icon: icon,
       url: url,
       isHeadline: (type == "text")
-    } only %}
+    } %}
+
+    {% if icon %}
+      {% set linkVars = linkVars | merge({ icon: icon }) %}
+    {% endif %}
+
+    {% include "@bolt/link.twig" with linkVars only %}
   {% else %}
     {{ text }}
   {% endif %}

--- a/packages/components/bolt-image/image.schema.yml
+++ b/packages/components/bolt-image/image.schema.yml
@@ -1,8 +1,11 @@
 $schema: http://json-schema.org/draft-04/schema#
 title: Image
 type: object
-required:
-  - src
+anyOf:
+  - required:
+    - src
+  - required:
+    - srcset
 properties:
   src:
     type: string

--- a/packages/components/bolt-link/link.schema.yml
+++ b/packages/components/bolt-link/link.schema.yml
@@ -2,9 +2,18 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Link
 type: object
 properties:
+  attributes:
+    type: object
+    description: A Drupal-style attributes object with extra attributes to append to this component.
   text:
+    type: [string, object, array]
+    description: Renderable text content for the link.
+  url:
     type: string
-    description: Link href attribute. Either url or href may be passed in.
+    description: A url to link to.  This may also be passed as part of `attributes`
+  href:
+    type: string
+    description: Deprecated. Use url instead.
   icon:
     type: object
     description: Bolt icon. Accepts the same options as Bolt Icon Component `@bolt-components-icon`

--- a/packages/components/bolt-link/link.schema.yml
+++ b/packages/components/bolt-link/link.schema.yml
@@ -9,3 +9,6 @@ properties:
     type: object
     description: Bolt icon. Accepts the same options as Bolt Icon Component `@bolt-components-icon`
     ref: '@bolt-components-icon/icon.schema.yml'
+  isHeadline:
+    type: boolean
+    description: Whether this link should get special headline styling treatment

--- a/packages/components/bolt-nav-priority/nav-priority.schema.yml
+++ b/packages/components/bolt-nav-priority/nav-priority.schema.yml
@@ -2,16 +2,6 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Nav Priority (Priority+ Navigation)
 type: object
 properties:
-  theme:
-    type: string
-    description: Color theme. Can be set to false for a transparent background.
-    default: dark
-    enum:
-      - xlight
-      - light
-      - dark
-      - xdark
-      - 'false'
   links:
     type: array
     items:

--- a/packages/components/bolt-navbar/navbar.schema.yml
+++ b/packages/components/bolt-navbar/navbar.schema.yml
@@ -4,14 +4,14 @@ type: object
 properties:
   theme:
     type: string
-    description: Color theme. Can be set to false for a transparent background.
+    description: Color theme. Can be set to 'none' for a transparent background.
     default: dark
     enum:
       - xlight
       - light
       - dark
       - xdark
-      - 'false'
+      - none
   gradient:
     # type: string
     description: DEPRECATED. In the latest iteration of the Navbar component, only solid color themes are supported ^

--- a/packages/components/bolt-navbar/src/navbar.twig
+++ b/packages/components/bolt-navbar/src/navbar.twig
@@ -4,8 +4,13 @@
 
 {% set schema = bolt.data.components["@bolt-components-navbar"].schema %}
 
+{# Support backwards compatibiliy.  Future implementations that wish to disable the theme should
+use the string "none" rather than a boolean false #}
+{% set theme = theme is sameas(false) ? "none" : theme %}
+
 {% set themeOptions = schema.properties.theme.enum %}
 {% set theme = theme in themeOptions ? theme : schema.properties.theme.default %}
+{% set theme = theme == "none" ? false : theme %}
 
 <bolt-navbar
   {% if theme %} class="t-bolt-{{ theme }}" {% endif %}

--- a/packages/components/bolt-teaser/teaser.schema.yml
+++ b/packages/components/bolt-teaser/teaser.schema.yml
@@ -29,7 +29,6 @@ properties:
   buttons:
     type: array
     description: An array of button component objects
-    maxItems: 2
     items:
       type: object
       description: A button

--- a/packages/components/bolt-unordered-list/src/unordered-list.twig
+++ b/packages/components/bolt-unordered-list/src/unordered-list.twig
@@ -1,5 +1,6 @@
+{% set schema = bolt.data.components['@bolt-components-unordered-list'].schema %}
 {% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-unordered-list'].schema, _self) | raw }}
+  {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
 {% set prefix = "c-bolt-" %}

--- a/packages/components/bolt-unordered-list/unordered-list.schema.yml
+++ b/packages/components/bolt-unordered-list/unordered-list.schema.yml
@@ -7,17 +7,6 @@ properties:
   attributes:
     type: object
     description: A Drupal-style attributes object with extra attributes to append to this component.
-  theme:
-    type: string
-    description: Color theme. Can be set to false for a transparent background.
-    default: false
-    enum:
-      - xlight
-      - light
-      - dark
-      - xdark
-      - medium
-      - 'false'
   contentItems:
     type: array
     title: The content items

--- a/packages/components/bolt-video/video.schema.yml
+++ b/packages/components/bolt-video/video.schema.yml
@@ -6,13 +6,13 @@ properties:
     type: object
     description: A Drupal-style attributes object with extra attributes to append to this component.
   videoId:
-    type: number
+    type: [string, number]
     description: Brightcove ID for this video.
   playerId:
     type: string
     description: Brightcover Player ID.
   accountID:
-    type: number
+    type: [string, number]
     description: ID of the Brightcove account that owns the video.
   videoUuid:
     type: string


### PR DESCRIPTION
Original issue: http://vjira2:8080/browse/BDS-291

This PR fixes all outstanding schema errors through two means:
- Fixing incorrectly declared variables in Pattern Lab
- Clarifying schema and/or editing patterns to correctly handle the expected variable types

Principles used when updating schema:
- Variables should avoid mixing booleans and other variable types.  For example, instead of allowing `FALSE` to be passed for `theme`, you should pass the string `none`.
- `null` is generally not valid.  You should either pass a value for the variable or not pass it at all.  This allows schema validation to catch errors like the one in 587da2dbc where someone thinks they are passing a string but they forgot to add the quotes.
- Variables that aren't logically evaluated but rather just printed to the page have relaxed parameters (see 4d692964).