### PR TITLE
Refactor: Wire Up Docs Site To New `<bolt-text>` Component

### DIFF
--- a/apps/bolt-site/templates/site.twig
+++ b/apps/bolt-site/templates/site.twig
@@ -70,7 +70,7 @@
         <a href="/pattern-lab/index.html" target="_blank">Pattern Lab</a>
       {% endif %}
     {% endfor %}
-    
+
     {% if 'docs/' in currentUrl %}
       <a href="#menu" class="storefront-docs__hamburger u-bolt-hide@medium">
         <span class="u-bolt-margin-right-xsmall">Menu</span>
@@ -175,15 +175,6 @@
 
 
 <script src="/build/bolt-global.js" async></script>
-
-{# Code syntax highlighting - https://highlightjs.org/ #}
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
-
-{# @todo Load async. See script tags in footer for these same scripts that are commented out. #}
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/scss.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/twig.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
 
 <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
 {#<script>#}

--- a/apps/pattern-lab/src/_includes/utils/docs.twig
+++ b/apps/pattern-lab/src/_includes/utils/docs.twig
@@ -46,7 +46,13 @@
           id: "usage"
         }
       } %}
-      <pre class="u-bolt-margin-bottom-large"><code>{{ code }}</code></pre>
+      <bolt-code-snippet display="block" lang="twig">
+        <pre>
+          <code is="shadow-root">
+          {{ code }}
+          </code>
+        </pre>
+      </bolt-code-snippet>
     {% endif %}
 
 

--- a/apps/pattern-lab/src/_includes/utils/docs.twig
+++ b/apps/pattern-lab/src/_includes/utils/docs.twig
@@ -46,13 +46,11 @@
           id: "usage"
         }
       } %}
+      {% spaceless %}
       <bolt-code-snippet display="block" lang="twig">
-        <pre>
-          <code is="shadow-root">
-          {{ code }}
-          </code>
-        </pre>
+          <pre><code is="shadow-root">{{ code }}</code></pre>
       </bolt-code-snippet>
+      {% endspaceless %}
     {% endif %}
 
 

--- a/apps/pattern-lab/src/_includes/utils/docs.twig
+++ b/apps/pattern-lab/src/_includes/utils/docs.twig
@@ -2,29 +2,12 @@
 <div class="c-bolt-docs t-bolt-xlight">
 
   <div class="c-bolt-docs__page-content">
-
-    {% include "@bolt/headline.twig" with {
-      size: "xxxlarge",
-      tag: "h1",
-      text: schema.title ? schema.title : "Component Title"
-    } %}
+    <bolt-text font-size="xxxlarge" tag="h1" display="block" headline>
+    {{ schema.title ? schema.title : "Component Title" }}
+    </bolt-text>
 
     {% if readmeFile %}
       <div class="c-bolt-docs__readme">
-        {% include "@bolt/headline.twig" with {
-          size: "xlarge",
-          tag: "h2",
-          url: "#getting-started",
-          text: "Getting Started",
-          icon: "none",
-          attributes: {
-            class: [
-              "u-bolt-margin-bottom-xsmall",
-              "c-bolt-docs__heading-fragment"
-            ],
-            id: "getting-started"
-          }
-        } %}
         <div class="c-bolt-docs__lead u-bolt-margin-bottom-large">
           {{ source(readmeFile) | markdown }}
         </div>
@@ -32,30 +15,24 @@
     {% endif %}
 
     {% if code %}
-      {% include "@bolt/headline.twig" with {
-        size: "xlarge",
-        tag: "h2",
-        url: "#usage",
-        text: "Usage",
-        icon: "none",
-        attributes: {
-          class: [
-            "u-bolt-margin-bottom-xsmall",
-            "c-bolt-docs__heading-fragment"
-          ],
-          id: "usage"
-        }
-      } %}
+      <bolt-text font-size="xlarge" tag="h2" id="usage" url="#usage" headline>
+        Usage
+      </bolt-text>
+
       {% spaceless %}
-      <bolt-code-snippet display="block" lang="twig">
+        <bolt-code-snippet display="block" lang="twig">
           <pre><code is="shadow-root">{{ code }}</code></pre>
-      </bolt-code-snippet>
+        </bolt-code-snippet>
       {% endspaceless %}
     {% endif %}
 
 
     {% if schema and schema.properties %}
