### PR TITLE
Hotfix: remove `es6-promise` injection to fix JS errors in Preact v8.3.0

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -421,9 +421,6 @@ async function createWebpackConfig(buildConfig) {
           name: 'Bolt Manifest',
         },
       }),
-      new webpack.ProvidePlugin({
-        Promise: 'es6-promise',
-      }),
       new webpack.DefinePlugin(globalJsData),
 
       // Show build progress


### PR DESCRIPTION
## Jira
No open Jira ticket on this -- observed this issue shortly after Bolt v1.7.1 was released yesterday.

## Summary
Removes auto-injecting the `es6-promise` library in Bolt's Webpack build to fix all JavaScript being broken on the Bolt Docs + Pattern Lab sites + for folks consuming Bolt downstream (Drupal and Bolt devs doing local development)

> Broken JS on bolt-design-system.com site
![image](https://user-images.githubusercontent.com/1617209/43963863-86f986d4-9c89-11e8-89f6-9a6fc7d03796.png)

> Broken video player in PL for example
![image](https://user-images.githubusercontent.com/1617209/43963893-9bd250b8-9c89-11e8-92cd-4f4305cd9da9.png)


## Details
Removes having Webpack automatically pull in the `es6-promise` library from `@bolt/build-tools` Webpack config (using the Webpack Provide plugin) as this dependency injection started causing JavaScript errors to get thrown in the latest minor version of Preact just released, v8.3.0.

Added bonus: this wasn't actually needed anymore for IE 11 support based on how we've been bundling up and polyfilling our JavaScript + which libraries we're including.

## How to test
1. Confirm overall JavaScript functionality working again as expected in supported browsers
2. Confirm the JavaScript error previously getting thrown no longer appears in the console.

![image](https://user-images.githubusercontent.com/1617209/43963716-175c0180-9c89-11e8-94ed-4ef6a0e12906.png)


Side note: Bolt v2.0 updates getting worked on should help avoid this sort of thing from slipping through the cracks as our Nightwatch tests for the Video Player have an added bonus of checking to make sure JavaScript in general is working as expected.