### PR TITLE
Hotfix: fix bolt-text component CSS class on master

### DIFF
--- a/packages/components/bolt-text/src/text.scss
+++ b/packages/components/bolt-text/src/text.scss
@@ -58,7 +58,7 @@ bolt-text {
 $bolt-text--minus-letter-spacing: -0.025rem;
 $bolt-text--plus-letter-spacing: 0.05rem;
 
-.c-bolt-text-2 {
+.c-bolt-text-v2 {
   margin: 0;
   padding: 0;
 
@@ -77,7 +77,7 @@ $bolt-text--plus-letter-spacing: 0.05rem;
     text-decoration: underline;
   }
 
-  &.c-bolt-text-2--body {
+  &.c-bolt-text-v2--body {
     a:link, a:visited {
       text-decoration: underline;
     }
@@ -87,7 +87,7 @@ $bolt-text--plus-letter-spacing: 0.05rem;
   }
 }
 
-.c-bolt-text-2 {
+.c-bolt-text-v2 {
   // Font-Family
   &--headline {
     @include bolt-font-family('heading');
@@ -213,48 +213,48 @@ $bolt-text--plus-letter-spacing: 0.05rem;
     line-height: $bolt-line-height--tight;
   }
   &--line-height-regular {
-    &.c-bolt-text-2--font-xxxlarge {
+    &.c-bolt-text-v2--font-xxxlarge {
       line-height: $bolt-line-height--xxxlarge;
     }
-    &.c-bolt-text-2--font-xxlarge {
+    &.c-bolt-text-v2--font-xxlarge {
       line-height: $bolt-line-height--xxlarge;
     }
-    &.c-bolt-text-2--font-xlarge {
+    &.c-bolt-text-v2--font-xlarge {
       line-height: $bolt-line-height--xlarge;
     }
-    &.c-bolt-text-2--font-large {
+    &.c-bolt-text-v2--font-large {
       line-height: $bolt-line-height--large;
     }
-    &.c-bolt-text-2--font-medium {
+    &.c-bolt-text-v2--font-medium {
       line-height: $bolt-line-height--medium;
     }
-    &.c-bolt-text-2--font-small {
+    &.c-bolt-text-v2--font-small {
       line-height: $bolt-line-height--small;
     }
-    &.c-bolt-text-2--font-xsmall {
+    &.c-bolt-text-v2--font-xsmall {
       line-height: $bolt-line-height--xsmall;
     }
   }
   &--line-height-loose {
-    &.c-bolt-text-2--font-xxxlarge {
+    &.c-bolt-text-v2--font-xxxlarge {
       line-height: ($bolt-line-height--xxxlarge + $bolt-line-height--add-loose);
     }
-    &.c-bolt-text-2--font-xxlarge {
+    &.c-bolt-text-v2--font-xxlarge {
       line-height: ($bolt-line-height--xxlarge + $bolt-line-height--add-loose);
     }
-    &.c-bolt-text-2--font-xlarge {
+    &.c-bolt-text-v2--font-xlarge {
       line-height: ($bolt-line-height--xlarge + $bolt-line-height--add-loose);
     }
-    &.c-bolt-text-2--font-large {
+    &.c-bolt-text-v2--font-large {
       line-height: ($bolt-line-height--large + $bolt-line-height--add-loose);
     }
-    &.c-bolt-text-2--font-medium {
+    &.c-bolt-text-v2--font-medium {
       line-height: ($bolt-line-height--medium + $bolt-line-height--add-loose);
     }
-    &.c-bolt-text-2--font-small {
+    &.c-bolt-text-v2--font-small {
       line-height: ($bolt-line-height--small + $bolt-line-height--add-loose);
     }
-    &.c-bolt-text-2--font-xsmall {
+    &.c-bolt-text-v2--font-xsmall {
       line-height: ($bolt-line-height--xsmall + $bolt-line-height--add-loose);
     }
   }
@@ -298,19 +298,19 @@ $bolt-text--plus-letter-spacing: 0.05rem;
   // @todo: uncomment once icon component decoupled and we can target wrapper around the icon.
   // &.has-icon:not(.has-url) {
 
-  //   &.c-bolt-text-2--icon-align-left-hang,
-  //   &.c-bolt-text-2--icon-align-right-hang {
+  //   &.c-bolt-text-v2--icon-align-left-hang,
+  //   &.c-bolt-text-v2--icon-align-right-hang {
   //     display: flex;
   //     justify-content: space-between;
   //   }
-  //   &.c-bolt-text-2--icon-align-left,
-  //   &.c-bolt-text-2--icon-align-left-hang {
+  //   &.c-bolt-text-v2--icon-align-left,
+  //   &.c-bolt-text-v2--icon-align-left-hang {
   //     bolt-icon {
   //       margin-right: 0.25rem;
   //     }
   //   }
-  //   &.c-bolt-text-2--icon-align-right,
-  //   &.c-bolt-text-2--icon-align-right-hang  {
+  //   &.c-bolt-text-v2--icon-align-right,
+  //   &.c-bolt-text-v2--icon-align-right-hang  {
   //     bolt-icon {
   //       margin-left: 0.25rem;
   //     }
@@ -318,21 +318,21 @@ $bolt-text--plus-letter-spacing: 0.05rem;
   // }
   // &.has-icon.has-url { // If we have an <a> tag we need that to be the flex parent
 
-  //   &.c-bolt-text-2--icon-align-left-hang,
-  //   &.c-bolt-text-2--icon-align-right-hang {
+  //   &.c-bolt-text-v2--icon-align-left-hang,
+  //   &.c-bolt-text-v2--icon-align-right-hang {
   //     > a {
   //       display: flex;
   //       justify-content: space-between;
   //     }
   //   }
-  //   &.c-bolt-text-2--icon-align-left,
-  //   &.c-bolt-text-2--icon-align-left-hang {
+  //   &.c-bolt-text-v2--icon-align-left,
+  //   &.c-bolt-text-v2--icon-align-left-hang {
   //     > a bolt-icon {
   //       margin-right: 0.25rem;
   //     }
   //   }
-  //   &.c-bolt-text-2--icon-align-right,
-  //   &.c-bolt-text-2--icon-align-right-hang {
+  //   &.c-bolt-text-v2--icon-align-right,
+  //   &.c-bolt-text-v2--icon-align-right-hang {
   //     > a bolt-icon {
   //       margin-left: 0.25rem;
   //     }
@@ -340,25 +340,25 @@ $bolt-text--plus-letter-spacing: 0.05rem;
   // }
 
   // &--vertical-align-top.has-icon {
-  //   &.c-bolt-text-2--font-xxxlarge bolt-icon {
+  //   &.c-bolt-text-v2--font-xxxlarge bolt-icon {
   //     margin-top: 0.06em;
   //   }
-  //   &.c-bolt-text-2--font-xxlarge bolt-icon {
+  //   &.c-bolt-text-v2--font-xxlarge bolt-icon {
   //     margin-top: 0.13em;
   //   }
-  //   &.c-bolt-text-2--font-xlarge bolt-icon {
+  //   &.c-bolt-text-v2--font-xlarge bolt-icon {
   //     margin-top: 0.15em;
   //   }
-  //   &.c-bolt-text-2--font-large bolt-icon {
+  //   &.c-bolt-text-v2--font-large bolt-icon {
   //     margin-top: 0.18em;
   //   }
-  //   &.c-bolt-text-2--font-medium bolt-icon {
+  //   &.c-bolt-text-v2--font-medium bolt-icon {
   //     margin-top: 0.3em;
   //   }
-  //   &.c-bolt-text-2--font-small bolt-icon {
+  //   &.c-bolt-text-v2--font-small bolt-icon {
   //     margin-top: 0.25em;
   //   }
-  //   &.c-bolt-text-2--font-xsmall bolt-icon {
+  //   &.c-bolt-text-v2--font-xsmall bolt-icon {
   //     margin-top: 0.15em;
   //   }
   //   bolt-icon {

--- a/packages/components/bolt-text/src/text.scss
+++ b/packages/components/bolt-text/src/text.scss
@@ -58,318 +58,316 @@ bolt-text {
 $bolt-text--minus-letter-spacing: -0.025rem;
 $bolt-text--plus-letter-spacing: 0.05rem;
 
-bolt-text {
-  .c-bolt-text {
-    margin: 0;
-    padding: 0;
+.c-bolt-text-2 {
+  margin: 0;
+  padding: 0;
 
+  a:link, a:visited {
+    color: inherit;
+    color: var(--bolt-theme-link-default,var(--bolt-theme-link,#545da6));
+    text-decoration: none;
+  }
+  a:active {
+    color: inherit;
+    color: var(--bolt-theme-link-active,var(--bolt-theme-link,#545da6));
+  }
+  a:hover, a:focus {
+    color: inherit;
+    color: var(--bolt-theme-link-hover,var(--bolt-theme-link,#545da6));
+    text-decoration: underline;
+  }
+
+  &.c-bolt-text-2--body {
     a:link, a:visited {
-      color: inherit;
-      color: var(--bolt-theme-link-default,var(--bolt-theme-link,#545da6));
-      text-decoration: none;
-    }
-    a:active {
-      color: inherit;
-      color: var(--bolt-theme-link-active,var(--bolt-theme-link,#545da6));
-    }
-    a:hover, a:focus {
-      color: inherit;
-      color: var(--bolt-theme-link-hover,var(--bolt-theme-link,#545da6));
       text-decoration: underline;
     }
+    a:hover {
+      text-decoration: none;
+    }
+  }
+}
 
-    &.c-bolt-text--body {
-      a:link, a:visited {
-        text-decoration: underline;
-      }
-      a:hover {
-        text-decoration: none;
-      }
+.c-bolt-text-2 {
+  // Font-Family
+  &--headline {
+    @include bolt-font-family('heading');
+  }
+  &--body {
+    @include bolt-font-family('body');
+  }
+  &--code {
+    @include bolt-font-family('code');
+  }
+
+  // Color
+  &--theme-headline-text-color {
+    color: inherit;
+    color: var(--bolt-theme-heading, inherit);
+  }
+  &--theme-body-text-color {
+    color: inherit;
+    color: var(--bolt-theme-body, inherit);
+  }
+  &--theme-code-text-color {
+    color: inherit;
+    color: var(--bolt-theme-code, inherit);
+  }
+
+  // Font Weight Options
+  &--weight-semibold {
+    @include bolt-font-weight(semibold);
+  }
+  &--weight-regular {
+    @include bolt-font-weight(regular);
+  }
+  &--weight-bold {
+    @include bolt-font-weight(bold);
+  }
+
+  // Font style variations
+  &--style-normal {
+    font-style: normal;
+  }
+  &--style-italic {
+    font-style: italic;
+  }
+
+  // Font size
+  &--font-xxxlarge {
+    @include bolt-font-size(xxxlarge);
+    letter-spacing: $bolt-text--minus-letter-spacing;
+
+    &.long-title {
+      font-size: $bolt-font-size--xxxlarge--min;
+    }
+  }
+  &--font-xxlarge {
+    @include bolt-font-size(xxlarge);
+    letter-spacing: $bolt-text--minus-letter-spacing;
+  }
+  &--font-xlarge {
+    @include bolt-font-size(xlarge);
+  }
+  &--font-large {
+    @include bolt-font-size(large);
+  }
+  &--font-medium {
+    @include bolt-font-size(medium);
+  }
+  &--font-small {
+    @include bolt-font-size(small);
+    letter-spacing: $bolt-text--plus-letter-spacing;
+  }
+  &--font-xsmall {
+    @include bolt-font-size(xsmall);
+    letter-spacing: $bolt-text--plus-letter-spacing;
+  }
+
+  // Display type
+  &--display-inline {
+    display: inline;
+  }
+  &--display-inline-block {
+    display: inline-block;
+  }
+  &--display-block {
+    display: block;
+  }
+
+  // Align content
+  &--align-left {
+    text-align: left;
+  }
+  &--align-center {
+    text-align: center;
+  }
+  &--align-right {
+    text-align: right;
+  }
+
+  // Transform text
+  &--transform-uppercase {
+    text-transform: uppercase;
+  }
+  &--transform-lowercase {
+    text-transform: lowercase;
+  }
+  &--transform-capitalize {
+    text-transform: capitalize;
+  }
+
+  // Letter spacing
+  &--letter-spacing-narrow {
+    letter-spacing:  $bolt-text--minus-letter-spacing;
+  }
+  &--letter-spacing-normal {
+    letter-spacing: normal;
+  }
+  &--letter-spacing-wide {
+    letter-spacing:  $bolt-text--plus-letter-spacing;
+  }
+
+  // Line height
+  $bolt-line-height--add-loose: 0.2;
+  &--line-height-tight {
+    line-height: $bolt-line-height--tight;
+  }
+  &--line-height-regular {
+    &.c-bolt-text-2--font-xxxlarge {
+      line-height: $bolt-line-height--xxxlarge;
+    }
+    &.c-bolt-text-2--font-xxlarge {
+      line-height: $bolt-line-height--xxlarge;
+    }
+    &.c-bolt-text-2--font-xlarge {
+      line-height: $bolt-line-height--xlarge;
+    }
+    &.c-bolt-text-2--font-large {
+      line-height: $bolt-line-height--large;
+    }
+    &.c-bolt-text-2--font-medium {
+      line-height: $bolt-line-height--medium;
+    }
+    &.c-bolt-text-2--font-small {
+      line-height: $bolt-line-height--small;
+    }
+    &.c-bolt-text-2--font-xsmall {
+      line-height: $bolt-line-height--xsmall;
+    }
+  }
+  &--line-height-loose {
+    &.c-bolt-text-2--font-xxxlarge {
+      line-height: ($bolt-line-height--xxxlarge + $bolt-line-height--add-loose);
+    }
+    &.c-bolt-text-2--font-xxlarge {
+      line-height: ($bolt-line-height--xxlarge + $bolt-line-height--add-loose);
+    }
+    &.c-bolt-text-2--font-xlarge {
+      line-height: ($bolt-line-height--xlarge + $bolt-line-height--add-loose);
+    }
+    &.c-bolt-text-2--font-large {
+      line-height: ($bolt-line-height--large + $bolt-line-height--add-loose);
+    }
+    &.c-bolt-text-2--font-medium {
+      line-height: ($bolt-line-height--medium + $bolt-line-height--add-loose);
+    }
+    &.c-bolt-text-2--font-small {
+      line-height: ($bolt-line-height--small + $bolt-line-height--add-loose);
+    }
+    &.c-bolt-text-2--font-xsmall {
+      line-height: ($bolt-line-height--xsmall + $bolt-line-height--add-loose);
     }
   }
 
-  .c-bolt-text {
-    // Font-Family
-    &--headline {
-      @include bolt-font-family('heading');
-    }
-    &--body {
-      @include bolt-font-family('body');
-    }
-    &--code {
-      @include bolt-font-family('code');
+  // Quoted style
+  &--quoted {
+    &:before,
+    &:after {
+      font-family: 'Georgia', serif; // TODO: Replace with Noto Serif when it is added.
     }
 
-    // Color
-    &--theme-headline-text-color {
-      color: inherit;
-      color: var(--bolt-theme-heading, inherit);
-    }
-    &--theme-body-text-color {
-      color: inherit;
-      color: var(--bolt-theme-body, inherit);
-    }
-    &--theme-code-text-color {
-      color: inherit;
-      color: var(--bolt-theme-code, inherit);
+    &:before {
+      content: '\201C';
+      transform: translate3d(-110%, 0, 0);
     }
 
-    // Font Weight Options
-    &--weight-semibold {
-      @include bolt-font-weight(semibold);
+    &:after {
+      content: '\201D';
     }
-    &--weight-regular {
-      @include bolt-font-weight(regular);
-    }
-    &--weight-bold {
-      @include bolt-font-weight(bold);
-    }
-
-    // Font style variations
-    &--style-normal {
-      font-style: normal;
-    }
-    &--style-italic {
-      font-style: italic;
-    }
-
-    // Font size
-    &--font-xxxlarge {
-      @include bolt-font-size(xxxlarge);
-      letter-spacing: $bolt-text--minus-letter-spacing;
-
-      &.long-title {
-        font-size: $bolt-font-size--xxxlarge--min;
-      }
-    }
-    &--font-xxlarge {
-      @include bolt-font-size(xxlarge);
-      letter-spacing: $bolt-text--minus-letter-spacing;
-    }
-    &--font-xlarge {
-      @include bolt-font-size(xlarge);
-    }
-    &--font-large {
-      @include bolt-font-size(large);
-    }
-    &--font-medium {
-      @include bolt-font-size(medium);
-    }
-    &--font-small {
-      @include bolt-font-size(small);
-      letter-spacing: $bolt-text--plus-letter-spacing;
-    }
-    &--font-xsmall {
-      @include bolt-font-size(xsmall);
-      letter-spacing: $bolt-text--plus-letter-spacing;
-    }
-
-    // Display type
-    &--display-inline {
-      display: inline;
-    }
-    &--display-inline-block {
-      display: inline-block;
-    }
-    &--display-block {
-      display: block;
-    }
-
-    // Align content
-    &--align-left {
-      text-align: left;
-    }
-    &--align-center {
-      text-align: center;
-    }
-    &--align-right {
-      text-align: right;
-    }
-
-    // Transform text
-    &--transform-uppercase {
-      text-transform: uppercase;
-    }
-    &--transform-lowercase {
-      text-transform: lowercase;
-    }
-    &--transform-capitalize {
-      text-transform: capitalize;
-    }
-
-    // Letter spacing
-    &--letter-spacing-narrow {
-      letter-spacing:  $bolt-text--minus-letter-spacing;
-    }
-    &--letter-spacing-normal {
-      letter-spacing: normal;
-    }
-    &--letter-spacing-wide {
-      letter-spacing:  $bolt-text--plus-letter-spacing;
-    }
-
-    // Line height
-    $bolt-line-height--add-loose: 0.2;
-    &--line-height-tight {
-      line-height: $bolt-line-height--tight;
-    }
-    &--line-height-regular {
-      &.c-bolt-text--font-xxxlarge {
-        line-height: $bolt-line-height--xxxlarge;
-      }
-      &.c-bolt-text--font-xxlarge {
-        line-height: $bolt-line-height--xxlarge;
-      }
-      &.c-bolt-text--font-xlarge {
-        line-height: $bolt-line-height--xlarge;
-      }
-      &.c-bolt-text--font-large {
-        line-height: $bolt-line-height--large;
-      }
-      &.c-bolt-text--font-medium {
-        line-height: $bolt-line-height--medium;
-      }
-      &.c-bolt-text--font-small {
-        line-height: $bolt-line-height--small;
-      }
-      &.c-bolt-text--font-xsmall {
-        line-height: $bolt-line-height--xsmall;
-      }
-    }
-    &--line-height-loose {
-      &.c-bolt-text--font-xxxlarge {
-        line-height: ($bolt-line-height--xxxlarge + $bolt-line-height--add-loose);
-      }
-      &.c-bolt-text--font-xxlarge {
-        line-height: ($bolt-line-height--xxlarge + $bolt-line-height--add-loose);
-      }
-      &.c-bolt-text--font-xlarge {
-        line-height: ($bolt-line-height--xlarge + $bolt-line-height--add-loose);
-      }
-      &.c-bolt-text--font-large {
-        line-height: ($bolt-line-height--large + $bolt-line-height--add-loose);
-      }
-      &.c-bolt-text--font-medium {
-        line-height: ($bolt-line-height--medium + $bolt-line-height--add-loose);
-      }
-      &.c-bolt-text--font-small {
-        line-height: ($bolt-line-height--small + $bolt-line-height--add-loose);
-      }
-      &.c-bolt-text--font-xsmall {
-        line-height: ($bolt-line-height--xsmall + $bolt-line-height--add-loose);
-      }
-    }
-
-    // Quoted style
-    &--quoted {
-      &:before,
-      &:after {
-        font-family: 'Georgia', serif; // TODO: Replace with Noto Serif when it is added.
-      }
-
-      &:before {
-        content: '\201C';
-        transform: translate3d(-110%, 0, 0);
-      }
-
-      &:after {
-        content: '\201D';
-      }
-    }
-
-    // Opacity
-    &--opacity-100 {
-      opacity: 1;
-    }
-    &--opacity-80 {
-      opacity: 0.8;
-    }
-    &--opacity-60 {
-      opacity: 0.6;
-    }
-    &--opacity-40 {
-      opacity: 0.4;
-    }
-    &--opacity-20 {
-      opacity: 0.2;
-    }
-
-    // Icon Alignment
-
-    // @todo: uncomment once icon component decoupled and we can target wrapper around the icon.
-    // &.has-icon:not(.has-url) {
-
-    //   &.c-bolt-text--icon-align-left-hang,
-    //   &.c-bolt-text--icon-align-right-hang {
-    //     display: flex;
-    //     justify-content: space-between;
-    //   }
-    //   &.c-bolt-text--icon-align-left,
-    //   &.c-bolt-text--icon-align-left-hang {
-    //     bolt-icon {
-    //       margin-right: 0.25rem;
-    //     }
-    //   }
-    //   &.c-bolt-text--icon-align-right,
-    //   &.c-bolt-text--icon-align-right-hang  {
-    //     bolt-icon {
-    //       margin-left: 0.25rem;
-    //     }
-    //   }
-    // }
-    // &.has-icon.has-url { // If we have an <a> tag we need that to be the flex parent
-
-    //   &.c-bolt-text--icon-align-left-hang,
-    //   &.c-bolt-text--icon-align-right-hang {
-    //     > a {
-    //       display: flex;
-    //       justify-content: space-between;
-    //     }
-    //   }
-    //   &.c-bolt-text--icon-align-left,
-    //   &.c-bolt-text--icon-align-left-hang {
-    //     > a bolt-icon {
-    //       margin-right: 0.25rem;
-    //     }
-    //   }
-    //   &.c-bolt-text--icon-align-right,
-    //   &.c-bolt-text--icon-align-right-hang {
-    //     > a bolt-icon {
-    //       margin-left: 0.25rem;
-    //     }
-    //   }
-    // }
-
-    // &--vertical-align-top.has-icon {
-    //   &.c-bolt-text--font-xxxlarge bolt-icon {
-    //     margin-top: 0.06em;
-    //   }
-    //   &.c-bolt-text--font-xxlarge bolt-icon {
-    //     margin-top: 0.13em;
-    //   }
-    //   &.c-bolt-text--font-xlarge bolt-icon {
-    //     margin-top: 0.15em;
-    //   }
-    //   &.c-bolt-text--font-large bolt-icon {
-    //     margin-top: 0.18em;
-    //   }
-    //   &.c-bolt-text--font-medium bolt-icon {
-    //     margin-top: 0.3em;
-    //   }
-    //   &.c-bolt-text--font-small bolt-icon {
-    //     margin-top: 0.25em;
-    //   }
-    //   &.c-bolt-text--font-xsmall bolt-icon {
-    //     margin-top: 0.15em;
-    //   }
-    //   bolt-icon {
-    //     vertical-align: top;
-    //   }
-    // }
-    // &--vertical-align-center.has-icon {
-    //   bolt-icon {
-    //     align-self: center;
-    //   }
-    // }
   }
+
+  // Opacity
+  &--opacity-100 {
+    opacity: 1;
+  }
+  &--opacity-80 {
+    opacity: 0.8;
+  }
+  &--opacity-60 {
+    opacity: 0.6;
+  }
+  &--opacity-40 {
+    opacity: 0.4;
+  }
+  &--opacity-20 {
+    opacity: 0.2;
+  }
+
+  // Icon Alignment
+
+  // @todo: uncomment once icon component decoupled and we can target wrapper around the icon.
+  // &.has-icon:not(.has-url) {
+
+  //   &.c-bolt-text-2--icon-align-left-hang,
+  //   &.c-bolt-text-2--icon-align-right-hang {
+  //     display: flex;
+  //     justify-content: space-between;
+  //   }
+  //   &.c-bolt-text-2--icon-align-left,
+  //   &.c-bolt-text-2--icon-align-left-hang {
+  //     bolt-icon {
+  //       margin-right: 0.25rem;
+  //     }
+  //   }
+  //   &.c-bolt-text-2--icon-align-right,
+  //   &.c-bolt-text-2--icon-align-right-hang  {
+  //     bolt-icon {
+  //       margin-left: 0.25rem;
+  //     }
+  //   }
+  // }
+  // &.has-icon.has-url { // If we have an <a> tag we need that to be the flex parent
+
+  //   &.c-bolt-text-2--icon-align-left-hang,
+  //   &.c-bolt-text-2--icon-align-right-hang {
+  //     > a {
+  //       display: flex;
+  //       justify-content: space-between;
+  //     }
+  //   }
+  //   &.c-bolt-text-2--icon-align-left,
+  //   &.c-bolt-text-2--icon-align-left-hang {
+  //     > a bolt-icon {
+  //       margin-right: 0.25rem;
+  //     }
+  //   }
+  //   &.c-bolt-text-2--icon-align-right,
+  //   &.c-bolt-text-2--icon-align-right-hang {
+  //     > a bolt-icon {
+  //       margin-left: 0.25rem;
+  //     }
+  //   }
+  // }
+
+  // &--vertical-align-top.has-icon {
+  //   &.c-bolt-text-2--font-xxxlarge bolt-icon {
+  //     margin-top: 0.06em;
+  //   }
+  //   &.c-bolt-text-2--font-xxlarge bolt-icon {
+  //     margin-top: 0.13em;
+  //   }
+  //   &.c-bolt-text-2--font-xlarge bolt-icon {
+  //     margin-top: 0.15em;
+  //   }
+  //   &.c-bolt-text-2--font-large bolt-icon {
+  //     margin-top: 0.18em;
+  //   }
+  //   &.c-bolt-text-2--font-medium bolt-icon {
+  //     margin-top: 0.3em;
+  //   }
+  //   &.c-bolt-text-2--font-small bolt-icon {
+  //     margin-top: 0.25em;
+  //   }
+  //   &.c-bolt-text-2--font-xsmall bolt-icon {
+  //     margin-top: 0.15em;
+  //   }
+  //   bolt-icon {
+  //     vertical-align: top;
+  //   }
+  // }
+  // &--vertical-align-center.has-icon {
+  //   bolt-icon {
+  //     align-self: center;
+  //   }
+  // }
 }

--- a/packages/components/bolt-text/src/text.standalone.js
+++ b/packages/components/bolt-text/src/text.standalone.js
@@ -174,23 +174,23 @@ class BoltText extends BoltComponent() {
       // iconName ? 'has-icon' : '', // @todo: remove when decoupled from icon component
       url ? 'has-url' : '',
       longTitle ? 'long-title' : '',
-      'c-bolt-text',
-      `c-bolt-text--${fontFamily}`,
-      `c-bolt-text--theme-${fontFamily}-text-color`,
-      `c-bolt-text--weight-${weight}`,
-      `c-bolt-text--style-${style}`,
-      `c-bolt-text--font-${fontSize}`,
-      `c-bolt-text--display-${display}`,
-      letterSpacing ? `c-bolt-text--letter-spacing-${letterSpacing}` : '',
-      align ? `c-bolt-text--align-${align}` : '',
-      transform ? `c-bolt-text--transform-${transform}` : '',
-      lineHeight ? `c-bolt-text--line-height-${lineHeight}` : '',
-      quoted ? 'c-bolt-text--quoted' : '',
-      opacity ? `c-bolt-text--opacity-${opacity}` : '',
+      'c-bolt-text-v2',
+      `c-bolt-text-v2--${fontFamily}`,
+      `c-bolt-text-v2--theme-${fontFamily}-text-color`,
+      `c-bolt-text-v2--weight-${weight}`,
+      `c-bolt-text-v2--style-${style}`,
+      `c-bolt-text-v2--font-${fontSize}`,
+      `c-bolt-text-v2--display-${display}`,
+      letterSpacing ? `c-bolt-text-v2--letter-spacing-${letterSpacing}` : '',
+      align ? `c-bolt-text-v2--align-${align}` : '',
+      transform ? `c-bolt-text-v2--transform-${transform}` : '',
+      lineHeight ? `c-bolt-text-v2--line-height-${lineHeight}` : '',
+      quoted ? 'c-bolt-text-v2--quoted' : '',
+      opacity ? `c-bolt-text-v2--opacity-${opacity}` : '',
 
       // @todo: remove once decoupled from icon component
-      // iconValign ? `c-bolt-text--vertical-align-${iconValign}` : '',
-      // iconAlign ? `c-bolt-text--icon-align-${iconAlign}` : '',
+      // iconValign ? `c-bolt-text-v2--vertical-align-${iconValign}` : '',
+      // iconAlign ? `c-bolt-text-v2--icon-align-${iconAlign}` : '',
     );
 
     // Adds out utilities to the outer parent <bolt-text />


### PR DESCRIPTION
Updates the new (unreleased) bolt-text component on master to use a unique class name instead of being scoped to the custom element selector.

Fixes styling regression when putting together the v1.5.0 release.