### PR TITLE
fix: prevent device viewer from overlapping bg video WWWD-2574

### DIFF
--- a/packages/components/bolt-device-viewer/src/device-viewer.scss
+++ b/packages/components/bolt-device-viewer/src/device-viewer.scss
@@ -13,6 +13,7 @@ bolt-device-viewer {
   height: auto; // Based on inner contents + padding;
   margin: 0 auto;
   box-sizing: content-box; //Required for now till device viewer updated to be fluid in size.
+  transform: translate3d(0, 0, 0); // Ensures correct z-index positioning
 }
 
 .c-bolt-device-viewer__inner {


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2574

## Summary

Fixes z-index regression where device viewer overlaps band background video

## Details

Honestly, it's unclear to me why this works.  
