### PR TITLE
BDS-369 louder schema errors

### DIFF
--- a/apps/pattern-lab/.boltrc.js
+++ b/apps/pattern-lab/.boltrc.js
@@ -8,6 +8,7 @@ module.exports = {
   startPath: 'pattern-lab/index.html',
   plConfigFile: './config/config.yml',
   verbosity: 1,
+  schemaErrorReporting: 'cli',
   webpackDevServer: true,
   extraTwigNamespaces: {
     'bolt': {

--- a/apps/pattern-lab/.patches/configurableSchemaErrorReporting.patch
+++ b/apps/pattern-lab/.patches/configurableSchemaErrorReporting.patch
@@ -6,7 +6,7 @@ index 321c938..7ac9694 100644
     */
    public static function validateDataSchema(\Twig_Environment $env, $data, $schema, $twig_self) {
      $output = '';
-+    $error_reporting = $data['bolt']['data']['config']['schemaErrorReporting'];
++    $error_reporting = !empty($data['bolt']['data']['config']['schemaErrorReporting']) ? $data['bolt']['data']['config']['schemaErrorReporting'] : '';
 +
 +    // Error reporting is turned off, so don't bother continuing with validation.
 +    if ($error_reporting == 'none') {

--- a/apps/pattern-lab/.patches/configurableSchemaErrorReporting.patch
+++ b/apps/pattern-lab/.patches/configurableSchemaErrorReporting.patch
@@ -1,0 +1,40 @@
+diff --git a/src/DataSchema.php b/src/DataSchema.php
+index 321c938..7ac9694 100644
+--- a/src/DataSchema.php
++++ b/src/DataSchema.php
+@@ -32,6 +32,12 @@ class DataSchema {
+    */
+   public static function validateDataSchema(\Twig_Environment $env, $data, $schema, $twig_self) {
+     $output = '';
++    $error_reporting = $data['bolt']['data']['config']['schemaErrorReporting'];
++
++    // Error reporting is turned off, so don't bother continuing with validation.
++    if ($error_reporting == 'none') {
++      return $output;
++    }
+     // Validate Data Schema requires Twig Debug turned on
+     if (!$env->isDebug()) {
+       return $output;
+@@ -60,10 +66,19 @@ class DataSchema {
+         ],
+       ];
+ 
+-      // @todo Consider if/how best to have Pattern Lab compile fail if a validation error is found; which is done with:
+-      // \PatternLab\Console::writeError($message_to_log);
+ 
+-      $output = Utils::consoleLog($to_log, 'error', ['message', 'details'], true);
++      switch ($error_reporting) {
++        case 'cli':
++          // Write to command line and fail build.
++          \PatternLab\Console::writeError($message_to_log);
++          break;
++
++        case 'console':
++        default:
++          // Write to browser console
++          $output = Utils::consoleLog($to_log, 'error', ['message', 'details'], true);
++          break;
++      }
+     }
+ 
+     return $output;

--- a/apps/pattern-lab/composer.lock
+++ b/apps/pattern-lab/composer.lock
@@ -160,11 +160,11 @@
         },
         {
             "name": "bolt-design-system/core-php",
-            "version": "1.1.5",
+            "version": "1.5.3",
             "dist": {
                 "type": "path",
                 "url": "../../packages/core-php",
-                "reference": "200acaf08bdda46b1b3dee447f8ba6740d381a1f",
+                "reference": "0a1eacf4fb0d5a684e66593e5ec5238d13275e95",
                 "shasum": null
             },
             "require": {
@@ -362,16 +362,16 @@
         },
         {
             "name": "cweagans/composer-patches",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "462e65061606dc6149349535d4322241515d1b16"
+                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/462e65061606dc6149349535d4322241515d1b16",
-                "reference": "462e65061606dc6149349535d4322241515d1b16",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
+                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
                 "shasum": ""
             },
             "require": {
@@ -393,7 +393,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-2-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -402,7 +402,7 @@
                 }
             ],
             "description": "Provides a way to patch Composer packages.",
-            "time": "2017-12-07T16:16:31+00:00"
+            "time": "2018-05-11T18:00:16+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -473,7 +473,7 @@
         },
         {
             "name": "drupal/core-render",
-            "version": "8.5.2",
+            "version": "8.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-render.git",
@@ -508,7 +508,7 @@
         },
         {
             "name": "drupal/core-utility",
-            "version": "8.5.2",
+            "version": "8.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-utility.git",
@@ -855,16 +855,16 @@
         },
         {
             "name": "kevinlebrun/colors.php",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kevinlebrun/colors.php.git",
-                "reference": "6d7140aeedef46c97c2324f09b752c599ef17dac"
+                "reference": "cdda5eee41314b87cd5a8bb91b1ffc7c0210e673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kevinlebrun/colors.php/zipball/6d7140aeedef46c97c2324f09b752c599ef17dac",
-                "reference": "6d7140aeedef46c97c2324f09b752c599ef17dac",
+                "url": "https://api.github.com/repos/kevinlebrun/colors.php/zipball/cdda5eee41314b87cd5a8bb91b1ffc7c0210e673",
+                "reference": "cdda5eee41314b87cd5a8bb91b1ffc7c0210e673",
                 "shasum": ""
             },
             "require": {
@@ -902,7 +902,7 @@
                 "console",
                 "shell"
             ],
-            "time": "2016-04-12T20:58:34+00:00"
+            "time": "2018-05-30T08:34:23+00:00"
         },
         {
             "name": "mexitek/phpcolors",
@@ -1039,16 +1039,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.12",
+            "version": "v2.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb"
+                "reference": "10bcb46e8f3d365170f6de9d05245aa066b81f09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
-                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/10bcb46e8f3d365170f6de9d05245aa066b81f09",
+                "reference": "10bcb46e8f3d365170f6de9d05245aa066b81f09",
                 "shasum": ""
             },
             "require": {
@@ -1080,10 +1080,11 @@
             "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
             "keywords": [
                 "csprng",
+                "polyfill",
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-04-04T21:24:14+00:00"
+            "time": "2018-06-08T15:26:40+00:00"
         },
         {
             "name": "pattern-lab/core",
@@ -1509,16 +1510,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.8",
+            "version": "v3.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d4bb70fa24d540c309d88a9d6e43fb2d339b1fbf"
+                "reference": "1b97071a26d028c9bd4588264e101e14f6e7cd00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d4bb70fa24d540c309d88a9d6e43fb2d339b1fbf",
-                "reference": "d4bb70fa24d540c309d88a9d6e43fb2d339b1fbf",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1b97071a26d028c9bd4588264e101e14f6e7cd00",
+                "reference": "1b97071a26d028c9bd4588264e101e14f6e7cd00",
                 "shasum": ""
             },
             "require": {
@@ -1539,7 +1540,7 @@
                 "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
-                "psr/log": "For using the console logger",
+                "psr/log-implementation": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -1574,20 +1575,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:22:50+00:00"
+            "time": "2018-05-23T05:02:55+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.0.8",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "5961d02d48828671f5d8a7805e06579d692f6ede"
+                "reference": "dbe0fad88046a755dcf9379f2964c61a02f5ae3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5961d02d48828671f5d8a7805e06579d692f6ede",
-                "reference": "5961d02d48828671f5d8a7805e06579d692f6ede",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/dbe0fad88046a755dcf9379f2964c61a02f5ae3d",
+                "reference": "dbe0fad88046a755dcf9379f2964c61a02f5ae3d",
                 "shasum": ""
             },
             "require": {
@@ -1603,7 +1604,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1630,11 +1631,11 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:24:00+00:00"
+            "time": "2018-06-08T09:39:36+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.8",
+            "version": "v3.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -1697,20 +1698,21 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.8",
+            "version": "v3.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "253a4490b528597aa14d2bf5aeded6f5e5e4a541"
+                "reference": "8a721a5f2553c6c3482b1c5b22ed60fe94dd63ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/253a4490b528597aa14d2bf5aeded6f5e5e4a541",
-                "reference": "253a4490b528597aa14d2bf5aeded6f5e5e4a541",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8a721a5f2553c6c3482b1c5b22ed60fe94dd63ed",
+                "reference": "8a721a5f2553c6c3482b1c5b22ed60fe94dd63ed",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
@@ -1742,20 +1744,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-22T10:48:49+00:00"
+            "time": "2018-06-21T11:10:19+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.8",
+            "version": "v3.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "bd14efe8b1fabc4de82bf50dce62f05f9a102433"
+                "reference": "3a8c3de91d2b2c68cd2d665cf9d00f7ef9eaa394"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/bd14efe8b1fabc4de82bf50dce62f05f9a102433",
-                "reference": "bd14efe8b1fabc4de82bf50dce62f05f9a102433",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/3a8c3de91d2b2c68cd2d665cf9d00f7ef9eaa394",
+                "reference": "3a8c3de91d2b2c68cd2d665cf9d00f7ef9eaa394",
                 "shasum": ""
             },
             "require": {
@@ -1791,20 +1793,75 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-04T05:07:11+00:00"
+            "time": "2018-06-19T20:52:10+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.7.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30T19:57:29+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
+                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
                 "shasum": ""
             },
             "require": {
@@ -1816,7 +1873,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -1850,20 +1907,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-01-30T19:27:44+00:00"
+            "time": "2018-04-26T10:06:28+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.8",
+            "version": "v3.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4b7d64e852886319e93ddfdecff0d744ab87658b"
+                "reference": "acc5a37c706ace827962851b69705b24e71ca17c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4b7d64e852886319e93ddfdecff0d744ab87658b",
-                "reference": "4b7d64e852886319e93ddfdecff0d744ab87658b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/acc5a37c706ace827962851b69705b24e71ca17c",
+                "reference": "acc5a37c706ace827962851b69705b24e71ca17c",
                 "shasum": ""
             },
             "require": {
@@ -1899,24 +1956,25 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:22:50+00:00"
+            "time": "2018-05-30T04:24:30+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.8",
+            "version": "v3.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a42f9da85c7c38d59f5e53f076fe81a091f894d0"
+                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a42f9da85c7c38d59f5e53f076fe81a091f894d0",
-                "reference": "a42f9da85c7c38d59f5e53f076fe81a091f894d0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
+                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
@@ -1957,7 +2015,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03T05:14:20+00:00"
+            "time": "2018-05-03T23:18:14+00:00"
         },
         {
             "name": "tooleks/php-avg-color-picker",

--- a/apps/pattern-lab/composer.patches.json
+++ b/apps/pattern-lab/composer.patches.json
@@ -9,8 +9,10 @@
       "[FEATURE] Allow regenerateion of Styleguidekit to be conditional based on config.yml flag. Set `regenerateStyleguidekit` to 'false' to BYO index.html file and not write to the public folder": ".patches/dont-regenerate-styleguidekit.patch"
     },
     "pattern-lab/patternengine-twig": {
-      "[FEATURE] Add Twig Globals to Pattern Engine.":
-      ".patches/addTwigGlobals.patch"
+      "[FEATURE] Add Twig Globals to Pattern Engine.": ".patches/addTwigGlobals.patch"
+    },
+    "basaltinc/twig-tools": {
+      "Add schema error reporting configuration": ".patches/configurableSchemaErrorReporting.patch"
     }
   }
 }

--- a/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/30-product-pages/-product-t3.twig
@@ -55,7 +55,6 @@
 
   {% endembed %}
 
-{% set videoUuid1 = "js-bolt-video-uuid--1" %}
 
 {% embed "@bolt/band.twig" with {
   size: "small",
@@ -63,6 +62,7 @@
   fullBleed: true
 } only %}
   {% block band_content %}
+    {% set videoUuid1 = "js-bolt-video-uuid--1" %}
 
     {% grid "o-bolt-grid--flex o-bolt-grid--large o-bolt-grid--middle o-bolt-grid--matrix" %}
 

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-10-d8-homepage-alt.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-10-d8-homepage-alt.twig
@@ -126,7 +126,6 @@
       {% cell "u-bolt-width-1/1@only-small" %}
         {% include "@bolt/button.twig" with {
           text: "Learn More",
-          style: "flat",
           width: "full",
           size: "medium"
         } only %}
@@ -280,7 +279,7 @@
               {% include "@bolt/button.twig" with {
                 text: "Get Real",
                 style: "primary",
-                size: small
+                size: "small"
               } only %}
 
             {% endcell %}

--- a/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/60-d8-homepage/-15-d8-homepage-video-band.twig
@@ -136,7 +136,6 @@
       {% cell "u-bolt-width-1/1@only-small" %}
         {% include "@bolt/button.twig" with {
           text: "Learn More",
-          style: "flat",
           width: "full",
           size: "medium"
         } only %}
@@ -416,7 +415,7 @@
               {% include "@bolt/button.twig" with {
                 text: "Get Real",
                 style: "primary",
-                size: small
+                size: "small"
               } only %}
 
             {% endcell %}

--- a/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/70-d8-agenda-manager/-agenda-manager-detail.twig
@@ -44,7 +44,7 @@
       } only %}
 
       {% include "@bolt/headline.twig" with {
-        text: pageTitle,
+        text: pageTitle|default('Page Title here'),
         size: "xxxlarge",
         tag: "h1"
       } only %}

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -26,6 +26,7 @@ const defaultConfig = {
   startPath: configSchema.properties.startPath.default,
   webpackStats: configSchema.properties.webpackStats.default,
   globalData: {},
+  schemaErrorReporting: configSchema.properties.schemaErrorReporting.default,
 };
 
 function getEnvVarsConfig() {

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -136,6 +136,14 @@
       type: boolean
       description: Production build, will compress assets.
       default: false
+    schemaErrorReporting:
+      description: Setting for where schema errors should be reported.  Note that reporting to cli will cause builds to fail if there are errors.
+      type: string
+      default: console
+      enum:
+        - none
+        - console
+        - cli
 
   definitions:
     components:


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-369

This PR makes the following changes:
- Adds a new Bolt configuration option called `schemaErrorReporting` that can be set to `none`, `console`, or `cli`.  It defaults to `console`, which means errors get printed to the browser js console (current behavior).
- Sets `schemaErrorReporting` in our pattern-lab app to be `cli`, which means schema errors will be reported on the command line and the build will not update.
- Fixes all outstanding schema errors in our pattern-lab app so we're starting with a clean slate

Note that adding the config option requires a patch to the basalt-inc/twig-tools project.  Since the patch relies on Bolt namespaced config, it's not appropriate for a PR against that project.  Some longer-term solutions (maybe for after we've trialled these changes in our workflow):

- Work with the Basalt team to come up with a more generic patch
- "[Overload](https://twig.symfony.com/doc/2.x/advanced.html#overloading)" the `validate_data_schema` function with functionality specific to the Bolt project. 