### PR TITLE
RFC [DO NOT MERGE]: Fix autoprefixer in Drupal builds (WWWD-2139)

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -240,7 +240,18 @@ function createConfig(config) {
         sourceMap: true,
         plugins: () => [
           postcssDiscardDuplicates,
-          autoprefixer({browsers: ['last 2 versions', 'IE 11']}),
+          autoprefixer({
+            browsers: [
+              '> 1% in US',
+              'last 3 Android major versions',
+              'last 3 iOS major versions',
+              'last 3 Chrome major versions',
+              'last 3 Edge major versions',
+              'last 3 Firefox major versions',
+              'last 3 Safari major versions',
+              'IE 11',
+            ],
+          }),
         ],
       },
     },

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -240,7 +240,7 @@ function createConfig(config) {
         sourceMap: true,
         plugins: () => [
           postcssDiscardDuplicates,
-          autoprefixer,
+          autoprefixer({browsers: ['last 2 versions', 'IE 11']}),
         ],
       },
     },


### PR DESCRIPTION
See my [comment on WWWD-2139](http://vjira2:8080/browse/WWWD-2139?focusedCommentId=43391&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-43391) for some of the back story.

In summary, adding a `.broswerslistrc` file to the Drupal theme fixes the autoprefixer issues, but then we have duplicate browser requirement lists.  This commit seems to accomplish the same thing.  Outstanding questions:

- Are the browser requirements in `@bolt/config-browserlist` accurate?  They seem really aggressive.  But if they are right, I at least need to update this PR to match them.  And the ones I put in this PR are really just placeholders.
- If we want to specify browser requirements as this PR does (i.e. as inline options), we should probably remove/deprecate `@bolt/config-browserlist`.  I wasn't clear on how that package is currently used, if at all.
- Alternatively, we could standardize on using a `.broswerslistrc` file instead of the inline options.  If that file is in a Bolt package, I suppose we'd need some way of copying it to the theme before running the build?

Lots of questions I guess, but at least I figured out how to fix the autoprefixer build issue :).  
