### PR TITLE
[WIP Do Not Merge] Remove conditional css from headlines

### DIFF
--- a/apps/pattern-lab/src/_includes/utils/docs.twig
+++ b/apps/pattern-lab/src/_includes/utils/docs.twig
@@ -10,11 +10,13 @@
 
 <div class="c-bolt-docs t-bolt-xlight">
   <div class="c-bolt-docs__page-content">
-    {% include "@bolt/headline.twig" with {
-      size: "xxxlarge",
-      tag: "h1",
-      text: schema.title ? schema.title : "Component Title"
-    } only %}
+    <div class="u-bolt-margin-bottom-large">
+      {% include "@bolt/headline.twig" with {
+        size: "xxxlarge",
+        tag: "h1",
+        text: schema.title ? schema.title : "Component Title"
+      } only %}
+    </div>
 
     {% if readmeFile %}
       <div class="c-bolt-docs__readme">
@@ -26,7 +28,6 @@
           icon: "none",
           attributes: {
             class: [
-              "u-bolt-margin-bottom-xsmall",
               "c-bolt-docs__heading-fragment"
             ],
             id: "getting-started"
@@ -47,7 +48,6 @@
         icon: "none",
         attributes: {
           class: [
-            "u-bolt-margin-bottom-xsmall",
             "c-bolt-docs__heading-fragment"
           ],
           id: "usage"
@@ -72,7 +72,6 @@
         icon: "none",
         attributes: {
           class: [
-            "u-bolt-margin-bottom-xsmall",
             "c-bolt-docs__heading-fragment"
           ],
           id: "schema"
@@ -93,7 +92,6 @@
         icon: "none",
         attributes: {
           class: [
-            "u-bolt-margin-bottom-xsmall",
             "c-bolt-docs__heading-fragment"
           ],
           id: "schema"

--- a/packages/components/bolt-headline/src/headline.scss
+++ b/packages/components/bolt-headline/src/headline.scss
@@ -20,12 +20,24 @@ $bolt-headline--plus-letter-spacing: 0.05rem;
   @include bolt-headline;
 }
 
+
+// Text stack spacing
+.c-bolt-headline,
+.c-bolt-eyebrow {
+  @include bolt-margin-bottom(xxsmall);
+}
+
+.c-bolt-subheadline {
+  @include bolt-margin-bottom(xsmall);
+}
+
+.c-bolt-text {
+  @include bolt-margin-bottom(medium);
+}
+
+
+// Default headline size
 .c-bolt-headline {
-
-  &:not(:last-child) {
-    @include bolt-margin-bottom(medium);
-  }
-
   &:not([class*='c-bolt-headline--']) {
     @include bolt-font-size(large);
   }
@@ -55,7 +67,6 @@ $bolt-headline--plus-letter-spacing: 0.05rem;
 
 
 .c-bolt-eyebrow {
-  @include bolt-margin-bottom(0.1rem);
   @include bolt-font-size(xsmall);
   text-transform: uppercase;
   letter-spacing: $bolt-headline--plus-letter-spacing;
@@ -87,36 +98,12 @@ $bolt-headline--plus-letter-spacing: 0.05rem;
 
 // Subheadline styles.
 .c-bolt-subheadline {
-  @include bolt-margin-bottom(medium);
   @include bolt-font-family(heading);
   @include bolt-font-weight(regular);
 
   &:not([class*='c-bolt-subheadline--']) {
     @include bolt-font-size(large);
   }
-}
-
-
-// Headline spacing with other elements.
-.c-bolt-headline:not(.c-bolt-headline--xxxlarge) + .c-bolt-headline,
-.c-bolt-headline:not(.c-bolt-headline--xxxlarge) + .c-bolt-subheadline,
-.c-bolt-headline:not(.c-bolt-headline--xxxlarge) + .c-bolt-text,
-.c-bolt-headline:not(.c-bolt-headline--xxxlarge) + bolt-inline-list,
-.c-bolt-headline:not(.c-bolt-headline--xxxlarge) + p:not([class]) {
-  margin-top: (-1 * bolt-v-spacing(medium)) + bolt-v-spacing(xsmall);
-}
-
-.c-bolt-headline--xxxlarge + .c-bolt-headline,
-.c-bolt-headline--xxxlarge + .c-bolt-subheadline,
-.c-bolt-headline--xxxlarge + .c-bolt-text,
-.c-bolt-headline--xxxlarge + bolt-inline-list,
-.c-bolt-headline--xxxlarge + p:not([class]) {
-  margin-top: (-1 * bolt-v-spacing(medium)) + bolt-v-spacing(small);
-}
-
-.c-bolt-subheadline + .c-bolt-text,
-.c-bolt-subheadline + p:not([class]) {
-  margin-top: (-1 * bolt-v-spacing(medium)) + bolt-v-spacing(xsmall);
 }
 
 


### PR DESCRIPTION
This removes conditional spacing on headlines which caused a lot of issues. Setting the specific spacing regardless of what comes after a headline would be more predictable.

With this change, we do need to make a lot of changes to where headline is followed by anything but regular text. We can also remove a lot of utility classes that aren't necessary.

@theSadowski 