### PR TITLE
Fix: word wrap and word break settings

### DIFF
--- a/packages/components/bolt-code-snippet/src/code-snippet-syntax.scss
+++ b/packages/components/bolt-code-snippet/src/code-snippet-syntax.scss
@@ -7,18 +7,7 @@
  */
 code[class*="language-"],
 pre[class*="language-"] {
-  white-space: -moz-pre-wrap;
-  white-space: -o-pre-wrap;
-  white-space: pre-wrap;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: break-word;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
   tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
   hyphens: none;
 }
 

--- a/packages/components/bolt-code-snippet/src/code-snippet.scss
+++ b/packages/components/bolt-code-snippet/src/code-snippet.scss
@@ -20,6 +20,12 @@ bolt-code-snippet {
 
 .c-bolt-code-snippet,
 .c-bolt-code-snippet__code {
+  white-space: -moz-pre-wrap;
+  white-space: -o-pre-wrap;
+  white-space: pre-wrap;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: break-word;
   color: inherit;
   color: $bolt-code-snippet-text-color;
   text-align: left;

--- a/packages/global/styles/04-elements/_elements-code.scss
+++ b/packages/global/styles/04-elements/_elements-code.scss
@@ -9,6 +9,12 @@ $bolt-code-background-color: rgba(bolt-color(indigo, light), 0.08);
 
 pre,
 code {
+  white-space: -moz-pre-wrap;
+  white-space: -o-pre-wrap;
+  white-space: pre-wrap;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: break-word;
   color: inherit;
   color: $bolt-code-text-color;
   text-align: left;


### PR DESCRIPTION
This fixes the long `pre` and `code` tags breaking the doc page layout.