### PR TITLE
fix: Prevent error display when form blur is triggered by js (BDS-509)

### DIFF
--- a/packages/components/bolt-form/src/form.js
+++ b/packages/components/bolt-form/src/form.js
@@ -29,7 +29,17 @@ for (let i = 0, len = inputs.length; i < len; i++) {
     }
   };
 
-  input.onblur = function() {
+  input.onblur = function(e) {
+    if (!e.isTrusted) {
+      // This blur event was triggered by a script, not a human, so don't mark
+      // the input as is-touched (because it actually wasn't) or show errors.
+
+      // Note that Mozilla claims that isTrusted shouldn't work in IE, but
+      // based on testing, it does.
+      // https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
+      return;
+    }
+
     input.classList.add('is-touched');
 
     if (input.validationMessage) {


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-509
http://vjira2:8080/browse/WWWD-2345

## Summary

Prevent Drupal webforms javascript from triggering form field error display

## Details

As summarized in my comment on http://vjira2:8080/browse/WWWD-2345, when external javascript (on the Drupal side) triggers a blur event on one of the form fields, the Bolt form javascript assumes that the user has blurred the field and proceeds to display the form validation errors.

This PR adds a check for whether the blur event was triggered by a human or another script-- only if it's a human do we proceed to display an relevant form errors.

## How to test
The way I tested was by manually making applying this change to Bolt within Drupal, rebuilding the webpack javascript with fin exec npm run build:default`, then confirming that the bug described in http://vjira2:8080/browse/WWWD-2345 was resolved.

I thought we'd be able to recreate it in pure Bolt by running js in the console, but I was unsuccessful.  Here's how far I got:

1. Open https://bolt-design-system.com/pattern-lab/patterns/02-components-form-form-full-campaign-landing/02-components-form-form-full-campaign-landing.html
2. In the console, run `document.querySelector('[placeholder="Enter your email address"]').focus()`
Expected behavior: focus is applied to the first field and the label is displayed
Actual behavior: focus doesn't appear to get applied :thinking: