### PR TITLE
Subfeature/bds 336 fix attributes support

### DIFF
--- a/packages/components/bolt-video/src/video.twig
+++ b/packages/components/bolt-video/src/video.twig
@@ -18,32 +18,24 @@
 ] %}
 
 {% if ratio == true %}
-  {% set utilClasses = [] %}
-  {% set videoClasses = [] %}
-
+  {# Move utility classes to a separate attributes object so they can be added to the wrapping ratio object instead #}
+  {% set ratioAttributes = create_attribute({}) %}
   {% for class in attributes["class"] %}
     {% if class starts with "u-" %}
-      {% set utilClasses = utilClasses|merge([class]) %}
-    {% else %}
-      {% set videoClasses = videoClasses|merge([class]) %}
+      {% set ratioAttributes = ratioAttributes.addClass(class) %}
+      {% set attributes = attributes.removeClass(class) %}
     {% endif %}
   {% endfor %}
 
   {% set innerVideo %}
-    {% include "@bolt/_video-tag.twig" with {
-      attributes: {
-        class: videoClasses
-      }
-    } %}
+    {% include "@bolt/_video-tag.twig" %}
   {% endset %}
 
   {% include "@bolt/ratio.twig" with {
     aspectRatioHeight: aspectRatioHeight ?? 9,
     aspectRatioWidth: aspectRatioWidth ?? 16,
     children: innerVideo,
-    attributes: {
-      class: utilClasses
-    }
+    attributes: ratioAttributes
   } only %}
 {% else %}
   {% include "@bolt/_video-tag.twig" %}

--- a/packages/components/bolt-video/src/video.twig
+++ b/packages/components/bolt-video/src/video.twig
@@ -17,26 +17,26 @@
   collapsed is not null and collapsed == false ? "is-expanded" : "is-collapsed"
 ] %}
 
-{% set utilClasses = [] %}
-{% set videoClasses = [] %}
-
-{% for class in attributes["class"] %}
-  {% if class starts with "u-" %}
-    {% set utilClasses = utilClasses|merge([class]) %}
-  {% else %}
-    {% set videoClasses = videoClasses|merge([class]) %}
-  {% endif %}
-{% endfor %}
-
-{% set innerVideo %}
-  {% include "@bolt/_video-tag.twig" with {
-    attributes: {
-      class: videoClasses
-    }
-  } %}
-{% endset %}
-
 {% if ratio == true %}
+  {% set utilClasses = [] %}
+  {% set videoClasses = [] %}
+
+  {% for class in attributes["class"] %}
+    {% if class starts with "u-" %}
+      {% set utilClasses = utilClasses|merge([class]) %}
+    {% else %}
+      {% set videoClasses = videoClasses|merge([class]) %}
+    {% endif %}
+  {% endfor %}
+
+  {% set innerVideo %}
+    {% include "@bolt/_video-tag.twig" with {
+      attributes: {
+        class: videoClasses
+      }
+    } %}
+  {% endset %}
+
   {% include "@bolt/ratio.twig" with {
     aspectRatioHeight: aspectRatioHeight ?? 9,
     aspectRatioWidth: aspectRatioWidth ?? 16,


### PR DESCRIPTION
## Jira
N/A (see #835)

## Summary

This is a "sub-feature" PR with cleanup/fixes for #835

## Details

In addition to various minor cleanup, this fixes a regression where the ability to pass attributes besides classes to the video component was lost.  To see the regression:

- Go to the `video w inline script and email share` demo on the master branch for #835 (https://bolt-design-system.com/pattern-lab/?p=components-video-w-inline-script-and-email-share).
- Play the video, then click to share.  You should see an email share button based on data attributes passed in.
- Now go to the `video w inline script and email share` demo on the feature branch for #835 (https://fix-bds-336-enable-utilities-on-video.bolt-design-system.com/pattern-lab/?p=components-video-w-inline-script-and-email-share).
- Play the video, then click to share.  You should not see the email share link (this is the regression)

## How to test
- Now go to the `video w inline script and email share` demo from this PR
- Play the video, then click to share.  Confirm that the share details have been populated the same as on the master branch.

