### PR TITLE
Fix: convert bolt-list to use the inner attributes convention

### DIFF
--- a/packages/components/bolt-list/src/list.twig
+++ b/packages/components/bolt-list/src/list.twig
@@ -7,6 +7,7 @@
 {# Variables #}
 {% set baseClass = "c-bolt-list" %}
 {% set attributes = create_attribute(attributes|default({})) %}
+{% set innerAttributes = create_attribute({}) %}
 
 {# Set up checks to validate that the component's prop values are allowed, based on the component's schema. #}
 {% set tagOptions = schema.properties.tag.enum %}
@@ -26,15 +27,6 @@
 {% set align = align in alignOptions ? align : schema.properties.align.default %}
 {% set valign = valign in valignOptions ? valign : schema.properties.valign.default %}
 
-{# Move utility classes to a separate attributes object so they can be added to the parent element. This is necessary for most utils to work as expected. #}
-{% set parentAttributes = create_attribute({}) %}
-{% for class in attributes["class"] %}
-  {% if class starts with "u-" %}
-    {% set parentAttributes = parentAttributes.addClass(class) %}
-    {% set attributes = attributes.removeClass(class) %}
-  {% endif %}
-{% endfor %}
-
 {# List component's custom element wrapper. #}
 <bolt-list
   {% if tag %} tag="{{ tag }}" {% endif %}
@@ -44,7 +36,7 @@
   {% if inset %} inset {% endif %}
   {% if align %} align="{{ align }}" {% endif %}
   {% if valign %} valign="{{ valign }}" {% endif %}
-  {{ parentAttributes }}
+  {{ attributes }}
 >
   {# This sets none values to not render anything. #}
   {% set spacing = spacing == "none" ? false : spacing %}
@@ -61,7 +53,7 @@
     valign in valignOptions ? "#{baseClass}--valign-#{valign}" : "",
   ] %}
 
-  <{{ tag }} {{ attributes.addClass(classes) }}>
+  <{{ tag }} {{ innerAttributes.addClass(classes) }}>
     {% for item in items %}
       <li class="{{ "#{baseClass}__item" }}">
         {{ item }}

--- a/packages/components/bolt-list/src/list.twig
+++ b/packages/components/bolt-list/src/list.twig
@@ -5,27 +5,27 @@
 {% endif %}
 
 {# Variables #}
-{% set baseClass = "c-bolt-list" %}
+{% set base_class = "c-bolt-list" %}
 {% set attributes = create_attribute(attributes|default({})) %}
-{% set innerAttributes = create_attribute({}) %}
+{% set inner_attributes = create_attribute({}) %}
 
 {# Set up checks to validate that the component's prop values are allowed, based on the component's schema. #}
-{% set tagOptions = schema.properties.tag.enum %}
-{% set displayOptions = schema.properties.display.enum %}
-{% set spacingOptions = schema.properties.spacing.enum %}
-{% set separatorOptions = schema.properties.separator.enum %}
-{% set insetOptions = schema.properties.inset.enum %}
-{% set alignOptions = schema.properties.align.enum %}
-{% set valignOptions = schema.properties.valign.enum %}
+{% set tag_options = schema.properties.tag.enum %}
+{% set display_options = schema.properties.display.enum %}
+{% set spacing_options = schema.properties.spacing.enum %}
+{% set separator_options = schema.properties.separator.enum %}
+{% set inset_options = schema.properties.inset.enum %}
+{% set align_options = schema.properties.align.enum %}
+{% set valign_options = schema.properties.valign.enum %}
 
 {# Check that the component's current prop values are valid. If not, default to the schema default #}
-{% set tag = tag in displayOptions ? tag : schema.properties.tag.default %}
-{% set display = display in displayOptions ? display : schema.properties.display.default %}
-{% set spacing = spacing in spacingOptions ? spacing : schema.properties.spacing.default %}
-{% set separator = separator in separatorOptions ? separator : schema.properties.separator.default %}
-{% set inset = inset in spacingOptions ? inset : schema.properties.inset.default %}
-{% set align = align in alignOptions ? align : schema.properties.align.default %}
-{% set valign = valign in valignOptions ? valign : schema.properties.valign.default %}
+{% set tag = tag in display_options ? tag : schema.properties.tag.default %}
+{% set display = display in display_options ? display : schema.properties.display.default %}
+{% set spacing = spacing in spacing_options ? spacing : schema.properties.spacing.default %}
+{% set separator = separator in separator_options ? separator : schema.properties.separator.default %}
+{% set inset = inset in spacing_options ? inset : schema.properties.inset.default %}
+{% set align = align in align_options ? align : schema.properties.align.default %}
+{% set valign = valign in valign_options ? valign : schema.properties.valign.default %}
 
 {# List component's custom element wrapper. #}
 <bolt-list
@@ -44,18 +44,18 @@
 
   {# Array of classes based on the defined + default props. #}
   {% set classes = [
-    baseClass,
-    display in displayOptions ? "#{baseClass}--display-#{display}" : "",
-    spacing in spacingOptions ? "#{baseClass}--spacing-#{spacing}" : "",
-    separator in separatorOptions ? "#{baseClass}--separator-#{separator}" : "",
-    inset == true ? "#{baseClass}--inset",
-    align in alignOptions ? "#{baseClass}--align-#{align}" : "",
-    valign in valignOptions ? "#{baseClass}--valign-#{valign}" : "",
+    base_class,
+    display in display_options ? "#{base_class}--display-#{display}" : "",
+    spacing in spacing_options ? "#{base_class}--spacing-#{spacing}" : "",
+    separator in separator_options ? "#{base_class}--separator-#{separator}" : "",
+    inset == true ? "#{base_class}--inset",
+    align in align_options ? "#{base_class}--align-#{align}" : "",
+    valign in valign_options ? "#{base_class}--valign-#{valign}" : "",
   ] %}
 
-  <{{ tag }} {{ innerAttributes.addClass(classes) }}>
+  <{{ tag }} {{ inner_attributes.addClass(classes) }}>
     {% for item in items %}
-      <li class="{{ "#{baseClass}__item" }}">
+      <li class="{{ "#{base_class}__item" }}">
         {{ item }}
       </li>
     {% endfor %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,9 +722,9 @@
     sleep-promise "^8.0.1"
 
 "@bolt/components-page-footer@file:packages/components/bolt-page-footer":
-  version "1.6.4"
+  version "1.7.0"
   dependencies:
-    "@bolt/core" "^1.6.4"
+    "@bolt/core" "^1.7.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -736,6 +736,12 @@
 "@nodelib/fs.stat@^1.0.1":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
+
+"@polymer/polymer@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@polymer/polymer/-/polymer-3.0.5.tgz#eaa42e70df7de818b5e1839452c82a5f83e39929"
+  dependencies:
+    "@webcomponents/shadycss" "^1.2.0"
 
 "@shellscape/koa-send@^4.1.0":
   version "4.1.3"
@@ -920,6 +926,10 @@
 "@webcomponents/custom-elements@^1.1.2":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.2.0.tgz#7fc8da6c8243b15b4f69c74c65dfe2a4996c694c"
+
+"@webcomponents/shadycss@^1.2.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.5.0.tgz#109e596027eed04bc5032414c9f094e1aeb9260e"
 
 "@webcomponents/shadydom@^1.1.0":
   version "1.1.3"


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-548

## Summary

Replace `parentAttributes` method in bolt-list with `inner_attributes`.

## Details

As discussed with @sghoweri and @remydenton, the `inner_attributes` method is the new standard of handling outer and inner attributes. By default, all attributes go to the parent container, `inner_attributes` only render the component specific class names.

In addition, I fixed some variable names to follow our conventions.

## How to test

Try to pass util classes (`u-bolt-whatever`) or other attributes to the bolt-list component and make sure they only get added to the `<bolt-list>` tag and not anything inside.
