### PR TITLE
BDS-575 Deprecate itemAlignment parameter in button component

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/card/00-card-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/00-card-docs.twig
@@ -26,7 +26,7 @@
       pattern: "button",
       style: "text",
       width: "full",
-      itemAlignment: "start",
+      align: "left",
       text: "Get the report"
     }
   ]

--- a/apps/pattern-lab/src/_patterns/02-components/card/00-card-docs.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/00-card-docs.twig
@@ -24,9 +24,7 @@
     },
     {
       pattern: "button",
-      style: "text",
       width: "full",
-      align: "left",
       text: "Get the report"
     }
   ]

--- a/apps/pattern-lab/src/_patterns/02-components/card/05-card.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/05-card.twig
@@ -26,7 +26,7 @@
       pattern: "button",
       style: "text",
       width: "full",
-      itemAlignment: "start",
+      align: "left",
       text: "Get the report"
     }
   ]

--- a/apps/pattern-lab/src/_patterns/02-components/card/05-card.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/05-card.twig
@@ -24,9 +24,7 @@
     },
     {
       pattern: "button",
-      style: "text",
       width: "full",
-      align: "left",
       text: "Get the report"
     }
   ]

--- a/apps/pattern-lab/src/_patterns/02-components/card/10-card-band-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/10-card-band-variation.twig
@@ -50,7 +50,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Button"
             }
           ]
@@ -166,7 +166,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -207,7 +207,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -248,7 +248,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -323,7 +323,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -364,7 +364,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -405,7 +405,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -479,7 +479,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -519,7 +519,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]
@@ -559,7 +559,7 @@
               pattern: "button",
               style: "text",
               width: "full",
-              itemAlignment: "start",
+              align: "left",
               text: "Get the report"
             }
           ]

--- a/apps/pattern-lab/src/_patterns/02-components/card/10-card-band-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/10-card-band-variation.twig
@@ -48,9 +48,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Button"
             }
           ]
@@ -164,9 +162,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -205,9 +201,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -246,9 +240,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -321,9 +313,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -362,9 +352,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -403,9 +391,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -477,9 +463,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -517,9 +501,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]
@@ -557,9 +539,7 @@
             },
             {
               pattern: "button",
-              style: "text",
               width: "full",
-              align: "left",
               text: "Get the report"
             }
           ]

--- a/apps/pattern-lab/src/_patterns/02-components/card/15-card-with-teaser.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/15-card-with-teaser.twig
@@ -18,12 +18,10 @@
       buttons: [
         {
           pattern: "button",
-          style: "primary",
           text: "CTA 1"
         },
         {
           pattern: "button",
-          style: "secondary",
           text: "CTA 2"
         }
       ]

--- a/apps/pattern-lab/src/_patterns/02-components/card/20-card-with-video.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/20-card-with-video.twig
@@ -31,7 +31,7 @@
         "pattern": "button",
         "style": "text",
         "width": "full",
-        "itemAlignment": "start",
+        "align": "left",
         "text": "Play or Pause",
         "attributes": {
           "on-click": "toggle",

--- a/apps/pattern-lab/src/_patterns/02-components/card/20-card-with-video.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/20-card-with-video.twig
@@ -29,9 +29,7 @@
       },
       {
         "pattern": "button",
-        "style": "text",
         "width": "full",
-        "align": "left",
         "text": "Play or Pause",
         "attributes": {
           "on-click": "toggle",

--- a/apps/pattern-lab/src/_patterns/04-pages/90-content-hub/anchor-ribbon-example.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/90-content-hub/anchor-ribbon-example.twig
@@ -158,9 +158,7 @@
                 },
                 {
                   pattern: "button",
-                  style: "text",
                   width: "full",
-                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -225,9 +223,7 @@
                 },
                 {
                   pattern: "button",
-                  style: "text",
                   width: "full",
-                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -290,9 +286,7 @@
                 },
                 {
                   pattern: "button",
-                  style: "text",
                   width: "full",
-                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -358,9 +352,7 @@
                 },
                 {
                   pattern: "button",
-                  style: "text",
                   width: "full",
-                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -423,9 +415,7 @@
                 },
                 {
                   pattern: "button",
-                  style: "text",
                   width: "full",
-                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -489,9 +479,7 @@
                 },
                 {
                   pattern: "button",
-                  style: "text",
                   width: "full",
-                  align: "left",
                   text: "Get the report"
                 }
               ]

--- a/apps/pattern-lab/src/_patterns/04-pages/90-content-hub/anchor-ribbon-example.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/90-content-hub/anchor-ribbon-example.twig
@@ -160,7 +160,7 @@
                   pattern: "button",
                   style: "text",
                   width: "full",
-                  itemAlignment: "start",
+                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -227,7 +227,7 @@
                   pattern: "button",
                   style: "text",
                   width: "full",
-                  itemAlignment: "start",
+                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -292,7 +292,7 @@
                   pattern: "button",
                   style: "text",
                   width: "full",
