### PR TITLE
Wire up Chips to use theming system

### DIFF
--- a/packages/components/bolt-chip/src/chip.scss
+++ b/packages/components/bolt-chip/src/chip.scss
@@ -13,7 +13,7 @@
 
 // Chip Variables
 $bolt-chip-border-radius: 100em;
-$bolt-chip-color: var(--bolt-theme-chip-text, var(--bolt-theme-color, inherit)); // TODO: Map this to theme text color when theming is done.
+$bolt-chip-color: bolt-theme(text);
 $bolt-chip-background-color: rgba(bolt-color(gray), 0.22);
 $bolt-chip-background-color--hover: rgba(bolt-color(gray), 0.30);
 $bolt-chip-transition: $bolt-transition;


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-506

This is also branched off of https://github.com/bolt-design-system/bolt/pull/827

## Summary

Convert Chip component to use new theming system.

## Details

Removed the interim theming fix in chip and then replaced with `bolt-theme` function to define colors.

## How to test

Run the branch locally and do cross browser testing to make sure there's no discrepancies. 

This is how it should look:

![screen shot 2018-08-15 at 4 06 13 pm](https://user-images.githubusercontent.com/3027663/44170367-283e0000-a0a5-11e8-8c17-758637bc0b53.png)
