### PR TITLE
RFC (DO NOT MERGE) Bolt global settings

### DIFF
--- a/packages/components/bolt-nav-indicator/nav-indicator.js
+++ b/packages/components/bolt-nav-indicator/nav-indicator.js
@@ -70,7 +70,7 @@ let gumshoeStateModule = (function () {
         // without a value for activeClass, so we give it a placeholder.
         activeClass: 'has-gumshoe-focus',
         scrollDelay: false,
-        offset,
+        offset: boltSettings.gumshoeOffset,
         callback(nav) {
           /**
             * Exit early if nav OR nav.nav (the target) is undefined. Workaround to occasional JS error throwing:

--- a/packages/components/bolt-smooth-scroll/src/smooth-scroll.js
+++ b/packages/components/bolt-smooth-scroll/src/smooth-scroll.js
@@ -21,7 +21,7 @@ export const scrollOptions = {
       return offsetElement.getAttribute('offset');
     }
     else {
-      return 0;
+      return boltSettings.smoothScrollOffset;
     }
   },
 

--- a/packages/core/data/bolt-settings.js
+++ b/packages/core/data/bolt-settings.js
@@ -1,0 +1,13 @@
+// boltSettings is a global variable designed to track settings that may be used multiple instances of the same
+// component (or even different components).  Consumers may modify these settings at any time (either before or after
+// the following code loads) by writing to window.boltSettings.
+
+// Read the existing boltSettings, if any
+boltSettings = window.boltSettings || {};
+
+// Set default values only if these variables are not already set
+boltSettings.smoothScrollOffset = window.boltSettings.smoothScrollOffset || 80;
+boltSettings.gumshoeOffset = window.boltSettings.gumshoeOffset || boltSettings.smoothScrollOffset + 100;
+
+// Write the result back to the global context.
+window.boltSettings = boltSettings;

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -26,3 +26,5 @@ export { spacingSizes } from './data/spacing-sizes';
 
 // Export polyfill loader
 export { polyfillLoader } from './polyfills';
+
+import './data/bolt-settings';


### PR DESCRIPTION
Addresses http://vjira2:8080/browse/BDS-446

This PR demonstrates a possible approach to handling global Bolt settings as discussed on #775.  It adds a `boltSettings` global javascript object, the idea being that you could write simple javascript on the consuming end (e.g. in Drupal) to change the default settings as necessary:

```js
window.boltSettings.smoothScrollOffset = 40;
```

An extra benefit is that you can also easily _read_ these settings anywhere (either Bolt or Drupal):

```js
console.log(boltSettings.smoothScrollOffset);
// Logs 40 to console when called from anywhere in both Bolt and Drupal
```

Some initial thoughts:
- While the settings themselves can easily be updated dynamically on a given page, we'd also have to read the settings at runtime on the Bolt end for that to actually work.  With smooth scroll, that's fine (it's what we're doing already).  For gumshoe, it's trickier-- gumshoe only accepts an offset param when it initializes, so has to be re-initialized if it changes.  That's what were currently doing with navbar.  With this approach though, we'd have to somehow listen for changes to `boltSettings` and reinitialize gumshoe then rather than just reading `boltSettings` at run time.
- How does this compare to the `<bolt-settings>` component approach Salem suggested?  On the plus side, it would allow us to more easily listen for changes.  On the downside, it would require you to add something extra to the page.  🤔 
- Are there other use cases for this?