### PR TITLE
Fix: Less Jumpy Smooth Scroll / Nav Links

### DIFF
--- a/packages/components/bolt-navlink/navlink.js
+++ b/packages/components/bolt-navlink/navlink.js
@@ -44,8 +44,14 @@ class BoltNavLink extends BoltComponent() {
     }
   }
 
-  onClick() {
-    if (!this.props.active) {
+  onClick(event) {
+    // prevent browser default if we're smooth scrolling to a navlink. this ensures a smoother, less jumpy animation in browsers (like Safari)
+    if (this._shadowLink.getAttribute('href').indexOf('#') !== -1){
+      event.preventDefault();
+    }
+
+    // manually add smooth scroll to dropdown links since these are added to the page AFTER smooth scroll event bindings would hae been added.
+    if (!this.props.active && this.props.isDropdownLink) {
       const scrollTarget = getScrollTarget(this._shadowLink);
       if (scrollTarget) {
         smoothScroll.animateScroll(scrollTarget, this._shadowLink, defaultScrollOptions);


### PR DESCRIPTION
Update the <bolt-navlink> to check if the link being interacted with is a hashed link and if so, preventDefault to ensure a much less jumpy smooth scroll experience. 

Fixes issues noticed when testing in Safari and IE 11

CC @theSadowski @remydenton @mikemai2awesome 