### PR TITLE
BDS-464 prevent navbar icon being overlapped safari 9

### DIFF
--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -166,6 +166,10 @@ bolt-navbar {
 
 .c-bolt-navbar__title-icon {
   @include bolt-margin(0 xsmall 0 0);
+
+  // Fix cross-browser bug where icon shrinks below its minimum natural width - see https://github.com/philipwalton/flexbugs#flexbug-1
+  flex-shrink: 0;
+  flex-basis: auto;
 }
 
 .c-bolt-navbar__title-text {

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -118,7 +118,6 @@ bolt-navbar {
   @include bolt-margin-right(medium); // Maintain space between items
   padding-bottom: $bolt-navbar-vspacing-small;
   align-self: center;
-  flex-shrink: 0;
   display: flex;
   flex-shrink: 1; // make sure the title can wrap to multiple lines and shrink if needed.
   flex-wrap: nowrap;


### PR DESCRIPTION
Resolves http://vjira2:8080/browse/BDS-464

## Testing Instructions
- To reproduce the original issue, see http://vjira2:8080/browse/WWWD-2296
- Review this code and confirm that it makes sense.  There is no demo where you can see it in action-- you can create a temporary one by making the title of one of the navbar demos in pattern lab as long as the one in Drupal.  Do so here: https://fix-bds-464-prevent-navbar-icon-being-overlapped-safari-9.bolt-design-system.com/pattern-lab/?p=components-navbar--centered