### PR TITLE
Fix: add shadow to video play button

### DIFF
--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -18,7 +18,8 @@ $bolt-video-js-button-background-color: bolt-color(yellow);
 $bolt-video-js-button-transition: $bolt-transition;
 $bolt-video-js-button-border-radius: $bolt-border-radius;
 $bolt-video-js-button-shadow-color: bolt-color(black);
-$bolt-video-js-button-shadow-level: 'level-40';
+$bolt-video-js-button-shadow-level: 'level-20';
+$bolt-video-js-button-shadow-level-hover: 'level-40';
 
 @mixin bolt-video-js-button($opacity: 1) {
   color: $bolt-video-js-button-text-color;
@@ -41,6 +42,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
     @include bolt-margin(0);
     @include bolt-padding(0);
     @include bolt-video-js-button($opacity: 1);
+    @include bolt-shadow($key: $bolt-video-js-button-shadow-level, $base-color: $bolt-video-js-button-shadow-color);
 
     position: absolute;
     top: auto;
@@ -99,7 +101,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
     &:hover,
     &:focus {
       @include bolt-video-js-button($opacity: $bolt-global-link-hover-opacity); // [1]
-      @include bolt-shadow($key: $bolt-video-js-button-shadow-level, $base-color: $bolt-video-js-button-shadow-color);
+      @include bolt-shadow($key: $bolt-video-js-button-shadow-level-hover, $base-color: $bolt-video-js-button-shadow-color);
     }
 
     &:active {
@@ -111,7 +113,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
   &:hover .vjs-big-play-button,
   &:focus .vjs-big-play-button {
     @include bolt-video-js-button($opacity: $bolt-global-link-hover-opacity); // [1]
-    @include bolt-shadow($key: $bolt-video-js-button-shadow-level, $base-color: $bolt-video-js-button-shadow-color);
+    @include bolt-shadow($key: $bolt-video-js-button-shadow-level-hover, $base-color: $bolt-video-js-button-shadow-color);
   }
 
   &:active .vjs-big-play-button {


### PR DESCRIPTION
# JIRA

http://vjira2:8080/browse/BDS-511

# Summary

Add shadows to play button so it doesn't bleed into the same color video background.

# Details

Marketing raised a concern about the their videos using the brand yellow as the background color, this will add a separation between the yellow play button and a yellow video background.

<img width="516" alt="screen shot 2018-07-31 at 12 48 23 pm" src="https://user-images.githubusercontent.com/3027663/43474144-11932970-94c0-11e8-9c42-905109f68eed.png">

# How to test

Pull down the branch and go to any video demo page. Use browser inspector to change the video thumbnail HTML element to use brand yellow as the `background-color`.