-                  itemAlignment: "start",
+                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -360,7 +360,7 @@
                   pattern: "button",
                   style: "text",
                   width: "full",
-                  itemAlignment: "start",
+                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -425,7 +425,7 @@
                   pattern: "button",
                   style: "text",
                   width: "full",
-                  itemAlignment: "start",
+                  align: "left",
                   text: "Get the report"
                 }
               ]
@@ -491,7 +491,7 @@
                   pattern: "button",
                   style: "text",
                   width: "full",
-                  itemAlignment: "start",
+                  align: "left",
                   text: "Get the report"
                 }
               ]

--- a/packages/components/bolt-button/button.schema.yml
+++ b/packages/components/bolt-button/button.schema.yml
@@ -61,11 +61,12 @@ properties:
     description: 'Use the align parameter instead.'
   align:
     title: 'Button Alignment'
+    description: 'How should content be horizontally aligned?  Note: the values <em>left</em> and <em>right</em> are <strong>DEPRECATED</strong>, use <em>start</em> and <em>end</em> instead.'
     type: string
     enum:
-      - left
+      - start
       - center
-      - right
+      - end
     default: center
   style:
     type: string

--- a/packages/components/bolt-button/button.schema.yml
+++ b/packages/components/bolt-button/button.schema.yml
@@ -4,6 +4,9 @@ description: 'Buttons are the core of our action components.'
 type: object
 required:
   - text
+not:
+  required:
+    - itemAlignment
 properties:
   attributes:
     type: object
@@ -53,6 +56,9 @@ properties:
       - medium
       - large
       - xlarge
+  itemAlignment:
+    title: 'DEPRECATED'
+    description: 'Use the align parameter instead.'
   align:
     title: 'Button Alignment'
     type: string

--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -174,7 +174,7 @@ bolt-button[width='full@small'],
   }
 }
 
-.c-bolt-button--left {
+.c-bolt-button--start {
   text-align: left;
 
   > *:last-child {
@@ -187,7 +187,7 @@ bolt-button[width='full@small'],
   }
 }
 
-.c-bolt-button--right {
+.c-bolt-button--end {
   text-align: right;
 
   > *:first-child {

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -10,13 +10,16 @@
 {% set baseClass = prefix ~ componentName %}
 {% set attributes = create_attribute(attributes|default({})) %}
 
-{# re-assign old itemAlignment paramater to the new `align` name that's replacing it; avoids breaking change till post v1.0 #}
-{# @todo Salem, is it safe to remove the coverage for legacy itemAlignment parameter? #}
+{# DEPRECATED.  Use the prooperty 'align' instead of 'itemAlignment'. #}
 {% if itemAlignment %}
-  {% if itemAlignment == "start" %}
-    {% set itemAlignment = "left" %}
-  {% endif %}
   {% set align = itemAlignment %}
+{% endif %}
+
+{# DEPRECATED.  Use the values 'start' and 'end' insted of 'left' and 'right'. #}
+{% if align == "left" %}
+ {% set align = "start" %}
+{% elseif align == "right" %}
+  {% set align = "end" %}
 {% endif %}
 
 {# set up psuedo self-validation by limiting param values to what's specifically allowed in the component schema #}

--- a/packages/components/bolt-card/src/card.twig
+++ b/packages/components/bolt-card/src/card.twig
@@ -141,7 +141,7 @@
 
           {% for item in _items if item.pattern in _allowedCardFooterItems %}
             {% set paramOverrides = {
-              itemAlignment: "left",
+              align: "left",
               style: "text",
             } %}
 

--- a/packages/components/bolt-card/src/card.twig
+++ b/packages/components/bolt-card/src/card.twig
@@ -141,7 +141,7 @@
 
           {% for item in _items if item.pattern in _allowedCardFooterItems %}
             {% set paramOverrides = {
-              align: "left",
+              align: "start",
               style: "text",
             } %}
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-575

## Summary

- Deprecates `itemAlignment` property of button component.  Use `align` instead.
- Deprecates `left` and `right` values for `align` property.  Use `start` and `end` instead.

## Details

More important than this specific deprecation is that we're defining the workflow for deprecation.  The steps in this PR create the deprecation; after it's merged, I'll create an additional PR against 2.x to remove support for the deprecated parameter.

I've created this page in the wiki to describe the whole process: https://github.com/bolt-design-system/bolt/wiki/Deprecating-component-properties

## How to test

1. Confirm schema shows as invalid if there's any usage of `itemAlignment`
    - Check out this branch
    - Add `itemAlignment: "start"` to button (anywhere it is removed in this PR)
    - Run `cd apps/pattern-lab` and `npm run start`.  The build should fail due to schema errors

2. Confirm the deprecated parameter can still be used
    - Stop pattern lab
    - In `apps/pattern-lab/.boltrc.js`, set `schemaErrorReporting` to `console`
    - Run `cd apps/pattern-lab` and `npm run start`.  The build should work, deprecated parameters should function as they have in the past, and schema validation errors should be shown in the browser console when viewing pattern lab pages that use the deprecated parameter.