### PR TITLE
Fix schema validation for sticky.

### DIFF
--- a/packages/components/bolt-sticky/src/sticky.twig
+++ b/packages/components/bolt-sticky/src/sticky.twig
@@ -1,5 +1,5 @@
 {% if enable_json_schema_validation %}
-  {{ validate_data_schema(bolt.data.components['@bolt-components-ordered-list'].schema, _self) | raw }}
+  {{ validate_data_schema(bolt.data.components['@bolt-components-sticky'].schema, _self) | raw }}
 {% endif %}
 
 {% set prefix = "c-bolt-" %}


### PR DESCRIPTION
## Summary

The wrong schema here will throw a 500 error when loading sticky with twig_debug enabled. This fixes it.

## How to test

Enabled twig_debug. View a page with the sticky component. It doesn't return a 500 error.