### PR TITLE
Make smooth scroll offset dynamic.

### DIFF
--- a/packages/components/bolt-nav-indicator/nav-indicator.schema.yml
+++ b/packages/components/bolt-nav-indicator/nav-indicator.schema.yml
@@ -1,0 +1,7 @@
+$schema: http://json-schema.org/draft-04/schema#
+title: Nav Indicator
+type: object
+properties:
+  offset:
+    type: integer
+    description: Number of pixels taken up by sticky items at the top of the page.  Used for smooth scroll and gumshoe.

--- a/packages/components/bolt-nav-indicator/package.json
+++ b/packages/components/bolt-nav-indicator/package.json
@@ -26,6 +26,7 @@
   "repository": "https://github.com/bolt-design-system/bolt/tree/master/packages/components/bolt-navbar",
   "bugs": "https://github.com/bolt-design-system/bolt/issues",
   "style": "nav-indicator.scss",
+  "schema": "nav-indicator.schema.yml",
   "main": "index.js",
   "publishConfig": {
     "access": "public"

--- a/packages/components/bolt-nav-priority/nav-priority.schema.yml
+++ b/packages/components/bolt-nav-priority/nav-priority.schema.yml
@@ -16,3 +16,6 @@ properties:
     type: string
     description: Button text that displays when the Priority+ Nav Dropdown is displayed
     default: 'More'
+  offset:
+    type: integer
+    description: (Inherited from nav-indicator) Number of pixels taken up by sticky items at the top of the page.  Used for smooth scroll and gumshoe.

--- a/packages/components/bolt-nav-priority/nav-priority.schema.yml
+++ b/packages/components/bolt-nav-priority/nav-priority.schema.yml
@@ -4,9 +4,9 @@ type: object
 properties:
   links:
     type: array
+    description: Array of Priority Nav links.
     items:
       type: object
-      description: Array of Priority Nav links.
       properties:
         text:
           type: string

--- a/packages/components/bolt-nav-priority/nav-priority.twig
+++ b/packages/components/bolt-nav-priority/nav-priority.twig
@@ -2,7 +2,7 @@
   {{ validate_data_schema(bolt.data.components['@bolt-components-nav-priority'].schema, _self) | raw }}
 {% endif %}
 
-<bolt-nav-priority more-text="{{ moreText | default("More") }}" {{ attributes }}>
+<bolt-nav-priority more-text="{{ moreText | default("More"|t) }}" {{ attributes }}>
   <nav class="c-bolt-nav-priority">
     <bolt-nav-indicator
       {% if offset %} offset="{{ offset }}" {% endif %}

--- a/packages/components/bolt-navbar/navbar.schema.yml
+++ b/packages/components/bolt-navbar/navbar.schema.yml
@@ -49,9 +49,9 @@ properties:
       - false
   links:
     type: array
+    description: (Inherited from nav-priority) Array of links
     items:
       type: object
-      description: (Inherited from nav-priority) Array of links
       properties:
         text:
           type: string

--- a/packages/components/bolt-navbar/navbar.schema.yml
+++ b/packages/components/bolt-navbar/navbar.schema.yml
@@ -41,19 +41,26 @@ properties:
           name:
             type: string
             description: Name of the (optional) icon to be used.
-  links:
-    type: array
-    items:
-      type: object
-      description: Navbar links (passed along to the nested Nav Priority that ships with Navbar by default.
-      properties:
-        text:
-          type: string
-        url:
-          type: string
   center:
     type: boolean
     description: Determines if you want the Navbar content to be center aligned or not
     enum:
       - true
       - false
+  links:
+    type: array
+    items:
+      type: object
+      description: (Inherited from nav-priority) Array of links
+      properties:
+        text:
+          type: string
+        url:
+          type: string
+  moreText:
+    type: string
+    description: (Inherited from nav-priority) Button text that displays when the Priority+ Nav Dropdown is displayed.
+    default: 'More'
+  offset:
+    type: integer
+    description: (Inherited from nav-indicator) Number of pixels taken up by sticky items at the top of the page.  Used for smooth scroll and gumshoe.

--- a/packages/components/bolt-navlink/navlink.js
+++ b/packages/components/bolt-navlink/navlink.js
@@ -14,7 +14,7 @@ import isVisible from 'is-visible';
 // Used for attaching smooth scroll behavior to dynamically created <bolt-navlink> instances
 import {
   smoothScroll,
-  defaultScrollOptions,
+  scrollOptions,
   getScrollTarget,
 } from '@bolt/components-smooth-scroll';
 
@@ -68,7 +68,7 @@ class BoltNavLink extends BoltComponent() {
     if (!this.props.active && this.props.isDropdownLink && shouldSmoothScroll !== false) {
       const scrollTarget = getScrollTarget(this._shadowLink);
       if (scrollTarget) {
-        smoothScroll.animateScroll(scrollTarget, this._shadowLink, defaultScrollOptions);
+        smoothScroll.animateScroll(scrollTarget, this._shadowLink, scrollOptions);
       }
     }
 

--- a/packages/components/bolt-smooth-scroll/src/smooth-scroll.js
+++ b/packages/components/bolt-smooth-scroll/src/smooth-scroll.js
@@ -3,14 +3,27 @@ import { isValidSelector } from '@bolt/core';
 
 export const smoothScroll = new SmoothScroll();
 
-export const defaultScrollOptions = {
+export const scrollOptions = {
   ignore: '[data-scroll-ignore]', // Selector for links to ignore (must be a valid CSS selector)
   header: '.js-bolt-smooth-scroll-offset', // Selector for fixed headers (must be a valid CSS selector)
 
   // Speed & Easing
   speed: 750, // Integer. How fast to complete the scroll in milliseconds
-  offset: 45, // Integer or Function returning an integer. How far to offset the scrolling anchor location in pixels
   easing: 'easeInOutCubic', // Easing pattern to use
+
+  // Here we have support for modifying scroll offset. It looks for the link's
+  // first ancestor that has an 'offset' attribute, returning that value. You'll
+  // find offset on the nav-indicator, where gumshoejs also gets its offset.
+  // @see nav-indicator.js
+  offset(anchor, toggle) {
+    var offsetElement = toggle.closest('[offset]');
+    if (offsetElement) {
+      return offsetElement.getAttribute('offset');
+    }
+    else {
+      return 0;
+    }
+  },
 
   // Callback API
   updateURL: true, // Update the URL on scroll
@@ -46,14 +59,6 @@ for (var i = 0, len = filteredCustomScrollElems.length; i < len; i++) {
 
   // only smooth scroll if hashed href matches with id on the page.
   if (matchedScrollTarget.length !== 0){
-    // In the future, we could add support for links to modify options like scrollOffset, scrollOffset, etc.  However,
-    // we should provide options carefully-- only enable these after considering whether the use case that requires them
-    // is justified.
-    //
-    const scrollOptions = Object.assign({}, defaultScrollOptions, {
-      offset: scrollElem.dataset.scrollOffset ? scrollElem.dataset.scrollOffset : defaultScrollOptions.offset,
-    });
-
     const scrollTarget = getScrollTarget(scrollElem);
 
     if (scrollTarget) {


### PR DESCRIPTION
Adds support for modifying scroll offset. It looks for the link's first ancestor that has an 'offset' attribute, returning that value. You'll find offset on the nav-indicator, where gumshoejs also gets its offset.