### PR TITLE
fix: Remove navlink focus state when clicking anchor links (BDS-412)

### DIFF
--- a/packages/components/bolt-navlink/navlink.js
+++ b/packages/components/bolt-navlink/navlink.js
@@ -48,6 +48,10 @@ class BoltNavLink extends BoltComponent() {
     // prevent browser default if we're smooth scrolling to a navlink. this ensures a smoother, less jumpy animation in browsers (like Safari)
     if (this._shadowLink.getAttribute('href').indexOf('#') !== -1){
       event.preventDefault();
+
+      // Don't add the :focus state to the link in this scenario.  The focus state is about to get removed anyway as
+      // we move down the page, and a flash of the focused state just adds confusion.
+      document.activeElement.blur();
     }
 
     // manually add smooth scroll to dropdown links since these are added to the page AFTER smooth scroll event bindings would hae been added.


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-412

## Testing instructions
- View the [content hub demo page in this PR](https://fix-bds-412-remove-navbar-focus-state-for-anchor-links.bolt-design-system.com/pattern-lab/patterns/04-pages-90-content-hub-anchor-ribbon-example/04-pages-90-content-hub-anchor-ribbon-example.html#transformation)
- Confirm that the bug described in http://vjira2:8080/browse/BDS-412 is resolved.