### PR TITLE
fix: Fix headline styling regression (BDS-368)

### DIFF
--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -88,7 +88,7 @@
     {% set linkVars = {
       text: text,
       url: url,
-      isHeadline: (type == "text")
+      isHeadline: (type != "text")
     } %}
 
     {% if icon %}


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-368

The problem is that, with the commit below, I inadvertently changed the logic from "If type is not text, give it the headline styling" to "if type _is_ text, give it the headline styling".

https://github.com/bolt-design-system/bolt/commit/730953b7a50d89abe4700e2d4fec80493cee7274#diff-96af1223b5d80a416426920a13a79b52