-      {% include "@bolt/headline.twig" with {
+      <bolt-text font-size="xlarge" tag="h2" id="schema" url="#schema" headline>
+        Schema
+      </bolt-text>
+
+      {# {% include "@bolt/headline.twig" with {
         size: "xlarge",
         tag: "h2",
         url: "#schema",
@@ -68,7 +45,7 @@
           ],
           id: "schema"
         }
-      } %}
+      } %} #}
 
       <div class="bolt-docs__schema u-bolt-margin-bottom-large">
         {% include '@utils/schema-docs.twig' with { schema: schema } only %}
@@ -76,20 +53,9 @@
     {% endif %}
 
     {% if links %}
-      {% include "@bolt/headline.twig" with {
-        size: "xlarge",
-        tag: "h2",
-        url: "#helpful-links",
-        text: "Helpful Links",
-        icon: "none",
-        attributes: {
-          class: [
-            "u-bolt-margin-bottom-xsmall",
-            "c-bolt-docs__heading-fragment"
-          ],
-          id: "schema"
-        }
-      } %}
+      <bolt-text font-size="xlarge" tag="h2" id="helpful-links" url="#helpful-links" headline>
+        Helpful Links
+      </bolt-text>
 
       <ul class="c-bolt-docs__page-nav-list u-bolt-margin-bottom-large">
         {% for link in links %}
@@ -124,115 +90,35 @@
         <ul class="o-bolt-ui-list o-bolt-ui-list--xxsmall o-bolt-ui-list--borderless">
           {% if readmeFile %}
             <li class="o-bolt-ui-list__item">
-              {% include "@bolt/headline.twig" with {
-                size: "xsmall",
-                transform: "capitalize",
-                weight: "regular",
-                tag: "h3",
-                text: include("@bolt/link.twig", {
-                  text: "Getting Started",
-                  url:  "#getting-started",
-                  attributes: {
-                    class: [
-                      "c-bolt-link--headline"
-                    ],
-                    'data-scroll-offset': 70
-                  }
-                }),
-                attributes: {
-                  class: [
-                    "c-bolt-headline--link",
-                    "u-bolt-margin-bottom-none"
-                  ]
-                },
-                icon: "none",
-              } only %}
+              <bolt-text font-size="xsmall" weight="regular" transform="capitalize" tag="h3" url="#getting-started" headline data-scroll-offset="70">
+                Getting Started
+              </bolt-text>
             </li>
           {% endif %}
 
           {% if code %}
             <li class="o-bolt-ui-list__item">
-              {% include "@bolt/headline.twig" with {
-                size: "xsmall",
-                transform: "capitalize",
-                weight: "regular",
-                tag: "h3",
-                text: include("@bolt/link.twig", {
-                  text: "Usage",
-                  url:  "#usage",
-                  attributes: {
-                    class: [
-                      "c-bolt-link--headline"
-                    ],
-                    'data-scroll-offset': 70
-                  }
-                }),
-                attributes: {
-                  class: [
-                    "c-bolt-headline--link",
-                    "u-bolt-margin-bottom-none"
-                  ]
-                },
-                icon: "none",
-              } only %}
+              <bolt-text font-size="xsmall" weight="regular" transform="capitalize" tag="h3" url="#getting-started" headline data-scroll-offset="70">
+                Usage
+              </bolt-text>
             </li>
           {% endif %}
 
 
           {% if schema and schema.properties %}
             <li class="o-bolt-ui-list__item">
-              {% include "@bolt/headline.twig" with {
-                size: "xsmall",
-                transform: "capitalize",
-                weight: "regular",
-                tag: "h3",
-                text: include("@bolt/link.twig", {
-                  text: "Schema",
-                  url:  "#schema",
-                  attributes: {
-                    class: [
-                      "c-bolt-link--headline"
-                    ],
-                    'data-scroll-offset': 70
-                  }
-                }),
-                attributes: {
-                  class: [
-                    "c-bolt-headline--link",
-                    "u-bolt-margin-bottom-none"
-                  ]
-                },
-                icon: "none",
-              } only %}
+              <bolt-text font-size="xsmall" weight="regular" transform="capitalize" tag="h3" url="#schema" headline data-scroll-offset="70">
+                Schema
+              </bolt-text>
             </li>
           {% endif %}
 
 
           {% if links %}
             <li class="o-bolt-ui-list__item">
