### PR TITLE
hotfix: remove flex-grow from `<bolt-nav-priority>` updates

### DIFF
--- a/packages/components/bolt-nav-priority/nav-priority.scss
+++ b/packages/components/bolt-nav-priority/nav-priority.scss
@@ -11,7 +11,6 @@ bolt-nav-priority {
   align-self: center;
   padding-bottom: var(--bolt-vspacing);
   flex-shrink: 2; // shrink faster than other components in tight spots
-  flex-grow: 0.5; // grow if space is available, but at 1/2 as much as normal
 
   @include bolt-if-browser-supports-display-contents {
     @media screen and (max-width: #{bolt-breakpoint(xsmall)}) {


### PR DESCRIPTION
I noticed in further testing the latest code released yesterday that in fixing one particular item with the new Navbar / Nav Priority updates on Friday, we inadvertently partially broke the center alignment of the priority nav (when stacked in the Navbar). This PR addresses that.

Broken:
![image](https://user-images.githubusercontent.com/1617209/41598751-280a166a-739f-11e8-88fe-c0a2f4381b67.png)

Fixed:
![image](https://user-images.githubusercontent.com/1617209/41598755-2e021d60-739f-11e8-87d7-c675bddb2ffa.png)

CC @remydenton @theSadowski @charginghawk 