### PR TITLE
Fix/bds 426 fix nav dropdown in mobile safari

### DIFF
--- a/packages/components/bolt-nav-priority/nav-priority.scss
+++ b/packages/components/bolt-nav-priority/nav-priority.scss
@@ -13,7 +13,7 @@ bolt-nav-priority {
   flex-shrink: 2; // shrink faster than other components in tight spots
   flex-grow: 0.5; // grow if space is available, but at 1/2 as much as normal
 
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       &.is-ready {
         display: contents;
@@ -31,7 +31,7 @@ bolt-nav-priority {
 }
 
 .c-bolt-nav-priority {
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       &.is-ready {
         display: contents;
@@ -122,7 +122,7 @@ bolt-nav-priority {
 }
 
 .c-bolt-nav-priority__primary {
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       .is-ready & {
         display: contents;
@@ -149,7 +149,7 @@ bolt-nav-priority {
 
 
 
-@supports (display: contents) {
+@include bolt-if-browser-supports-display-contents {
    .c-bolt-nav-priority__show-more {
      @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
        display: contents;
@@ -227,7 +227,7 @@ bolt-nav-priority {
 
 
 
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       grid-row: 2/span 1;
       grid-column: 1/span 6;
@@ -364,7 +364,7 @@ bolt-nav-priority {
     }
   }
 
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       .is-ready & {
         grid-row: 1/span 1;

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -33,7 +33,7 @@ bolt-navbar {
     padding-top: var(--bolt-vspacing, $bolt-navbar-vspacing-small);
   }
 
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       @include bolt-padding-top(0);
     }
@@ -63,7 +63,7 @@ bolt-navbar {
     }
   }
 
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       @include bolt-padding-left(0);
       @include bolt-padding-right(0);
@@ -135,7 +135,7 @@ bolt-navbar {
     @include bolt-margin-right(auto);
   }
 
-  @supports (display: contents) {
+  @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {
       @include bolt-padding-top($bolt-navbar-vspacing-small);
       grid-column: 2/span 1;

--- a/packages/core/styles/02-tools/tools-browser-support/_tools-browser-support.scss
+++ b/packages/core/styles/02-tools/tools-browser-support/_tools-browser-support.scss
@@ -1,0 +1,17 @@
+/* ------------------------------------ *\
+Browser Support
+\* ------------------------------------ */
+
+// This file contains mixins needed for checking browser support.
+
+
+// Just checking "@supports (display: contents)" isn't enough to know that a browser supports it FULLY.  So, we check
+// support for both "display: contents" and "caret-color" (which has similar browser support) -- if a browser fails
+// either check, it gets the cross-browser fallback instead.
+//
+// See https://www.meltajon.com/dev/how-to-use-supports-display-contents-feature-query-in-safari
+@mixin bolt-if-browser-supports-display-contents {
+  @supports (display: contents) and (caret-color: red) {
+    @content;
+  }
+}


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-426.

I'm not sure I put the mixin in the best place, nor named it the right thing (I initially didn't have the `bolt-` prefix, but linting told me to add it).  Suggestions on either are welcome.