-              {% include "@bolt/headline.twig" with {
-                size: "xsmall",
-                transform: "capitalize",
-                weight: "regular",
-                tag: "h3",
-                text: include("@bolt/link.twig", {
-                  text: "Helpful Links",
-                  url:  "#helpful-links",
-                  attributes: {
-                    class: [
-                      "c-bolt-link--headline"
-                    ],
-                    'data-scroll-offset': 70
-                  }
-                }),
-                attributes: {
-                  class: [
-                    "c-bolt-headline--link",
-                    "u-bolt-margin-bottom-none"
-                  ]
-                },
-                icon: "none",
-              } only %}
+              <bolt-text font-size="xsmall" weight="regular" transform="capitalize" tag="h3" url="#helpful-links" headline data-scroll-offset="70">
+                Helpful Links
+              </bolt-text>
             </li>
           {% endif %}
         </ul>
@@ -240,10 +126,12 @@
 
       {% if readmeFile %}
         <li class="o-bolt-ui-list__item">
-          <a href="{{ github_url(readmeFile) }}" class="c-bolt-docs__page-nav__link" target="_blank">
-            <bolt-icon name="pencil"></bolt-icon>
-            Edit this page
-          </a>
+          <bolt-text font-size="xsmall" weight="regular" transform="capitalize" tag="h3" headline>
+            <a href="{{ github_url(readmeFile) }}" target="_blank">
+              <bolt-icon name="pencil"></bolt-icon>
+              Edit this page
+            </a>
+          </bolt-text>
         </li>
       {% endif %}
     </ul>

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/00-action-blocks-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/00-action-blocks-docs.twig
@@ -1,7 +1,6 @@
 {% set schema = bolt.data.components['@bolt-components-action-blocks'].schema %}
 
-{% set code %} {% verbatim %}
-{% include "@bolt-components-action-blocks/action-blocks.twig" with {
+{% set code %}{% verbatim %}{% include "@bolt-components-action-blocks/action-blocks.twig" with {
   contentItems: [
     {
       text: "Item 1",
@@ -31,8 +30,7 @@
       }
     }
   ]
-} only %}
-{% endverbatim %}
+} only %}{% endverbatim %}
 {% endset %}
 
 {% include '@utils/docs.twig' with {

--- a/packages/components/bolt-action-blocks/README.md
+++ b/packages/components/bolt-action-blocks/README.md
@@ -1,15 +1,31 @@
+<div>
+<bolt-text font-size="xxlarge" tag="h2" subheadline>
+  Stylistic block layout for displaying an actionable icon and text.
+</bolt-text>
 
-Stylistic block layout for displaying actionable icon and text. Part of the Bolt “Components” CSS framework that powers the [Bolt Design System](https://www.boltdesignsystem.com).
+<br>
 
-### Install via NPM
-```
-npm install @bolt/components-action-blocks
-```
+<bolt-text font-size="xlarge" tag="h2" headline>
+  Install via NPM
+</bolt-text>
 
-## Description:
-Action blocks work as a group to provide the user an easy to browse list of options of relativeto take action to discover more information. They commonly exist as links to more detailed content. 
+<bolt-code-snippet display="block" lang="bash">
+<code is="shadow-root" class="c-bolt-code-snippet">npm install @bolt/components-action-blocks</code>
+</bolt-code-snippet>
 
-## Best practices
+
+<bolt-text font-size="xlarge" tag="h2" headline>Description</bolt-text>
+
+<bolt-text font-size="medium" tag="p">
+  Action blocks work as a group to provide the user an easy to browse list of options of relativeto take action to discover more information. They commonly exist as links to more detailed content.
+</bolt-text>
+
+<bolt-text font-size="xlarge" tag="h2" headline>
+  Best practices
+</bolt-text>
+
+</div>
+
 * Can use xlight, light, dark, and xdark themes.
 * Can have an image, icon, and/or text
 * Should link to content 


### PR DESCRIPTION
Updates the docs site to use the new `<bolt-text>` component for testing purposes; Also updates the Action Block readme as an example testing out using the component to style the text there as well 