### PR TITLE
Fix newly broken schema, re-enable louder schema errors

### DIFF
--- a/apps/pattern-lab/.boltrc.js
+++ b/apps/pattern-lab/.boltrc.js
@@ -12,7 +12,7 @@ module.exports = {
   startPath: 'pattern-lab/index.html',
   plConfigFile: './config/config.yml',
   verbosity: 1,
-  schemaErrorReporting: 'console',
+  schemaErrorReporting: 'cli',
   webpackDevServer: true,
   extraTwigNamespaces: {
     'bolt': {

--- a/packages/components/bolt-icon/icon.schema.yml
+++ b/packages/components/bolt-icon/icon.schema.yml
@@ -25,6 +25,7 @@ properties:
       - asset-presentation
       - asset-text
       - asset-video
+      - brand-operations
       - calendar
       - careers
       - case-management


### PR DESCRIPTION
(No Jira issue)

@sghoweri I'll be honest, I'm disappointed that I have to create this PR to get this working again.  Here's the sequence of events as I see it:

- I set up an automated test to make sure we followed our own schema in pattern lab
- You disabled the automated test when it failed because you couldn't figure out why it was breaking
- I helped you by fixing the (legitimate) schema errors you had committed and merged
- You left the test disabled (I realize I could have re-enabled it myself-- I suppose I was hoping you would take the initiative since you had done the disabling)
- You committed and merged additional code that again broke the schema (again, legitimate errors: you had forgotten to update the icon yaml file when adding a new icon)
- I recognized that schema validation was still disabled, re-enabled it, then went about fixing your new errors for you

Reasonable or unreasonable for me to be frustrated?