### PR TITLE
Fix: remove align-items prop from text align util

### DIFF
--- a/packages/global/styles/07-utilities/_utilities-text-align.scss
+++ b/packages/global/styles/07-utilities/_utilities-text-align.scss
@@ -4,15 +4,18 @@
 
 .u-bolt-text-align-right {
   text-align: right !important;
-  align-items: flex-end !important;
+  text-align: end !important;
 }
 
 .u-bolt-text-align-left {
   text-align: left !important;
-  align-items: flex-start !important;
+  text-align: start !important;
 }
 
 .u-bolt-text-align-center {
   text-align: center !important;
-  align-items: center !important;
+}
+
+.u-bolt-text-align-justify {
+  text-align: justify !important;
 }


### PR DESCRIPTION
This fixes the text-align utility class.

# Changes
1. Removed `align-items` prop because that depends on `flex-direction` being declared for desired results, which makes this util has no context of.
2. Added `start` and `end` values for better internationalization support. This allows RTL pages to know the exact intended alignment. (source: https://davidwalsh.name/text-align-start)
3. Added `justify` option.
