### PR TITLE
Fix Twig-Embedded Dropdown Menu Server-side Rendering / Progressive Enhancement

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/30-dropdown-custom-element-demo-collection.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/30-dropdown-custom-element-demo-collection.twig
@@ -125,19 +125,19 @@
       "items": [
         include("@bolt-components-link/link.twig", {
           "text": "Link 1 Text",
-          "url": "#link-1-url"
+          "url": "#"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 2 Text",
-          "url": "#link-2-url"
+          "url": "#"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 3 Text",
-          "url": "#link-3-url"
+          "url": "#"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 4 Text",
-          "url": "#link-4-url"
+          "url": "#"
         }),
       ]
     } %}
@@ -153,19 +153,35 @@
     "items": [
       include("@bolt-components-link/link.twig", {
         "text": "Link 1 Text",
-        "url": "#link-1-url"
+        "url": "#"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 2 Text",
-        "url": "#link-2-url"
+        "url": "#"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 3 Text",
-        "url": "#link-3-url"
+        "url": "#"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 4 Text",
-        "url": "#link-4-url"
+        "url": "#"
+      }),
+      include("@bolt-components-link/link.twig", {
+        "text": "Link 5 Text",
+        "url": "#"
+      }),
+      include("@bolt-components-link/link.twig", {
+        "text": "Link 6 Text",
+        "url": "#"
+      }),
+      include("@bolt-components-link/link.twig", {
+        "text": "Link 7 Text",
+        "url": "#"
+      }),
+      include("@bolt-components-link/link.twig", {
+        "text": "Link 8 Text",
+        "url": "#"
       }),
     ]
   } %}

--- a/packages/components/bolt-dropdown/_dropdown-item.twig
+++ b/packages/components/bolt-dropdown/_dropdown-item.twig
@@ -23,7 +23,9 @@
 
     <div class="c-bolt-dropdown__content">
       <div class="c-bolt-dropdown__content-inner">
-        {{ ( _content ? _content : content) | raw }}
+        {% block content %}
+          {{ ( _content ? _content : content) | raw }}
+        {% endblock %}
       </div>
     </div>
   </div>

--- a/packages/components/bolt-dropdown/dropdown.twig
+++ b/packages/components/bolt-dropdown/dropdown.twig
@@ -11,15 +11,13 @@
   {% if title %}title='{{ title }}' {% endif %}
   {% if children %}children='{{ children|json_encode() }}' {% endif %}
   >
-  {% block content %}
-    {% if items %}
-      {% for item in items %}
-        {% include "@bolt-components-dropdown/_dropdown-item.twig" with item only %}
-      {% endfor %}
-    {% endif %}
+  {% if items %}
+    {% for item in items %}
+      {% include "@bolt-components-dropdown/_dropdown-item.twig" with item only %}
+    {% endfor %}
+  {% endif %}
 
-    {% if _content is not empty %}
-      {% include "@bolt-components-dropdown/_dropdown-item.twig" %}
-    {% endif %}
-  {% endblock %}
+  {% if _content is not empty %}
+    {% include "@bolt-components-dropdown/_dropdown-item.twig" %}
+  {% endif %}
 </bolt-dropdown>


### PR DESCRIPTION
I spent a lot of time getting our Dropdown component to be fully server-side rendered and mouse + keyboard accessible via Twig prior to our web component's JavaScript kicks in (which, for reference, further enhances this component with cleaner animations + even better accessibility).

This PR fixes a small but fatal issue with how the original code we shipped handles content composition when using Twig embeds.

## Current Twig-included Dropdown Menu on Master** 😢

![bolt-dropdown-menu--without-twig-ssr](https://user-images.githubusercontent.com/1617209/41466149-04d9e2e8-706f-11e8-883a-5b1a9b7482ca.gif)

<br>

## Twig-included Dropdown Menu with this fix:

**With & Without JS**
![bolt-dropdown-menu--with-twig-ssr](https://user-images.githubusercontent.com/1617209/41466284-a0964244-706f-11e8-851d-9a4c891dcd3a.gif)


For reference, the actual 
**Source Code (before Web Component JS kicks in):**
![bolt-dropdown-menu--no-javascript](https://user-images.githubusercontent.com/1617209/41466416-29372528-7070-11e8-8d23-37365a98ac10.png)

**Source Code (with Web Component JS kicked in):**
![bolt-dropdown-menu--with-javascript](https://user-images.githubusercontent.com/1617209/41466463-5e3b5a64-7070-11e8-9347-c76457281834.png)

CC @theSadowski 