### PR TITLE
Fix: remove margin on inline list's last item

### DIFF
--- a/packages/global/styles/05-objects/objects-inline-list/_objects-inline-list.scss
+++ b/packages/global/styles/05-objects/objects-inline-list/_objects-inline-list.scss
@@ -82,7 +82,7 @@ bolt-inline-list {
     }
   }
 
-  > .o-bolt-inline-list__item {
+  > .o-bolt-inline-list__item:not(:last-child) {
     margin-right: bolt-spacing(xsmall);
 
     &:after {
@@ -102,7 +102,7 @@ bolt-inline-list {
     }
   }
 
-  > .o-bolt-inline-list__item {
+  > .o-bolt-inline-list__item:not(:last-child) {
     margin-right: bolt-spacing(small);
 
     &:after {
@@ -123,7 +123,7 @@ bolt-inline-list {
     }
   }
 
-  > .o-bolt-inline-list__item {
+  > .o-bolt-inline-list__item:not(:last-child) {
     margin-right: bolt-spacing(medium);
   }
 


### PR DESCRIPTION
The last child is not supposed to have any spacing, this is consistent in all other lists.