### PR TITLE
docs: add example of standalone form inside a card

### DIFF
--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/form-example.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/form-example.twig
@@ -1,0 +1,46 @@
+ {% embed "@bolt/band.twig" with {
+    size: "small",
+    theme: "xlight"
+  } only %}
+
+    {% block band_content  %}
+
+      {% embed "@bolt/card.twig" with {
+        theme: "light",
+      } only %}
+
+        {% block card_media %}{% endblock %}
+
+        {% block card_body %}
+
+          {% include "@bolt/headline.twig" with {
+            text: "Register now",
+            size: "xlarge"
+          } only %}
+
+          {% include "@bolt/text.twig" with {
+            text: "(all fields are required)",
+            size: "small",
+            attributes: {
+              class: "u-bolt-color-gray-dark"
+            }
+          } only %}
+
+          <p class="u-bolt-margin-bottom-small">
+            {% include "@bolt/link.twig" with {
+              "text": "Fill out this form with LinkedIn"|t,
+              "icon": {
+                "position": "before",
+                "name": "linkedin-solid",
+                "color": "blue",
+                "size": "medium"
+              }
+            } only %}
+          </p>
+
+        {% endblock %}
+
+      {% endembed %}
+       
+    {% endblock %}
+  {% endembed %}

--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/form-example.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/form-example.twig
@@ -37,6 +37,8 @@
               }
             } only %}
           </p>
+          
+          {% include "@pl/_event-sponsors-with-action-block.twig" %}
 
         {% endblock %}
 

--- a/apps/pattern-lab/src/_patterns/04-pages/80-events/form-example.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/80-events/form-example.twig
@@ -38,7 +38,7 @@
             } only %}
           </p>
           
-          {% include "@pl/_event-sponsors-with-action-block.twig" %}
+          {% include "@pl/_event-register-form.twig" %}
 
         {% endblock %}
 


### PR DESCRIPTION
Standalone example of rendering a form inside of a card in Bolt, wired up to use validation.