### PR TITLE
feat: Remove all vertical padding on video share overlay (BDS-495)

### DIFF
--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -143,7 +143,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
     background: rgba(bolt-color(black), 0.9);
 
     .vjs-modal-dialog-content {
-      @include bolt-padding(medium large medium medium);
+      @include bolt-padding(0 large 0 medium);
       @include bolt-font-size(medium);
 
       display: block;

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -162,11 +162,11 @@ $bolt-video-js-button-shadow-level: 'level-40';
 
       .vjs-social-share-links {
         @include bolt-font-size(small, tight);
-        margin-right: (bolt-spacing(xsmall) * -1);
-        margin-left: (bolt-spacing(xsmall) * -1);
+        margin-right: -0.25rem;
+        margin-left: -0.25rem;
 
         &:before {
-          @include bolt-margin(xsmall);
+          @include bolt-margin(0.25rem);
           @include bolt-font-size(small, tight);
           @include bolt-font-weight(bold);
 
@@ -177,7 +177,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
       }
 
       .vjs-social-share-link {
-        @include bolt-margin(xsmall);
+        @include bolt-margin(0.25rem);
       }
 
       .vjs-social-label-text {

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -5,12 +5,11 @@
 // 1. [Mai] Because these styles are overrides, they need to be repeated.
 // 2. [Mai] Input font-size needs to be 16px to prevent zooming.
 // 3. [Mai] Hide close captions button.
-// 4. [Mai] Add white space for IE because padding got ignored.
-// 5. [Mai] Flexbox messes up IE layout, this prevents IE from loading display: flex.
-// 6. Required so videos with intrinsic ratio (used in the <bolt-ratio> object) properly fill the space available in IE 11.
-// 7. [Mai] These gradients cover up part of the squre to form a triangle. A triangle had to be formed this way because % width has to be used to determine a flexible triangle based on the video size.
-// 8. [Mai] This optically centers the triangle.
-// 9. [Denton] Hide the title and description when sharing to minimize the chances that you'll see a scrollbar, which is undesirable.  Replace it will the CSS content "Share This Video"
+// 4. [Mai] Flexbox messes up IE layout, this prevents IE from loading display: flex.
+// 5. Required so videos with intrinsic ratio (used in the <bolt-ratio> object) properly fill the space available in IE 11.
+// 6. [Mai] These gradients cover up part of the squre to form a triangle. A triangle had to be formed this way because % width has to be used to determine a flexible triangle based on the video size.
+// 7. [Mai] This optically centers the triangle.
+// 8. [Denton] Hide the title and description when sharing to minimize the chances that you'll see a scrollbar, which is undesirable.  Replace it will the CSS content "Share This Video"
 
 
 $bolt-video-js-button-text-color: bolt-color(indigo);
@@ -28,7 +27,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
 }
 
 .video-js {
-  position: absolute; // [6]
+  position: absolute; // [5]
   width: 100%;
   height: 100%;
 
@@ -59,8 +58,8 @@ $bolt-video-js-button-shadow-level: 'level-40';
 
       display: block;
       position: absolute;
-      top: 18%; // [8]
-      left: 42%; // [8]
+      top: 18%; // [7]
+      left: 42%; // [7]
       width: 40%;
       height: auto;
       padding-bottom: 40%;
@@ -81,7 +80,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
         background:
           linear-gradient(
             -30deg,
-            $bolt-video-js-button-background-color 48%, // [7]
+            $bolt-video-js-button-background-color 48%, // [6]
             transparent 50%
           );
       }
@@ -90,7 +89,7 @@ $bolt-video-js-button-shadow-level: 'level-40';
         background:
           linear-gradient(
             -150deg,
-            $bolt-video-js-button-background-color 48%, // [7]
+            $bolt-video-js-button-background-color 48%, // [6]
             transparent 50%
           );
       }
@@ -143,35 +142,37 @@ $bolt-video-js-button-shadow-level: 'level-40';
     background: rgba(bolt-color(black), 0.9);
 
     .vjs-modal-dialog-content {
-      @include bolt-padding(0 large 0 medium);
-      @include bolt-font-size(medium);
+      @include bolt-padding(xsmall 2.5rem xsmall small);
+      @include bolt-font-size(medium, tight);
 
-      display: block;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
       overflow: auto;
 
-      @supports(display: flex) { // [5]
+      @supports(display: flex) { // [4]
         display: flex;
         justify-content: center;
       }
 
       .vjs-social-title,
       .vjs-social-description {
-        @include bolt-visuallyhidden; // [9]
+        @include bolt-visuallyhidden; // [8]
       }
 
       .vjs-social-share-links {
-        @include bolt-font-size(small);
+        @include bolt-font-size(small, tight);
         margin-right: (bolt-spacing(xsmall) * -1);
         margin-left: (bolt-spacing(xsmall) * -1);
 
         &:before {
-          @include bolt-font-size(medium);
+          @include bolt-margin(xsmall);
+          @include bolt-font-size(small, tight);
           @include bolt-font-weight(bold);
 
-          content: "Share This Video"; // [9]
-          white-space: normal;
           display: block;
-          margin: 0 bolt-spacing(xsmall) bolt-spacing(xsmall);
+          content: "Share This Video"; // [8]
+          white-space: nowrap;
         }
       }
 
@@ -189,7 +190,9 @@ $bolt-video-js-button-shadow-level: 'level-40';
 
       form {
         @include bolt-margin(auto);
+        @include bolt-font-family(body);
         width: 100%;
+        max-width: 40rem;
 
         input[type='text'] {
           font-size: 16px; // [2]
@@ -202,20 +205,15 @@ $bolt-video-js-button-shadow-level: 'level-40';
         }
 
         > * {
-          @include bolt-margin-bottom(small);
-
-          &:last-child {
-            @include bolt-margin-bottom(0);
-            @include bolt-padding-bottom(medium); // [4]
-          }
+          @include bolt-margin-bottom(xsmall);
         }
       }
     }
   }
 
   .vjs-control.vjs-close-button {
-    width: bolt-spacing(large);
-    height: bolt-spacing(large);
+    width: bolt-spacing(2.5rem);
+    height: bolt-spacing(2.5rem);
 
     > * {
       display: flex;


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-495
http://vjira2:8080/browse/WWWD-2367

## Summary

Prevent scrollbar from appearing on video overlay unless absolutely necessary.

## Details

Stakeholders were pretty adamant about not seeing scrollbars in the video overlay.  This takes previous measures a step further still without hindering usability.

Specifically, this removes the top and bottom padding from the overlay.  It's vertically centered anyway, so this only affects cases where the content is slightly too large to fit vertically.  In those cases, the share content now presses closer to the top and bottom of the video player without activating the scrollbar.  However, the scrollbar still activates if the content would actually be cropped.

## How to test

- Go to the videos page `pattern-lab/?p=viewall-components-video`
- Make the browser width as small as possible in pattern lab
- Play a video, then press the share button icon to pull up the share overlay.
- Attempt to scroll up or down in the video
Previous behavior: the overlay would scroll up and down, even though no content was hidden
New behavior: the overlay does not scroll unless content is actually cropped.