### PR TITLE
Hotfix: WWWD-2469 copy to clipboard ie 11

### DIFF
--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -44,7 +44,8 @@ export class BoltCopyToClipboard extends BoltComponent() {
 
         // Reset so the link can be used again without refreshing the page.
         setTimeout(() => {
-          this.parentElem.classList.remove('is-successful', 'is-animating');
+          this.parentElem.classList.remove('is-successful');
+          this.parentElem.classList.remove('is-animating');
         }, 3000);
       }, 1000);
     });

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
@@ -53,8 +53,9 @@
     } only %}
 
     <span class="{{ "#{baseClass}__confirmation" }}">
-      {% include "@bolt-components-headline/text.twig" with {
+      {% include "@bolt-components-link/link.twig" with {
         "text": copiedText,
+        "url": url,
         "icon": {
           "name": "check",
           "position": "before",


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2469

## Summary

Fixes IE 11 bug where copy to clipboard was not resetting properly

## Details

In addition to updating javascript syntax to work with IE 11 (see https://stackoverflow.com/questions/11115998/is-there-a-way-to-add-remove-several-classes-in-one-single-instruction-with-clas), I also revert a change that turned the confirmation text into text rather than a link.  That is what we want long-term, but it introduced some regressions that I will deal with in http://vjira2:8080/browse/BDS-569.

## How to test

Go to `https://bug-wwwd-2469-copy-to-clipboard-ie-11.bolt-design-system.com/pattern-lab/?p=components-share-inline` in IE 11 and confirm that copy to clipboard resets as expected in IE 11.  Also confirm that the text "copied!" does not appear in the inline share component.
