### PR TITLE
BDS-438 Button alignment safari

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/button/35-button-align-items.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/35-button-align-items.twig
@@ -7,6 +7,6 @@
   {% include "@bolt-components-button/button.twig" with {
     "align": align,
     "width": "full",
-    "text": align ~ " Aligned Button"
+    "text": align|capitalize ~ " Aligned Full Width Button"
   } %}
 {% endfor %}

--- a/packages/components/bolt-button/src/_button.mixins.scss
+++ b/packages/components/bolt-button/src/_button.mixins.scss
@@ -51,7 +51,6 @@
 
   flex-grow: 1;
   flex-direction: row; // Vertically center inner content
-  justify-content: center; // Vertically center inner content
 
   &:before {
     display: block;

--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -156,31 +156,47 @@ bolt-button[width='full@small'],
 
 
 /** Button Alignments **/
-.c-bolt-button__inner-wrapper {
-  width: 100%;
-}
 
 .c-bolt-button--center {
-  .c-bolt-button__inner-wrapper {
-    align-items: center;
-    justify-content: center;
-    text-align: center;
+  text-align: center;
+
+  > *:first-child {
+    @include bolt-margin-left(auto);
+  }
+
+  > *:last-child {
+    @include bolt-margin-right(auto);
+  }
+
+  > *:only-child {
+    @include bolt-margin-right(auto);
+    @include bolt-margin-left(auto);
   }
 }
 
 .c-bolt-button--left {
-  .c-bolt-button__inner-wrapper {
-    align-items: flex-start;
-    justify-content: flex-start;
-    text-align: left;
+  text-align: left;
+
+  > *:last-child {
+    @include bolt-margin-right(auto);
+  }
+
+  > *:only-child {
+    @include bolt-margin-right(auto);
+    @include bolt-margin-left(0);
   }
 }
 
 .c-bolt-button--right {
-  .c-bolt-button__inner-wrapper {
-    align-items: flex-end;
-    justify-content: flex-end;
-    text-align: right;
+  text-align: right;
+
+  > *:first-child {
+    @include bolt-margin-left(auto);
+  }
+
+  > *:only-child {
+    @include bolt-margin-right(0);
+    @include bolt-margin-left(auto);
   }
 }
 

--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -156,22 +156,32 @@ bolt-button[width='full@small'],
 
 
 /** Button Alignments **/
+.c-bolt-button__inner-wrapper {
+  width: 100%;
+}
+
 .c-bolt-button--center {
-  align-items: center;
-  justify-content: center;
-  text-align: center;
+  .c-bolt-button__inner-wrapper {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
 }
 
 .c-bolt-button--left {
-  align-items: flex-start;
-  justify-content: flex-start;
-  text-align: left;
+  .c-bolt-button__inner-wrapper {
+    align-items: flex-start;
+    justify-content: flex-start;
+    text-align: left;
+  }
 }
 
 .c-bolt-button--right {
-  align-items: flex-end;
-  justify-content: flex-end;
-  text-align: right;
+  .c-bolt-button__inner-wrapper {
+    align-items: flex-end;
+    justify-content: flex-end;
+    text-align: right;
+  }
 }
 
 

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -121,19 +121,21 @@
 
     {# Add component-specific classes to a Bolt temp element that gets removed and replaced by it's children once the JS kicks in #}
     <replace-with-children class="{{ classes|join(' ') }}">
-      {% if icon and iconPosition == "before"  %}
-        <span class="{{ "#{baseClass}__icon" }}">
-          {% include "@bolt/icon.twig" with icon only %}
-        </span>
-      {% endif %}
+      <span class="c-bolt-button__inner-wrapper">
+        {% if icon and iconPosition == "before"  %}
+          <span class="{{ "#{baseClass}__icon" }}">
+            {% include "@bolt/icon.twig" with icon only %}
+          </span>
+        {% endif %}
 
-      <span class="{{ "#{baseClass}__item" }} {{ iconOnly ? 'u-bolt-visuallyhidden' : '' }}">{{ text }}</span>
+        <span class="{{ "#{baseClass}__item" }} {{ iconOnly ? 'u-bolt-visuallyhidden' : '' }}">{{ text }}</span>
 
-      {% if icon and iconPosition == "after" %}
-        <span class="{{ "#{baseClass}__icon" }}">
-          {% include "@bolt/icon.twig" with icon only %}
-        </span>
-      {% endif %}
+        {% if icon and iconPosition == "after" %}
+          <span class="{{ "#{baseClass}__icon" }}">
+            {% include "@bolt/icon.twig" with icon only %}
+          </span>
+        {% endif %}
+      </span>
     </replace-with-children>
 
   </{{ tag }}>

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -75,46 +75,45 @@
 {% endif %}
 
 {# Set up the custom element's prop values based on the params passed into the Twig template - used to hydrate the component's initial state and appearance once the Button Component's JavaScript kicks in #}
- <bolt-button
-    {% if align %} align="{{ align }}" {% endif %}
-    {% if style %} color="{{ style }}" {% endif %}
-    {% if size %} size="{{ size }}" {% endif %}
-    {% if url %} url="{{ url }}" {% endif %}
-    {% if width %} width="{{ width }}" {% endif %}
-    {% if rounded %} rounded=" {{ rounded }}" {% endif %}
-    {% if iconOnly %} icon-only="true" {% endif %}
-    {% if transform %} transform="{{ transform }}" {% endif %}
-    {% if disabled == true %} disabled {% endif %}
+<bolt-button
+  {% if align %} align="{{ align }}" {% endif %}
+  {% if style %} color="{{ style }}" {% endif %}
+  {% if size %} size="{{ size }}" {% endif %}
+  {% if url %} url="{{ url }}" {% endif %}
+  {% if width %} width="{{ width }}" {% endif %}
+  {% if rounded %} rounded=" {{ rounded }}" {% endif %}
+  {% if iconOnly %} icon-only="true" {% endif %}
+  {% if transform %} transform="{{ transform }}" {% endif %}
+  {% if disabled == true %} disabled {% endif %}
 
-    {# Failsafe to manually switch off Shadow DOM encapsulation #}
-    {% if noShadow %} no-shadow {% endif %}
+  {# Failsafe to manually switch off Shadow DOM encapsulation #}
+  {% if noShadow %} no-shadow {% endif %}
 
-    {% if target or attributes['target'] %} target="{{ target | default(attributes['target']) }}" {% endif %}
-
-
-    {# todo: rename on-click + on-click-target to only allow onClick + onClickTarget to unify the prop syntax; deprecate adding these via attributes #}
-    {% if onClick or attributes['on-click'] %} on-click="{{ onClick | default(attributes['on-click']) }}" {% endif %}
-    {% if onClickTarget or attributes['on-click-target'] %} on-click-target="{{ onClickTarget | default(attributes['on-click-target']) }}" {% endif %}
+  {% if target or attributes['target'] %} target="{{ target | default(attributes['target']) }}" {% endif %}
 
 
-    {#
-      @todo: create Twig function to translate shorthand utility class references to actual classnames
-      For example:
+  {# todo: rename on-click + on-click-target to only allow onClick + onClickTarget to unify the prop syntax; deprecate adding these via attributes #}
+  {% if onClick or attributes['on-click'] %} on-click="{{ onClick | default(attributes['on-click']) }}" {% endif %}
+  {% if onClickTarget or attributes['on-click-target'] %} on-click-target="{{ onClickTarget | default(attributes['on-click-target']) }}" {% endif %}
 
-      {% include "@bolt/button.twig' with {
-        text: "Example Button",
-        color: "primary",
-        utils: [
-          "-mb-sm", --> small negative margin bottom spacing
-          "mt-md"   --> medium margin top spacing
-        ]
-      } %}
-    #}
-    {# @todo: share `utils` prop across all Twig components #}
-    {# workaround to still allow external utility classes to get added (ex. for spacing or layout tweaks) while still encapsulating internal styling #}
-    {% if utils %} class="{{ utils|join(' ') }}"{% endif %}
-  >
 
+  {#
+    @todo: create Twig function to translate shorthand utility class references to actual classnames
+    For example:
+
+    {% include "@bolt/button.twig' with {
+      text: "Example Button",
+      color: "primary",
+      utils: [
+        "-mb-sm", --> small negative margin bottom spacing
+        "mt-md"   --> medium margin top spacing
+      ]
+    } %}
+  #}
+  {# @todo: share `utils` prop across all Twig components #}
+  {# workaround to still allow external utility classes to get added (ex. for spacing or layout tweaks) while still encapsulating internal styling #}
+  {% if utils %} class="{{ utils|join(' ') }}"{% endif %}
+>
 
   {# choose a semantic <a> tag or <button> tag for better accessibility, depending on whether or not a url is getting passed along #}
   <{{ tag }} {{ attributes.addClass('c-bolt-button__root') | without('on-click') | without('on-click-target') }}>

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -120,21 +120,19 @@
 
     {# Add component-specific classes to a Bolt temp element that gets removed and replaced by it's children once the JS kicks in #}
     <replace-with-children class="{{ classes|join(' ') }}">
-      <span class="c-bolt-button__inner-wrapper">
-        {% if icon and iconPosition == "before"  %}
-          <span class="{{ "#{baseClass}__icon" }}">
-            {% include "@bolt/icon.twig" with icon only %}
-          </span>
-        {% endif %}
+      {% if icon and iconPosition == "before"  %}
+        <span class="{{ "#{baseClass}__icon" }}">
+          {% include "@bolt/icon.twig" with icon only %}
+        </span>
+      {% endif %}
 
-        <span class="{{ "#{baseClass}__item" }} {{ iconOnly ? 'u-bolt-visuallyhidden' : '' }}">{{ text }}</span>
+      <span class="{{ "#{baseClass}__item" }} {{ iconOnly ? 'u-bolt-visuallyhidden' : '' }}">{{ text }}</span>
 
-        {% if icon and iconPosition == "after" %}
-          <span class="{{ "#{baseClass}__icon" }}">
-            {% include "@bolt/icon.twig" with icon only %}
-          </span>
-        {% endif %}
-      </span>
+      {% if icon and iconPosition == "after" %}
+        <span class="{{ "#{baseClass}__icon" }}">
+          {% include "@bolt/icon.twig" with icon only %}
+        </span>
+      {% endif %}
     </replace-with-children>
 
   </{{ tag }}>


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-438

The bug turned out to be the one described here: https://github.com/philipwalton/flexbugs/issues/236

I used the same workaround from that ticket.  Considerations for this PR:
- Does the naming of `c-bolt-button__inner-wrapper` make sense?
- Could this change conceivably cause other regressions?