### PR TITLE
RFC: Prevent escaping of other patterns included in share

### DIFF
--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -13,14 +13,17 @@
 
 {# Share inline #}
 {% if isFlat is sameas(true) %}
-  {% set items = items|merge([include("@bolt-components-headline/text.twig", {
-    tag: "span",
-    text: text,
-    weight: "bold",
-    transform: "uppercase",
-    size: "small",
-    attributes: create_attribute(attributes|default({})).addClass("u-bolt-color-gray-dark c-bolt-share--inline-heading")
-  })]) %}
+  {% set item %}
+    {% include "@bolt-components-headline/text.twig" with {
+      tag: "span",
+      text: text,
+      weight: "bold",
+      transform: "uppercase",
+      size: "small",
+      attributes: create_attribute(attributes|default({})).addClass("u-bolt-color-gray-dark c-bolt-share--inline-heading")
+    } only %}
+  {% endset %}
+  {% set items = items|merge([item]) %}
 {% endif %}
 
 {% for source in sources %}
@@ -44,21 +47,28 @@
   {% endif %}
 
   {% if sourceName %}
-    {% set items = items|merge([include("@bolt-components-link/link.twig", {
-      text: sourceName,
-      url: source.url,
-      icon: {
-        name: sourceIcon,
-        position: "before",
-        size: "medium"
-      },
-      attributes: create_attribute(attributes|default({})).addClass("js-bolt-share__"~source.name).setAttribute("target",sourceTarget)
-    })]) %}
+    {% set item %}
+      {% include "@bolt-components-link/link.twig" with {
+        text: sourceName,
+        url: source.url,
+        icon: {
+          name: sourceIcon,
+          position: "before",
+          size: "medium"
+        },
+        attributes: create_attribute(attributes|default({})).addClass("js-bolt-share__"~source.name).setAttribute("target",sourceTarget)
+      } only %}
+    {% endset %}
+
+    {% set items = items|merge([item]) %}
   {% endif %}
 {% endfor %}
 
 {% if copyToClipboard %}
-  {% set items = items|merge([include("@bolt-components-copy-to-clipboard/copy-to-clipboard.twig", copyToClipboard)]) %}
+  {% set item %}
+    {% include "@bolt-components-copy-to-clipboard/copy-to-clipboard.twig" with copyToClipboard only %}
+  {% endset %}
+  {% set items = items|merge([item]) %}
 {% endif %}
 
 {% set attributes = create_attribute(attributes|default({})) %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2454

## Summary

Prevent auto-escaping of patterns included within the Share component

## Details

Auto-escaping is not enabled in Pattern Lab, so you won't see this issue on the PL side.

Auto-escaping _is_ enabled on the Drupal side, as it should be for security.  However, one of the side affects of the way the escaping is done is that if you set a variable to the result of an include function, the output will be escaped HTML.  In the example below, link1 will be escaped HTML, while link2 and link3 will print as rendered links

```
{% set link1 = include("@bolt-components-link/link.twig", {
  text: "Link 1",
  url: "#!"
}) %}

{% set link2 %}
  {{ include("@bolt-components-link/link.twig", {
    text: "Link 2",
    url: "#!"
  }}
}) %}

{% set link3 %}
  {% include "@bolt-components-link/link.twig" with {
    text: "Link 3",
    url: "#!"
  } only %}
}) %}

{{ link1 }}
{{ link2 }}
{{ link3 }}
```
This may actually be a bug in how Drupal's auto-escaping works since the result of an include function should be considered safe (as the examples for link2 and link3 above demonstrate).  But, this PR gets the job done.  If we choose this route, the rule of thumb is to never save the result of include() to a variable without printing it in Bolt components (use the technique for either link2 or link3 instead).  The syntax for link1 is fine to use in Pattern Lab.

## How to test

### Reproduce the bug
- In Drupal, include a bare bones share component in a twig template
```
{% include '@bolt-components-share/share.twig' with {
  inline: true,
  text: 'Share this page'|trans,
  sources: [
    {
      name: "facebook",
      url: "#!"
    }
} only %}
```
- Disable javascript
- Confirm that escaped markup is output to the page

![screen shot 2018-08-21 at 3 21 55 pm](https://user-images.githubusercontent.com/677668/44432228-02f23b80-a556-11e8-8241-362326455eef.png)


### Fix the bug
- Copy the updated markup for share.twig from this PR into Drupal
- Refresh the page and confirm that the markup is not escaped

![screen shot 2018-08-21 at 3 22 02 pm](https://user-images.githubusercontent.com/677668/44432233-0a194980-a556-11e8-83e4-773a5d00b0e1.png)

