### PR TITLE
Restore headerOffset to navbar.

### DIFF
--- a/packages/components/bolt-nav-priority/nav-priority.twig
+++ b/packages/components/bolt-nav-priority/nav-priority.twig
@@ -4,7 +4,9 @@
 
 <bolt-nav-priority more-text="{{ moreText | default("More") }}" {{ attributes }}>
   <nav class="c-bolt-nav-priority">
-    <bolt-nav-indicator>
+    <bolt-nav-indicator
+      {% if offset %} offset="{{ offset }}" {% endif %}
+    >
       <ul class="c-bolt-nav-priority__list c-bolt-nav-priority__primary">
         {% for item in links %}
           <li class="c-bolt-nav-priority__item">


### PR DESCRIPTION
In Drupal, we use headerOffset to manage the gumshoe offset (for more information, see [this comment](https://github.com/bolt-design-system/bolt/pull/714#issuecomment-392167450)). This PR restores that functionality in Bolt.