### PR TITLE
feat: Add Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Jira
+
+(Enter a link to the Jira issue this PR applies to, if any)
+
+## Summary
+
+(Enter a one-line summary of the changes in this PR.  This will be included in the release notes)
+
+## Details
+
+(Explain the changes in enough detail fo reviewers to understand.  Raise any questions for reviewers to consider.)
+
+## How to test
+
+(List clear steps to test that the changes are working)


### PR DESCRIPTION
## Jira
(No issue)

## Summary
Adds a template for Github PR descriptions

## Details
Helps standardize our PR descriptions.  See https://blog.github.com/2016-02-17-issue-and-pull-request-templates/

Is the text I included in the template adequately useful?  Should we just include the headings without help text that you have to delete every time?

## How to test
I _think_ we have to merge this into master in order to test.  Once merged:
- Create a new PR
- Confirm that the description for the PR is pre-populated with the markup in .github/PULL_REQUEST_TEMPLATE.md