### PR TITLE
chore: add `sassdoc:build` to Lerna postbootstrap NPM script tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "composer": "npm-run-all --parallel composer:* --aggregate-output --print-label --print-name",
     "xcomposer:drupal-lab": "cd apps/drupal-lab && composer install --no-interaction --prefer-dist",
     "bootstrap": "lerna bootstrap --reject-cycles",
-    "postbootstrap": "yarn run build:icons && yarn run build:uikit && node scripts/monorepo-tests.js",
+    "postbootstrap": "yarn run build:icons && yarn run sassdoc:build && yarn run build:uikit && node scripts/monorepo-tests.js",
     "Xpredeploy": "yarn run build",
     "deploy": "./scripts/deploy.js",
     "clean:git": "git clean -xdf && rm -rf apps/**/vendor apps/**/node_modules && find . -empty -type d -delete",
@@ -87,7 +87,8 @@
     "now": "^11.0.6",
     "npm-run-all": "^4.1.2",
     "yaml-lint": "^1.2.2",
-    "git-semver-tags": "^1.3.6"
+    "git-semver-tags": "^1.3.6",
+    "sassdoc": "^2.5.0"
   },
   "workspaces": {
     "nohoist": [


### PR DESCRIPTION
Automatically generate Sassdoc docs when `npm run bootstrap` command is run; also add Sassdoc as a root level NPM dependency in not globally installed

CC @mikemai2awesome and @rockymountainhigh1943 