### PR TITLE
Add indicator to active item on page load

### DIFF
--- a/packages/components/bolt-nav-indicator/nav-indicator.js
+++ b/packages/components/bolt-nav-indicator/nav-indicator.js
@@ -84,55 +84,60 @@ let gumshoeStateModule = (function () {
             return;
           }
 
-          // if this there's a <bolt-nav-priority> instance, make sure that component's ready to go before proceeding trying to animate anything.
+          // logic once we know we should try to animate in a gumshoe-activated link
+          function activateGumshoeLink(waitedToAnimate = false) {
 
-          // @todo: iterate on a more refined solution so we animate in ASAP
+            const originalTarget = nav.nav;
+            let originalTargetHref;
+            let normalizedTarget;
+
+            if (originalTarget) {
+              originalTargetHref = originalTarget.getAttribute('href');
+            } else {
+              originalTargetHref = nav.nav.getAttribute('href');
+            }
+
+            // Need to target via document vs this custom element reference since only one gumshoe instance is shared across every component instance to better optimize for performance
+            const matchedTargetLinks = document.querySelectorAll(`bolt-navlink > [href*="${originalTargetHref}"]`);
+
+            for (var i = 0, len = matchedTargetLinks.length; i < len; i++) {
+              const linkInstance = matchedTargetLinks[i];
+
+              // Stop if normalizedTarget already set.
+              if (normalizedTarget) {
+                break;
+              }
+
+              // Prefer visible links over hidden links
+              if (isVisible(linkInstance)) {
+                normalizedTarget = linkInstance;
+
+                // Prefer dropdown links over non-dropdown links if the link is hidden
+              } else if (linkInstance.parentNode.isDropdownLink) {
+                normalizedTarget = linkInstance;
+
+                // otherwise default to what was originally selected.
+              } else if (i === len - 1) {
+                normalizedTarget = originalTarget;
+              }
+            }
+
+            const normalizedParent = normalizedTarget.parentNode;
+
+            normalizedParent.activate();
+          }
+
+          // if this there's a <bolt-nav-priority> instance, make sure that component's ready to go before proceeding trying to animate anything.
           if (nav.nav.closest('bolt-nav-priority')){
             const priorityNav = nav.nav.closest('bolt-nav-priority');
-
             if (!priorityNav.isReady){
-              return;
+              document.addEventListener('nav-priority:ready', activateGumshoeLink(true));
+            } else {
+              activateGumshoeLink();
             }
-          }
-
-          const originalTarget = nav.nav;
-          let originalTargetHref;
-          let normalizedTarget;
-
-          if (originalTarget) {
-            originalTargetHref = originalTarget.getAttribute('href');
           } else {
-            originalTargetHref = nav.nav.getAttribute('href');
+            activateGumshoeLink();
           }
-
-          // Need to target via document vs this custom element reference since only one gumshoe instance is shared across every component instance to better optimize for performance
-          const matchedTargetLinks = document.querySelectorAll(`bolt-navlink > [href*="${originalTargetHref}"]`);
-
-          for (var i = 0, len = matchedTargetLinks.length; i < len; i++) {
-            const linkInstance = matchedTargetLinks[i];
-
-            // Stop if normalizedTarget already set.
-            if (normalizedTarget) {
-              break;
-            }
-
-            // Prefer visible links over hidden links
-            if (isVisible(linkInstance)) {
-              normalizedTarget = linkInstance;
-
-            // Prefer dropdown links over non-dropdown links if the link is hidden
-            } else if (linkInstance.parentNode.isDropdownLink) {
-              normalizedTarget = linkInstance;
-
-            // otherwise default to what was originally selected.
-            } else if (i === len - 1) {
-              normalizedTarget = originalTarget;
-            }
-          }
-
-          const normalizedParent = normalizedTarget.parentNode;
-
-          normalizedParent.activate();
         },
       });
     }

--- a/packages/components/bolt-nav-priority/nav-priority.js
+++ b/packages/components/bolt-nav-priority/nav-priority.js
@@ -205,6 +205,15 @@ export class BoltNavPriority extends BoltComponent() {
       this.setAttribute('is-ready', '');
       this.classList.add('is-ready');
 
+      this.dispatchEvent(
+        new CustomEvent('nav-priority:ready', {
+          detail: {
+            isReady: true,
+          },
+          bubbles: true,
+        }),
+      );
+
       // make sure containerTabs exists first
       if (this.containerTabs) {
         this.containerTabs.classList.add('is-ready');


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-380

- add a custom event to the nav-priority component to let others know when the component is ready to go (like the nav-indicator)
- update nav indicator logic to listen for this even before trying to animate if the nav-priority is a nested component AND isn't yet ready to go