### PR TITLE
Fix: increase sass math precision to 3 decimals

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -283,7 +283,7 @@ function createConfig(config) {
         ],
         functions: sassExportData,
         outputStyle: 'expanded',
-        precision: 2,
+        precision: 3,
         data: globalSassData.join('\n'),
       },
     },


### PR DESCRIPTION
Need this to work with the max breakpoint calc of `-0.001em`.