### PR TITLE
BDS-554 copy to clipboard updates

### DIFF
--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
@@ -19,7 +19,7 @@ bolt-copy-to-clipboard {
   position: relative;
   text-align: left;
 
-  &.is-copied {
+  &.is-copying {
     .c-bolt-copy-to-clipboard__trigger {
       pointer-events: none;
       opacity: 0;
@@ -34,7 +34,7 @@ bolt-copy-to-clipboard {
     }
   }
 
-  &.is-copied.is-transitioning {
+  &.is-copying.has-copied {
     .c-bolt-copy-to-clipboard__spinner {
       opacity: 0;
       transition-delay: 0s; // [2]

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
@@ -1,8 +1,12 @@
+@import '@bolt/core';
+
 /* ------------------------------------ *\
    Copy to Clipboard
 \* ------------------------------------ */
 
-@import '@bolt/core';
+// Dev Notes
+// 1. When tranistioning in (any time opacity is 1), add a delay to wait for the previously visible item to fade out.
+// 2. When transitioning out (any time opacity is 0), reset any existing delay so the transition runs immediately.
 
 $bolt-copy-transition: all 0.5s ease;
 
@@ -19,22 +23,26 @@ bolt-copy-to-clipboard {
     .c-bolt-copy-to-clipboard__trigger {
       pointer-events: none;
       opacity: 0;
+      transition-delay: 0s; // [2]
     }
 
     .c-bolt-copy-to-clipboard__spinner {
       left: 0;
       opacity: 1;
       transform: scale(1) rotate(360deg) translateY(-50%);
+      transition-delay: 0.5s; // [1]
     }
   }
 
   &.is-copied.is-transitioning {
     .c-bolt-copy-to-clipboard__spinner {
       opacity: 0;
+      transition-delay: 0s; // [2]
     }
 
     .c-bolt-copy-to-clipboard__confirmation {
       opacity: 1;
+      transition-delay: 0.5s; // [1]
     }
   }
 }
@@ -42,6 +50,7 @@ bolt-copy-to-clipboard {
 .c-bolt-copy-to-clipboard__trigger {
   display: block;
   transition: $bolt-copy-transition;
+  transition-delay: 0.5s; // [1]
 }
 
 .c-bolt-copy-to-clipboard__spinner,

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
@@ -4,6 +4,8 @@
 
 @import '@bolt/core';
 
+$bolt-copy-transition: all 0.5s ease;
+
 bolt-copy-to-clipboard {
   display: inline-block;
 }
@@ -23,26 +25,23 @@ bolt-copy-to-clipboard {
       left: 0;
       opacity: 1;
       transform: scale(1) rotate(360deg) translateY(-50%);
-      transition: all 0.5s ease 0.75s;
     }
   }
 
   &.is-copied.is-transitioning {
     .c-bolt-copy-to-clipboard__spinner {
       opacity: 0;
-      transition: opacity 1s ease;
     }
 
     .c-bolt-copy-to-clipboard__confirmation {
       opacity: 1;
-      transition: opacity 1s ease 0.75s;
     }
   }
 }
 
 .c-bolt-copy-to-clipboard__trigger {
   display: block;
-  transition: opacity 0.5s ease;
+  transition: $bolt-copy-transition;
 }
 
 .c-bolt-copy-to-clipboard__spinner,
@@ -51,6 +50,7 @@ bolt-copy-to-clipboard {
   position: absolute;
   pointer-events: none;
   opacity: 0;
+  transition: $bolt-copy-transition;
 }
 
 .c-bolt-copy-to-clipboard__spinner {

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
@@ -19,7 +19,7 @@ bolt-copy-to-clipboard {
   position: relative;
   text-align: left;
 
-  &.is-copying {
+  &.is-animating {
     .c-bolt-copy-to-clipboard__trigger {
       pointer-events: none;
       opacity: 0;
@@ -34,7 +34,7 @@ bolt-copy-to-clipboard {
     }
   }
 
-  &.is-copying.has-copied {
+  &.is-animating.is-successful {
     .c-bolt-copy-to-clipboard__spinner {
       opacity: 0;
       transition-delay: 0s; // [2]

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -36,15 +36,15 @@ export class BoltCopyToClipboard extends BoltComponent() {
       // Copying is already successful at this point.  Everything from here on is UX flair.
 
       // Show the "in progress" status.
-      this.parentElem.classList.add('is-copied');
+      this.parentElem.classList.add('is-copying');
 
       // Show the "success" status.
       setTimeout(() => {
-        this.parentElem.classList.add('is-transitioning');
+        this.parentElem.classList.add('has-copied');
 
         // Reset so the link can be used again without refreshing the page.
         setTimeout(() => {
-          this.parentElem.classList.remove('is-transitioning', 'is-copied');
+          this.parentElem.classList.remove('has-copied', 'is-copying');
         }, 3000);
       }, 1000);
     });

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -32,16 +32,21 @@ export class BoltCopyToClipboard extends BoltComponent() {
 
     this.clipboardInstance = new ClipboardJS(this.copyLink); // ClipboardJS adds it's own event listener
 
-    /*
-     * [1] Adds a class onClick after successful copy and enables the first set of animations
-     * [2] Waits until the first set of animations complete and adds the last class for last animations
-     */
     this.clipboardInstance.on('success', () => {
-      this.parentElem.classList.add('is-copied'); // [1]
+      // Copying is already successful at this point.  Everything from here on is UX flair.
+
+      // Show the "in progress" status.
+      this.parentElem.classList.add('is-copied');
+
+      // Show the "success" status.
       setTimeout(() => {
-        // [2]
         this.parentElem.classList.add('is-transitioning');
-      }, 2000);
+
+        // Reset so the link can be used again without refreshing the page.
+        setTimeout(() => {
+          this.parentElem.classList.remove('is-transitioning', 'is-copied');
+        }, 3000);
+      }, 1000);
     });
   }
 

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -36,15 +36,15 @@ export class BoltCopyToClipboard extends BoltComponent() {
       // Copying is already successful at this point.  Everything from here on is UX flair.
 
       // Show the "in progress" status.
-      this.parentElem.classList.add('is-copying');
+      this.parentElem.classList.add('is-animating');
 
       // Show the "success" status.
       setTimeout(() => {
-        this.parentElem.classList.add('has-copied');
+        this.parentElem.classList.add('is-successful');
 
         // Reset so the link can be used again without refreshing the page.
         setTimeout(() => {
-          this.parentElem.classList.remove('has-copied', 'is-copying');
+          this.parentElem.classList.remove('is-successful', 'is-animating');
         }, 3000);
       }, 1000);
     });

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
@@ -53,9 +53,8 @@
     } only %}
 
     <span class="{{ "#{baseClass}__confirmation" }}">
-      {% include "@bolt-components-link/link.twig" with {
+      {% include "@bolt-components-headline/text.twig" with {
         "text": copiedText,
-        "url": url,
         "icon": {
           "name": "check",
           "position": "before",

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
@@ -57,7 +57,7 @@
         "text": copiedText,
         "url": url,
         "icon": {
-          "name": "asset-link",
+          "name": "check",
           "position": "before",
           "size": iconSize
         },


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-554
http://vjira2:8080/browse/WWWD-2469
http://vjira2:8080/browse/WWWD-2468

## Summary

- Allow copy-to-clipboard to work multiple times
- Change icon on copy-to-clipboard when complete to indicate success

## Details

Aside from some general cleanup (like naming conventions), one important thing this PR does is modify the transitions somewhat.  I took the liberty of speeding them up a bit because I felt impatient when using them.

I also updated the CSS transition properties a bit.  There's a weird situation where we're trying to have something finishing animating out before the next thing animates in, which is why we have the transition delay properties.  Here's the difference:

Without any transition delay:
![copy-no-fade-in-delay](https://user-images.githubusercontent.com/677668/44597873-fbb17480-a785-11e8-8523-f1689e669c09.gif)

With transition delay:
![copy-with-fade-in-delay](https://user-images.githubusercontent.com/677668/44597879-00762880-a786-11e8-8075-3a2951ec8a10.gif)

I'm all ears if there's a better way to handle that.

## How to test

- Click the icon at https://feature-BDS-554-copy-to-clipboard-updates.bolt-design-system.com/pattern-lab/patterns/02-components-copy-to-clipboard-05-copy-to-clipboard/02-components-copy-to-clipboard-05-copy-to-clipboard.html
- Confirm that the icon changes when the copy is successful
- Confirm that the link resets after copying
- Confirm that the transitions work smoothly
