### PR TITLE
BDS-435 hash bang demo urls

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/00-action-blocks-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/00-action-blocks-docs.twig
@@ -3,7 +3,7 @@
   contentItems: [
     {
       text: "Item 1",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "icon-name",
         size: "large",
@@ -12,7 +12,7 @@
     },
     {
       text: "Item 2",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "icon-name",
         size: "large",
@@ -21,7 +21,7 @@
     },
     {
       text: "Item 3",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "icon-name",
         size: "large",

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/05-action-blocks.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/05-action-blocks.twig
@@ -2,7 +2,7 @@
   contentItems: [
     {
       text: "Item 1",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "download",
         size: "large",
@@ -11,7 +11,7 @@
     },
     {
       text: "Item 2",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "copy-to-clipboard",
         size: "large",
@@ -20,7 +20,7 @@
     },
     {
       text: "Item 3",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "calendar",
         size: "large",

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/10-action-blocks-align-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/10-action-blocks-align-variation.twig
@@ -8,7 +8,7 @@
     contentItems: [
       {
         text: "Item 1, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus dignissim non dui vel elementum. Cras id lorem tincidunt turpis mollis pretium. ",
-        url: "http://google.com",
+        url: "#!",
         icon: {
           name: "download",
           size: "large",
@@ -17,7 +17,7 @@
       },
       {
         text: "Item 2",
-        url: "http://google.com",
+        url: "#!",
         icon: {
           name: "copy-to-clipboard",
           size: "large",
@@ -26,7 +26,7 @@
       },
       {
         text: "Item 3",
-        url: "http://google.com",
+        url: "#!",
         icon: {
           name: "calendar",
           size: "large",
@@ -35,7 +35,7 @@
       },
       {
         text: "Item 4",
-        url: "http://google.com",
+        url: "#!",
         icon: {
         name: "copy-to-clipboard",
         size: "large",

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/10-action-blocks-border-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/10-action-blocks-border-variation.twig
@@ -15,7 +15,7 @@
       },
       {
         text: "Item 2",
-        url: "http://google.com",
+        url: "#!",
         icon: {
           name: "copy-to-clipboard",
           size: "large",
@@ -24,7 +24,7 @@
       },
       {
         text: "Item 3",
-        url: "http://google.com",
+        url: "#!",
         icon: {
           name: "calendar",
           size: "large",

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/15-action-blocks-max-items-per-row-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/15-action-blocks-max-items-per-row-variation.twig
@@ -8,7 +8,7 @@
       contentItems: [
         {
           text: "Item 1, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus dignissim non dui vel elementum. Cras id lorem tincidunt turpis mollis pretium. ",
-          url: "http://google.com",
+          url: "#!",
           icon: {
             name: "download",
             size: "large",
@@ -17,7 +17,7 @@
         },
         {
           text: "Item 2",
-          url: "http://google.com",
+          url: "#!",
           icon: {
             name: "copy-to-clipboard",
             size: "large",
@@ -26,7 +26,7 @@
         },
         {
           text: "Item 3",
-          url: "http://google.com",
+          url: "#!",
           icon: {
             name: "calendar",
             size: "large",
@@ -35,7 +35,7 @@
         },
         {
           text: "Item 4",
-          url: "http://google.com",
+          url: "#!",
           icon: {
           name: "copy-to-clipboard",
           size: "large",
@@ -44,7 +44,7 @@
         },
         {
           text: "Item 5, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus dignissim non dui vel elementum. Cras id lorem tincidunt turpis mollis pretium. ",
-          url: "http://google.com",
+          url: "#!",
           icon: {
           name: "download",
           size: "large",
@@ -53,7 +53,7 @@
         },
         {
           text: "Item 5",
-          url: "http://google.com",
+          url: "#!",
           icon: {
           name: "copy-to-clipboard",
           size: "large",

--- a/apps/pattern-lab/src/_patterns/02-components/action-blocks/20-action-blocks-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/action-blocks/20-action-blocks-theme-variation.twig
@@ -9,7 +9,7 @@
         contentItems: [
           {
             text: "Item 1, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus dignissim non dui vel elementum. Cras id lorem tincidunt turpis mollis pretium. ",
-            url: "http://google.com",
+            url: "#!",
             icon: {
               name: "download",
               size: "large",
@@ -18,7 +18,7 @@
           },
           {
             text: "Item 2",
-            url: "http://google.com",
+            url: "#!",
             icon: {
               name: "copy-to-clipboard",
               size: "large",
@@ -27,7 +27,7 @@
           },
           {
             text: "Item 3",
-            url: "http://google.com",
+            url: "#!",
             icon: {
               name: "calendar",
               size: "large",
@@ -36,7 +36,7 @@
           },
           {
             text: "Item 4",
-            url: "http://google.com",
+            url: "#!",
             icon: {
             name: "copy-to-clipboard",
             size: "large",

--- a/apps/pattern-lab/src/_patterns/02-components/band/30-band-collection-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/band/30-band-collection-variation.twig
@@ -55,7 +55,7 @@
           {
             text: "Learn More About Pega 7",
             style: "secondary",
-            url: "www.google.com/pega7"
+            url: "#!"
           }
         ]
       }
@@ -139,7 +139,7 @@
             {
               text: "Learn More About Pega 7",
               style: "secondary",
-              url: "www.google.com/pega7"
+              url: "#!"
             }
           ]
         }
@@ -167,7 +167,7 @@
             {
               text: "Learn More About Pega 7",
               style: "secondary",
-              url: "www.google.com/pega7"
+              url: "#!"
             }
           ]
         }

--- a/apps/pattern-lab/src/_patterns/02-components/block-list/00-block-list-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/block-list/00-block-list-docs.twig
@@ -3,7 +3,7 @@
   items: [
     include("@bolt-components-link/link.twig", {
       text: "Link 1",
-      url: "#",
+      url: "#!",
       icon: {
         name: "chevron-right",
         position: "before"
@@ -11,7 +11,7 @@
     }),
     include("@bolt-components-link/link.twig", {
       text: "Link 2",
-      url: "#",
+      url: "#!",
       icon: {
         name: "chevron-right",
         position: "before"
@@ -19,7 +19,7 @@
     }),
     include("@bolt-components-link/link.twig", {
       text: "Link 3",
-      url: "#",
+      url: "#!",
       icon: {
         name: "chevron-right",
         position: "before"

--- a/apps/pattern-lab/src/_patterns/02-components/block-list/05-block-list.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/block-list/05-block-list.twig
@@ -2,7 +2,7 @@
   "items" : [
     include("@bolt-components-link/link.twig", {
       text: "Link 1",
-      url: "#",
+      url: "#!",
       icon: {
         name: "chevron-right",
         position: "before"
@@ -10,7 +10,7 @@
     }),
     include("@bolt-components-link/link.twig", {
       text: "Link 2",
-      url: "#",
+      url: "#!",
       icon: {
         name: "chevron-right",
         position: "before"
@@ -18,7 +18,7 @@
     }),
     include("@bolt-components-link/link.twig", {
       text: "Link 3",
-      url: "#",
+      url: "#!",
       icon: {
         name: "chevron-right",
         position: "before"

--- a/apps/pattern-lab/src/_patterns/02-components/block-list/10-block-list-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/block-list/10-block-list-theme-variation.twig
@@ -6,7 +6,7 @@
         "items" : [
           include("@bolt-components-link/link.twig", {
             text: "Link 1",
-            url: "#",
+            url: "#!",
             icon: {
               name: "chevron-right",
               position: "before"
@@ -14,7 +14,7 @@
           }),
           include("@bolt-components-link/link.twig", {
             text: "Link 2",
-            url: "#",
+            url: "#!",
             icon: {
               name: "chevron-right",
               position: "before"
@@ -22,7 +22,7 @@
           }),
           include("@bolt-components-link/link.twig", {
             text: "Link 3",
-            url: "#",
+            url: "#!",
             icon: {
               name: "chevron-right",
               position: "before"

--- a/apps/pattern-lab/src/_patterns/02-components/breadcrumb/05-breadcrumb.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/breadcrumb/05-breadcrumb.twig
@@ -2,15 +2,15 @@
   "contentItems": [
     include("@bolt-components-link/link.twig", {
       "text": "Home",
-      "url": "#"
+      "url": "#!"
     }),
     include("@bolt-components-link/link.twig", {
       "text": "Landing Page",
-      "url": "#"
+      "url": "#!"
     }),
     include("@bolt-components-link/link.twig", {
       "text": "Sub Page",
-      "url": "#"
+      "url": "#!"
     }),
     "Current Page"
   ]

--- a/apps/pattern-lab/src/_patterns/02-components/breadcrumb/10-breadcrumb-current-page-aria-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/breadcrumb/10-breadcrumb-current-page-aria-variation.twig
@@ -2,19 +2,19 @@
   "contentItems": [
     include("@bolt-components-link/link.twig", {
       "text": "Home",
-      "url": "#"
+      "url": "#!"
     }),
     include("@bolt-components-link/link.twig", {
       "text": "Landing Page",
-      "url": "#"
+      "url": "#!"
     }),
     include("@bolt-components-link/link.twig", {
       "text": "Sub Page",
-      "url": "#"
+      "url": "#!"
     }),
     include("@bolt-components-link/link.twig", {
       "text": "Current Page",
-      "url": "#",
+      "url": "#!",
       "attributes": {
         "aria-current": "page"
       },

--- a/apps/pattern-lab/src/_patterns/02-components/card/00-card-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/00-card-docs.twig
@@ -1,6 +1,6 @@
 {% set usage %}{% verbatim %}
 {% include "@bolt-components-card/card.twig" with {
-  url: "javascript:",
+  url: "#!",
   contentItems: [
     {
       pattern: "image",

--- a/apps/pattern-lab/src/_patterns/02-components/card/05-card.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/05-card.twig
@@ -1,5 +1,5 @@
 {% include "@bolt-components-card/card.twig" with {
-  url: "javascript:",
+  url: "#!",
   contentItems: [
     {
       pattern: "image",

--- a/apps/pattern-lab/src/_patterns/02-components/card/15-card-with-teaser.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/15-card-with-teaser.twig
@@ -1,5 +1,5 @@
 {% include "@bolt-components-card/card.twig" with {
-  url: "javascript:",
+  url: "#!",
   contentItems: [
     {
       pattern: "image",

--- a/apps/pattern-lab/src/_patterns/02-components/card/20-card-with-video.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/20-card-with-video.twig
@@ -2,7 +2,7 @@
 
 <div style="max-width: 500px; padding: 2rem;">
   {% include "@bolt-components-card/card.twig" with {
-    "url": "javascript:",
+    "url": "#!",
     "contentItems": [
       {
         "pattern": "video",

--- a/apps/pattern-lab/src/_patterns/02-components/chip/00-chip-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/chip/00-chip-docs.twig
@@ -1,7 +1,7 @@
 {% set usage %}{% verbatim %}
 {% include "@bolt-components-chip/chip.twig" with {
   text: "This is a chip",
-  url: "http://google.com",
+  url: "#!",
 } only %}
 {% endverbatim %}{% endset %}
 

--- a/apps/pattern-lab/src/_patterns/02-components/chip/05-chip.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/chip/05-chip.twig
@@ -1,4 +1,4 @@
 {% include "@bolt-components-chip/chip.twig" with {
   "text": "This is a chip",
-  "url": "javascript:"
+  "url": "#!"
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/chips-list/00-chip-list-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/chips-list/00-chip-list-docs.twig
@@ -3,15 +3,15 @@
   contentItems: [
     {
       text: "Chip 1",
-      url: "http://google.com"
+      url: "#!"
     },
     {
       text: "Chip 2",
-      url: "http://google.com"
+      url: "#!"
     },
     {
       text: "Chip 3",
-      url: "http://google.com"
+      url: "#!"
     }
   ]
 } only %}

--- a/apps/pattern-lab/src/_patterns/02-components/chips-list/05-chip-list.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/chips-list/05-chip-list.twig
@@ -2,19 +2,19 @@
   "contentItems": [
     {
       text: "Do not include any data or information in your posts that are confidential!",
-      url: "javascript:"
+      url: "#!"
     },
     {
       text: "Apply basic practices for collaborative work.",
-      url: "javascript:"
+      url: "#!"
     },
     {
       text: "Be honest, respectful, trustworthy and helpful.",
-      url: "javascript:"
+      url: "#!"
     },
     {
       text: "Answer questions authoritatively and concisely. Avoid cluttering discussions with noise.",
-      url: "javascript:"
+      url: "#!"
     }
   ]
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/-30-dropdown-sticky.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/-30-dropdown-sticky.twig
@@ -12,67 +12,67 @@
           "links": [
             {
               "text": "Link 1 Text",
-              "url": "#link-1-url"
+              "url": "#!"
             },
             {
               "text": "Link 2 Text",
-              "url": "#link-2-url"
+              "url": "#!"
             },
             {
               "text": "Link 3 Text",
-              "url": "#link-3-url"
+              "url": "#!"
             },
             {
               "text": "Link 4 Text",
-              "url": "#link-4-url"
+              "url": "#!"
             },
             {
               "text": "Link 5 Text",
-              "url": "#link-5-url"
+              "url": "#!"
             },
             {
               "text": "Link 6 Text",
-              "url": "#link-6-url"
+              "url": "#!"
             },
             {
               "text": "Link 7 Text",
-              "url": "#link-7-url"
+              "url": "#!"
             },
             {
               "text": "Link 8 Text",
-              "url": "#link-8-url"
+              "url": "#!"
             },
             {
               "text": "Link 9 Text",
-              "url": "#link-9-url"
+              "url": "#!"
             },
             {
               "text": "Link 10 Text",
-              "url": "#link-10-url"
+              "url": "#!"
             },
             {
               "text": "Link 11 Text",
-              "url": "#link-12-url"
+              "url": "#!"
             },
             {
               "text": "Link 13 Text",
-              "url": "#link-13-url"
+              "url": "#!"
             },
             {
               "text": "Link 14 Text",
-              "url": "#link-14-url"
+              "url": "#!"
             },
             {
               "text": "Link 15 Text",
-              "url": "#link-15-url"
+              "url": "#!"
             },
             {
               "text": "Link 16 Text",
-              "url": "#link-16-url"
+              "url": "#!"
             },
             {
               "text": "Link 17 Text",
-              "url": "#link-17-url"
+              "url": "#!"
             }
           ]
         } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/00-dropdown-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/00-dropdown-docs.twig
@@ -9,15 +9,15 @@
       links: [
         {
         text: "Link 1 Text",
-        url: "#link-1-url"
+        url": "#!"
       },
       {
         text: "Link 2 Text",
-        url: "#link-2-url"
+        url": "#!"
       },
       {
         text: "Link 3 Text",
-        url: "#link-3-url"
+        url": "#!"
       }
       ]
     } %}
@@ -32,15 +32,15 @@
     links: [
       {
         text: "Link 1 Text",
-        url: "#link-1-url"
+        url": "#!"
       },
       {
         text: "Link 2 Text",
-        url: "#link-2-url"
+        url": "#!"
       },
       {
         text: "Link 3 Text",
-        url: "#link-3-url"
+        url": "#!"
       }
     ]
   } only %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/05-dropdown.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/05-dropdown.twig
@@ -6,19 +6,19 @@
       "items": [
         include("@bolt-components-link/link.twig", {
           "text": "Link 1 Text",
-          "url": "#link-1-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 2 Text",
-          "url": "#link-2-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 3 Text",
-          "url": "#link-3-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 4 Text",
-          "url": "#link-4-url"
+          "url": "#!"
         }),
       ]
     } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/10-dropdown-center.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/10-dropdown-center.twig
@@ -7,19 +7,19 @@
       "items": [
         include("@bolt-components-link/link.twig", {
           "text": "Link 1 Text",
-          "url": "#link-1-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 2 Text",
-          "url": "#link-2-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 3 Text",
-          "url": "#link-3-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 4 Text",
-          "url": "#link-4-url"
+          "url": "#!"
         }),
       ]
     } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/15-dropdown-collapse.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/15-dropdown-collapse.twig
@@ -7,19 +7,19 @@
       "items": [
         include("@bolt-components-link/link.twig", {
           "text": "Link 1 Text",
-          "url": "#link-1-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 2 Text",
-          "url": "#link-2-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 3 Text",
-          "url": "#link-3-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 4 Text",
-          "url": "#link-4-url"
+          "url": "#!"
         }),
       ]
     } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/16-dropdown-collapse-center.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/16-dropdown-collapse-center.twig
@@ -8,35 +8,35 @@
       "items": [
         include("@bolt-components-link/link.twig", {
           "text": "Link 1 Text",
-          "url": "#link-1-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 2 Text",
-          "url": "#link-2-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 3 Text",
-          "url": "#link-3-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 4 Text",
-          "url": "#link-4-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 5 Text",
-          "url": "#link-5-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 6 Text",
-          "url": "#link-6-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 7 Text",
-          "url": "#link-7-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 8 Text",
-          "url": "#link-8-url"
+          "url": "#!"
         }),
       ]
     } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/20-dropdown-theme-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/20-dropdown-theme-variations.twig
@@ -17,19 +17,19 @@
           "items": [
             include("@bolt-components-link/link.twig", {
               "text": "Link 1 Text",
-              "url": "#link-1-url"
+              "url": "#!"
             }),
             include("@bolt-components-link/link.twig", {
               "text": "Link 2 Text",
-              "url": "#link-2-url"
+              "url": "#!"
             }),
             include("@bolt-components-link/link.twig", {
               "text": "Link 3 Text",
-              "url": "#link-3-url"
+              "url": "#!"
             }),
             include("@bolt-components-link/link.twig", {
               "text": "Link 4 Text",
-              "url": "#link-4-url"
+              "url": "#!"
             }),
           ]
         } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/25-dropdown-long-header.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/25-dropdown-long-header.twig
@@ -7,35 +7,35 @@
       "items": [
         include("@bolt-components-link/link.twig", {
           "text": "Link 1 Text",
-          "url": "#link-1-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 2 Text",
-          "url": "#link-2-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 3 Text",
-          "url": "#link-3-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 4 Text",
-          "url": "#link-4-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 5 Text",
-          "url": "#link-5-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 6 Text",
-          "url": "#link-6-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 7 Text",
-          "url": "#link-7-url"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 8 Text",
-          "url": "#link-8-url"
+          "url": "#!"
         }),
       ]
     } %}

--- a/apps/pattern-lab/src/_patterns/02-components/dropdown/30-dropdown-custom-element-demo-collection.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/dropdown/30-dropdown-custom-element-demo-collection.twig
@@ -14,19 +14,19 @@
     "items": [
       include("@bolt-components-link/link.twig", {
         "text": "Link 1 Text",
-        "url": "#link-1-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 2 Text",
-        "url": "#link-2-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 3 Text",
-        "url": "#link-3-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 4 Text",
-        "url": "#link-4-url"
+        "url": "#!"
       }),
     ]
   } %}
@@ -41,19 +41,19 @@
     "items": [
       include("@bolt-components-link/link.twig", {
         "text": "Link 1 Text",
-        "url": "#link-1-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 2 Text",
-        "url": "#link-2-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 3 Text",
-        "url": "#link-3-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 4 Text",
-        "url": "#link-4-url"
+        "url": "#!"
       }),
     ]
   } %}
@@ -68,19 +68,19 @@
     "items": [
       include("@bolt-components-link/link.twig", {
         "text": "Link 1 Text",
-        "url": "#link-1-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 2 Text",
-        "url": "#link-2-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 3 Text",
-        "url": "#link-3-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 4 Text",
-        "url": "#link-4-url"
+        "url": "#!"
       }),
     ]
   } %}
@@ -96,19 +96,19 @@
     "items": [
       include("@bolt-components-link/link.twig", {
         "text": "Link 1 Text",
-        "url": "#link-1-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 2 Text",
-        "url": "#link-2-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 3 Text",
-        "url": "#link-3-url"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 4 Text",
-        "url": "#link-4-url"
+        "url": "#!"
       }),
     ]
   } %}
@@ -125,19 +125,19 @@
       "items": [
         include("@bolt-components-link/link.twig", {
           "text": "Link 1 Text",
-          "url": "#"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 2 Text",
-          "url": "#"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 3 Text",
-          "url": "#"
+          "url": "#!"
         }),
         include("@bolt-components-link/link.twig", {
           "text": "Link 4 Text",
-          "url": "#"
+          "url": "#!"
         }),
       ]
     } %}
@@ -153,35 +153,35 @@
     "items": [
       include("@bolt-components-link/link.twig", {
         "text": "Link 1 Text",
-        "url": "#"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 2 Text",
-        "url": "#"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 3 Text",
-        "url": "#"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 4 Text",
-        "url": "#"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 5 Text",
-        "url": "#"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 6 Text",
-        "url": "#"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 7 Text",
-        "url": "#"
+        "url": "#!"
       }),
       include("@bolt-components-link/link.twig", {
         "text": "Link 8 Text",
-        "url": "#"
+        "url": "#!"
       }),
     ]
   } %}

--- a/apps/pattern-lab/src/_patterns/02-components/form/00-form-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/form/00-form-docs.twig
@@ -1,7 +1,7 @@
 {% set usage %}{% verbatim %}
 {% include "@bolt-components-form/form.twig" with {
   text: "This is a form",
-  url: "http://google.com",
+  url: "#!",
 } only %}
 {% endverbatim %}{% endset %}
 

--- a/apps/pattern-lab/src/_patterns/02-components/headline/30-headline-link-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/headline/30-headline-link-variations.twig
@@ -1,16 +1,16 @@
 {% include "@bolt-components-headline/headline.twig" with {
   text: "This headline is a link, with Default Icon",
-  url: "https://www.google.com"
+  url: "#!"
 } only %}
 
 {% include "@bolt-components-headline/headline.twig" with {
   text: "This headline is also a link, with Defined Icon",
-  url: "https://www.google.com",
+  url: "#!",
   icon: "search"
 } only %}
 
 {% include "@bolt-components-headline/headline.twig" with {
   text: "This headline is also a link, without an Icon",
-  url: "https://www.google.com",
+  url: "#!",
   icon: "none"
 } only %}

--- a/apps/pattern-lab/src/_patterns/02-components/link/00-link-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/link/00-link-docs.twig
@@ -1,7 +1,7 @@
 {% set usage %}{% verbatim %}
 {% include "@bolt-components-link/link.twig" with {
   text: "This is a link",
-  url: "http://google.com"
+  url: "#!"
 } only %}
 {% endverbatim %}{% endset %}
 

--- a/apps/pattern-lab/src/_patterns/02-components/link/05-link.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/link/05-link.twig
@@ -1,4 +1,4 @@
 {% include "@bolt-components-link/link.twig" with {
   text: "This is a text link",
-  url: "http://google.com",
+  url: "#!",
 } only %}

--- a/apps/pattern-lab/src/_patterns/02-components/link/10-link-icon-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/link/10-link-icon-variation.twig
@@ -2,7 +2,7 @@
 <p>
   {% include "@bolt-components-link/link.twig" with {
     text: "Like This",
-    url: "http://google.com",
+    url: "#!",
     icon: {
       name: "info-open",
     },
@@ -12,7 +12,7 @@
 <p>
   {% include "@bolt-components-link/link.twig" with {
     text: "Like This",
-    url: "http://google.com",
+    url: "#!",
     icon: {
       name: "info-open",
       position: "before"

--- a/apps/pattern-lab/src/_patterns/02-components/link/15-link-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/link/15-link-theme-variation.twig
@@ -1,11 +1,11 @@
 {% set link %}
   {% include "@bolt-components-headline/headline.twig" with {
     text: "Headline Link with Default Icon",
-    url: "javascript:"
+    url: "#!"
   } only %}
   {% include "@bolt-components-link/link.twig" with {
     text: "Text link",
-    url: "javascript:"
+    url: "#!"
   } only %}
 {% endset %}
 

--- a/apps/pattern-lab/src/_patterns/02-components/nav-priority/00-nav-priority.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/nav-priority/00-nav-priority.twig
@@ -2,27 +2,27 @@
   "links": [
     {
       "text": "Real-Time AI",
-      "url": "link-1-url"
+      "url": "#!"
     },
     {
       "text": "End-to-end Automation",
-      "url": "link-2-url"
+      "url": "#!"
     },
     {
       "text": "Journey-centric Delivery",
-      "url": "link-3-url"
+      "url": "#!"
     },
     {
       "text": "Low Code",
-      "url": "link-1-url"
+      "url": "#!"
     },
     {
       "text": "Multi-dimensional Power",
-      "url": "link-2-url"
+      "url": "#!"
     },
     {
       "text": "Cloud Choice",
-      "url": "link-3-url"
+      "url": "#!"
     }
   ]
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/00-navbar-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/00-navbar-docs.twig
@@ -10,15 +10,15 @@
   links: [
     {
       text: "Link 1 Text",
-      url: "link-1-url"
+      url": "#!"
     },
     {
       text: "Link 2 Text",
-      url: "link-2-url"
+      url": "#!"
     },
     {
       text: "Link 3 Text",
-      url: "link-3-url"
+      url": "#!"
     }
   ]
 } only %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/05-navbar--centered.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/05-navbar--centered.twig
@@ -10,27 +10,27 @@
   links: [
     {
       "text": "Real-Time AI",
-      "url": "link-1-url"
+      "url": "#!"
     },
     {
       "text": "End-to-end Automation",
-      "url": "link-2-url"
+      "url": "#!"
     },
     {
       "text": "Journey-centric Delivery",
-      "url": "link-3-url"
+      "url": "#!"
     },
     {
       "text": "Low Code",
-      "url": "link-1-url"
+      "url": "#!"
     },
     {
       "text": "Multi-dimensional Power",
-      "url": "link-2-url"
+      "url": "#!"
     },
     {
       "text": "Cloud Choice",
-      "url": "link-3-url"
+      "url": "#!"
     }
   ]
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/05-navbar-short.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/05-navbar-short.twig
@@ -9,19 +9,19 @@
   "links": [
     {
       "text": "Features",
-      "url": "link-1-url"
+      "url": "#!"
     },
     {
       "text": "Resources",
-      "url": "link-2-url"
+      "url": "#!"
     },
     {
       "text": "Industry Apps",
-      "url": "link-3-url"
+      "url": "#!"
     },
     {
       "text": "Customer Success",
-      "url": "link-1-url"
+      "url": "#!"
     }
   ]
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/05-navbar.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/05-navbar.twig
@@ -9,27 +9,27 @@
   "links": [
     {
       "text": "Real-Time AI",
-      "url": "link-1-url"
+      "url": "#!"
     },
     {
       "text": "End-to-end Automation",
-      "url": "link-2-url"
+      "url": "#!"
     },
     {
       "text": "Journey-centric Delivery",
-      "url": "link-3-url"
+      "url": "#!"
     },
     {
       "text": "Low Code",
-      "url": "link-1-url"
+      "url": "#!"
     },
     {
       "text": "Multi-dimensional Power Long Title",
-      "url": "link-2-url"
+      "url": "#!"
     },
     {
       "text": "Cloud Choice",
-      "url": "link-3-url"
+      "url": "#!"
     }
   ]
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/10-navbar-theme-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/10-navbar-theme-variation.twig
@@ -21,15 +21,15 @@
       "links": [
         {
           "text": "Link 1 Text",
-          "url": "javascript:"
+          "url": "#!"
         },
         {
           "text": "Link 2 Text",
-          "url": "javascript:"
+          "url": "#!"
         },
         {
           "text": "Link 3 Text",
-          "url": "javascript:"
+          "url": "#!"
         }
       ]
     } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/25-navbar-linked-title.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/25-navbar-linked-title.twig
@@ -10,20 +10,20 @@
     "icon": {
       "name": "marketing-gray"
     },
-    "url": "https://www.google.com"
+    "url": "#!"
   },
   "links": [
     {
       "text": "Link 1 Text",
-      "url": "javascript:"
+      "url": "#!"
     },
     {
       "text": "Link 2 Text",
-      "url": "javascript:"
+      "url": "#!"
     },
     {
       "text": "Link 3 Text",
-      "url": "javascript:"
+      "url": "#!"
     }
   ]
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/30-navbar-transparent.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/30-navbar-transparent.twig
@@ -11,20 +11,20 @@
     "icon": {
       "name": "marketing-gray"
     },
-    "url": "https://www.google.com"
+    "url": "#!"
   },
   "links": [
     {
       "text": "Link 1 Text",
-      "url": "javascript:"
+      "url": "#!"
     },
     {
       "text": "Link 2 Text",
-      "url": "javascript:"
+      "url": "#!"
     },
     {
       "text": "Link 3 Text",
-      "url": "javascript:"
+      "url": "#!"
     }
   ]
 } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/_15-navbar-gradient-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/_15-navbar-gradient-variation.twig
@@ -22,15 +22,15 @@
       "links": [
         {
           "text": "Link 1 Text",
-          "url": "javascript:"
+          "url": "#!"
         },
         {
           "text": "Link 2 Text",
-          "url": "javascript:"
+          "url": "#!"
         },
         {
           "text": "Link 3 Text",
-          "url": "javascript:"
+          "url": "#!"
         }
       ]
     } %}

--- a/apps/pattern-lab/src/_patterns/02-components/navbar/_20-navbar-vspacing-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/_20-navbar-vspacing-variation.twig
@@ -21,15 +21,15 @@
       "links": [
         {
           "text": "Link 1 Text",
-          "url": "javascript:"
+          "url": "#!"
         },
         {
           "text": "Link 2 Text",
-          "url": "javascript:"
+          "url": "#!"
         },
         {
           "text": "Link 3 Text",
-          "url": "javascript:"
+          "url": "#!"
         }
       ]
     } only %}

--- a/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-00-homepage.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-00-homepage.twig
@@ -98,7 +98,7 @@
         {
           text: "Get Real",
           style: "primary",
-          url: "https://www.google.com",
+          url: "#!",
           icon: {
             name: "chevron-right"
           }
@@ -317,21 +317,21 @@
   "contentItems": [
     {
       text: "Product Information",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "product"
       }
     },
     {
       text: "Industry Solutions",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "industries"
       }
     },
     {
       text: "Training and Certification",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "training",
         background: "circle"
@@ -339,7 +339,7 @@
     },
     {
       text: "Vision and Technology",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "vision",
         background: "circle"
@@ -347,7 +347,7 @@
     },
     {
       text: "Services and Partners",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "partners",
         background: "square"
@@ -355,7 +355,7 @@
     },
     {
       text: "Career Opportunities",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "careers",
         background: "square"

--- a/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-01-homepage-w-background-video.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/10-homepage/-01-homepage-w-background-video.twig
@@ -98,7 +98,7 @@
         {
           text: "Get Real",
           style: "primary",
-          url: "https://www.google.com",
+          url: "#!",
           icon: {
             name: "chevron-right"
           }
@@ -413,21 +413,21 @@
   "contentItems": [
     {
       text: "Product Information",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "product"
       }
     },
     {
       text: "Industry Solutions",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "industries"
       }
     },
     {
       text: "Training and Certification",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "training",
         background: "circle"
@@ -435,7 +435,7 @@
     },
     {
       text: "Vision and Technology",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "vision",
         background: "circle"
@@ -443,7 +443,7 @@
     },
     {
       text: "Services and Partners",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "partners",
         background: "square"
@@ -451,7 +451,7 @@
     },
     {
       text: "Career Opportunities",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "careers",
         background: "square"

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-landing-page.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-landing-page.twig
@@ -55,7 +55,7 @@
         {
           text: "Call to Action",
           style: "primary",
-          url: "https://www.google.com"
+          url: "#!"
         }
       ]
     }
@@ -92,7 +92,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "app-development",
@@ -125,7 +125,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "sales-automation",
@@ -158,7 +158,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "customer-service",

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t2-page.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t2-page.twig
@@ -48,7 +48,7 @@
         {
           text: "Call to Action",
           style: "primary",
-          url: "https://www.google.com"
+          url: "#!"
         }
       ]
     }
@@ -94,7 +94,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "app-development",
@@ -123,7 +123,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "sales-automation",
@@ -151,7 +151,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "customer-service",

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3-extra-videos.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3-extra-videos.twig
@@ -47,7 +47,7 @@
         {
           text: "Call to Action",
           style: "primary",
-          url: "https://www.google.com"
+          url: "#!"
         }
       ]
     }
@@ -98,7 +98,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "app-development",
@@ -127,7 +127,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "sales-automation",
@@ -155,7 +155,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "customer-service",

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3.twig
@@ -47,7 +47,7 @@
         {
           text: "Call to Action",
           style: "primary",
-          url: "https://www.google.com"
+          url: "#!"
         }
       ]
     }
@@ -99,7 +99,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "app-development",
@@ -128,7 +128,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "sales-automation",
@@ -156,7 +156,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "customer-service",

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t4.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t4.twig
@@ -47,7 +47,7 @@
         {
           text: "Call to Action",
           style: "primary",
-          url: "https://www.google.com"
+          url: "#!"
         }
       ]
     }
@@ -98,7 +98,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "app-development",
@@ -127,7 +127,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "sales-automation",
@@ -155,7 +155,7 @@
                 {
                   pattern: "flag",
                   valign: "middle",
-                  url: "https://www.google.com",
+                  url: "#!",
                   figure: {
                     "icon": {
                       name: "customer-service",

--- a/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-full-page-theming/_full-page-theming.twig
@@ -93,17 +93,17 @@
         {
           text: "Sign Up",
           style: "primary",
-          url: "https://www.google.com"
+          url: "#!"
         },
         {
           text: "Learn More",
           style: "secondary",
-          url: "https://www.google.com"
+          url: "#!"
         },
         {
           text: "Read More",
           style: "text",
-          url: "https://www.google.com",
+          url: "#!",
           icon: {
             name: "chevron-right"
           }

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-05-d8-homepage.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-05-d8-homepage.twig
@@ -97,7 +97,7 @@
         {
           text: "Get Real",
           style: "primary",
-          url: "https://www.google.com",
+          url: "#!",
           icon: {
             name: "chevron-right"
           }
@@ -318,21 +318,21 @@
   "contentItems": [
     {
       text: "Product Information",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "product"
       }
     },
     {
       text: "Industry Solutions",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "industries"
       }
     },
     {
       text: "Training and Certification",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "training",
         background: "circle"
@@ -340,7 +340,7 @@
     },
     {
       text: "Vision and Technology",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "vision",
         background: "circle"
@@ -348,7 +348,7 @@
     },
     {
       text: "Services and Partners",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "partners",
         background: "square"
@@ -356,7 +356,7 @@
     },
     {
       text: "Career Opportunities",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "careers",
         background: "square"

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-10-d8-homepage-alt.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-10-d8-homepage-alt.twig
@@ -77,7 +77,7 @@
         {
           text: "Call to action",
           style: "primary",
-          url: "https://www.google.com"
+          url: "#!"
         }
       ]
     },

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
@@ -97,7 +97,7 @@
         {
           text: "Get Real",
           style: "primary",
-          url: "https://www.google.com",
+          url: "#!",
           icon: {
             name: "chevron-right"
           }
@@ -490,21 +490,21 @@
   "contentItems": [
     {
       text: "Product Information",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "product"
       }
     },
     {
       text: "Industry Solutions",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "industries"
       }
     },
     {
       text: "Training and Certification",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "training",
         background: "circle"
@@ -512,7 +512,7 @@
     },
     {
       text: "Vision and Technology",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "vision",
         background: "circle"
@@ -520,7 +520,7 @@
     },
     {
       text: "Services and Partners",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "partners",
         background: "square"
@@ -528,7 +528,7 @@
     },
     {
       text: "Career Opportunities",
-      url: "http://google.com",
+      url: "#!",
       icon: {
         name: "careers",
         background: "square"

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-20-d8-homepage-video-test.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-20-d8-homepage-video-test.twig
@@ -116,7 +116,7 @@
         {
           text: "Get Real",
           style: "primary",
-          url: "https://www.google.com",
+          url: "#!",
           icon: {
             name: "chevron-right"
           }

--- a/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail.twig
@@ -26,7 +26,7 @@
         text: "2018 Agenda",
         size: "small",
         tag: "span",
-        url: "#",
+        url: "#!",
         icon: {
           name: "arrow-left",
           position: "before"
@@ -308,7 +308,7 @@
             text: "What Aflac is learning about consumer expectations through monitoring tech disruptions",
             size: "large",
             tag: "h3",
-            url: "#"
+            url: "#!"
           } only %}
         {% endcell %}
 
@@ -321,7 +321,7 @@
             text: "Leverage Mobile and Collaboration to Increase Revenue and Decrease Order-to-Cash Cycle Time",
             size: "large",
             tag: "h3",
-            url: "#"
+            url: "#!"
           } only %}
         {% endcell %}
 
@@ -334,7 +334,7 @@
             text: "PayPal Delivers World Class Customer Service, Worldwide",
             size: "large",
             tag: "h3",
-            url: "#"
+            url: "#!"
           } only %}
         {% endcell %}
 
@@ -407,19 +407,19 @@
           {% set socialIcons = [
             {
               name: "twitter",
-              url: "#"
+              url: "#!"
             },
             {
               name: "facebook-solid",
-              url: "#"
+              url: "#!"
             },
             {
               name: "linkedin-solid",
-              url: "#"
+              url: "#!"
             },
             {
               name: "youtube-solid",
-              url: "#"
+              url: "#!"
             }
           ] %}
 

--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/event-detail.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/event-detail.twig
@@ -42,7 +42,7 @@
               text: "January 25, 2018",
               size: "large",
               tag: "span",
-              url: "#",
+              url: "#!",
               icon: {
                 name: "calendar",
                 position: "before",
@@ -55,7 +55,7 @@
               text: "10:00 AM EST",
               size: "large",
               tag: "span",
-              url: "#",
+              url: "#!",
               icon: {
                 name: "watch",
                 position: "before",
@@ -68,7 +68,7 @@
               text: "New York, NY",
               size: "large",
               tag: "span",
-              url: "#",
+              url: "#!",
               icon: {
                 name: "map-pin",
                 position: "before",
@@ -375,7 +375,7 @@
             <p>Executive Director, My Company</p>
             {% include "@bolt-components-link/link.twig" with {
               text: "Show more",
-              url: "#",
+              url: "#!",
             } only %}
 
             {% include "@pl/_event-annotation.twig" with {
@@ -404,7 +404,7 @@
             <p>Executive Director, My Company</p>
             {% include "@bolt-components-link/link.twig" with {
               text: "Show more",
-              url: "#",
+              url: "#!",
             } only %}
           {% endcell %}
         {% endgrid %}
@@ -426,7 +426,7 @@
             <p>Executive Director, My Company</p>
             {% include "@bolt-components-link/link.twig" with {
               text: "Show more",
-              url: "#",
+              url: "#!",
             } only %}
           {% endcell %}
         {% endgrid %}
@@ -448,7 +448,7 @@
             <p>Executive Director, My Company</p>
             {% include "@bolt-components-link/link.twig" with {
               text: "Show more",
-              url: "#",
+              url: "#!",
             } only %}
           {% endcell %}
         {% endgrid %}
@@ -470,7 +470,7 @@
             <p>Executive Director, My Company</p>
             {% include "@bolt-components-link/link.twig" with {
               text: "Show more",
-              url: "#",
+              url: "#!",
             } only %}
           {% endcell %}
         {% endgrid %}
@@ -492,7 +492,7 @@
             <p>Executive Director, My Company</p>
             {% include "@bolt-components-link/link.twig" with {
               text: "Show more",
-              url: "#",
+              url: "#!",
             } only %}
           {% endcell %}
         {% endgrid %}

--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/event-landing.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/event-landing.twig
@@ -70,7 +70,7 @@
               {% grid "o-bolt-grid--flex o-bolt-grid--matrix" %}
                 {% cell "u-bolt-width-1/1 u-bolt-width-1/2@medium" %}
                   {% embed "@bolt-components-card/card.twig" with {
-                    url: "#",
+                    url: "#!",
                     contentItems: [
                       {
                         pattern: "button",
@@ -104,7 +104,7 @@
                 {% cell "u-bolt-width-1/1 u-bolt-width-1/2@medium" %}
 
                   {% embed "@bolt-components-card/card.twig" with {
-                    url: "#",
+                    url: "#!",
                     contentItems: [
                       {
                         pattern: "button",

--- a/apps/pattern-lab/src/_patterns/04-pages/90-content-hub/anchor-ribbon-example.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/90-content-hub/anchor-ribbon-example.twig
@@ -134,7 +134,7 @@
       
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@medium" %}
             {% include "@bolt-components-card/card.twig" with {
-              url: "javascript:",
+              url: "#!",
               contentItems: [
                 {
                   pattern: "image",
@@ -201,7 +201,7 @@
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@small" %}
             {% include "@bolt-components-card/card.twig" with {
-              url: "javascript:",
+              url: "#!",
               contentItems: [
                 {
                   pattern: "image",
@@ -266,7 +266,7 @@
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@medium" %}
             {% include "@bolt-components-card/card.twig" with {
-              url: "javascript:",
+              url: "#!",
               contentItems: [
                 {
                   pattern: "image",
@@ -334,7 +334,7 @@
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@small" %}
             {% include "@bolt-components-card/card.twig" with {
-              url: "javascript:",
+              url: "#!",
               contentItems: [
                 {
                   pattern: "image",
@@ -399,7 +399,7 @@
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@medium" %}
             {% include "@bolt-components-card/card.twig" with {
-              url: "javascript:",
+              url: "#!",
               contentItems: [
                 {
                   pattern: "image",
@@ -465,7 +465,7 @@
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@small u-bolt-margin---small" %}
             {% include "@bolt-components-card/card.twig" with {
-              url: "javascript:",
+              url: "#!",
               contentItems: [
                 {
                   pattern: "image",

--- a/apps/pattern-lab/src/_patterns/04-pages/99999-bolt-dev-sandbox/00-wysiwyg-kitchen-sink.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/99999-bolt-dev-sandbox/00-wysiwyg-kitchen-sink.twig
@@ -98,7 +98,7 @@ ClassicEditor
     <figure class="u-bolt-margin-bottom-medium">
       {% include "@bolt-components-link/link.twig" with {
         text: "Link is link component with default settings.",
-        url: "http://google.com",
+        url: "#!",
       } only %}
     </figure>
     <h3>Blockquote</h3>


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-435

Pretty straightforward.  Only two things I can think of:

- Did I miss any?  The only place I intentionally left links was for things like navbar/sticky that link to real anchors on the page.
- I think we agree that live examples in pattern lab should have hash bangs for links.  But should all the docs have these as well?  I definitely don't think it should be "google.com" at least.  I left this as a separate commit in case we think it should be something else.