### PR TITLE
Limit access to bolt_connect admin pages.

### DIFF
--- a/packages/drupal-modules/bolt_connect/bolt_connect.routing.yml
+++ b/packages/drupal-modules/bolt_connect/bolt_connect.routing.yml
@@ -4,13 +4,13 @@ bolt_connect.info_page:
     _controller: '\Drupal\bolt_connect\Controller\BoltConnectController::customPage'
     _title: 'Bolt Connect Info'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer themes'
 bolt_connect.config_form:
   path: '/admin/config/bolt_connect/config'
   defaults:
     _form: '\Drupal\bolt_connect\BoltConnectForm'
     _title: 'Bolt Connect Config'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer themes'
   options:
     _admin_route: TRUE


### PR DESCRIPTION
## Summary

There are specialized admin users who don't need access to Bolt admin pages, and for whom it's just distracting.