### PR TITLE
Fix / Refactor Button Component's Rounded / Icon Only Options

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/button/45-button-icon-only.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/45-button-icon-only.twig
@@ -1,0 +1,25 @@
+{% set schema = bolt.data.components['@bolt-components-button'].schema %}
+
+<p>Icon-only buttons display just an icon + visually hidden text if any text content is defined.</p>
+
+{% set icon_only_options = [
+  true,
+  false
+] %}
+
+{% for option in icon_only_options %}
+  {% include "@bolt-components-text/text.twig" with {
+    text: "Icon Only? #{option == true ? 'True' : 'False'}",
+    headline: true
+  } %}
+
+  {% include "@bolt-components-button/button.twig" with {
+    iconOnly: option == true ? true : false,
+    text: "Icon Only: " ~ option == true ? "True" : "False",
+    rounded: "rounded",
+    size: "small",
+    icon: {
+      name: "close"
+    }
+  } only %}
+{% endfor %}

--- a/packages/components/bolt-button/button.schema.yml
+++ b/packages/components/bolt-button/button.schema.yml
@@ -87,5 +87,6 @@ properties:
     type: boolean
     title: 'Icon Only?'
     description: 'Is this an icon-only button (with visually hidden text)?'
+    default: false
     required:
       - icon

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -79,8 +79,7 @@ class BoltButton extends withHyperHtml() {
   }
 
   render() {
-    const classes = cx({
-      'c-bolt-button': true,
+    const classes = cx('c-bolt-button', {
       'c-bolt-button--rounded': this.props.rounded,
       'c-bolt-button--disabled': this.props.disabled,
       'c-bolt-button--icon-only': this.props.iconOnly,
@@ -104,14 +103,11 @@ class BoltButton extends withHyperHtml() {
     let buttonElement;
     const self = this;
 
-    const itemClasses = cx({
-      'c-bolt-button__item': true,
+    const itemClasses = cx('c-bolt-button__item', {
       'u-bolt-visuallyhidden': this.props.iconOnly,
     });
 
-    const iconClasses = cx({
-      'c-bolt-button__icon': true,
-    });
+    const iconClasses = cx('c-bolt-button__icon');
 
     const slotMarkup = name => {
       if (name in this.slots) {

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -104,16 +104,25 @@ class BoltButton extends withHyperHtml() {
     let buttonElement;
     const self = this;
 
+    const itemClasses = cx({
+      'c-bolt-button__item': true,
+      'u-bolt-visuallyhidden': this.props.iconOnly,
+    });
+
+    const iconClasses = cx({
+      'c-bolt-button__icon': true,
+    });
+
     const slotMarkup = name => {
       if (name in this.slots) {
         switch (name) {
           case 'before':
           case 'after':
             return wire(this)`
-              <span class="c-bolt-button__icon">${this.slot(name)}</span>`;
+              <span class="${iconClasses}">${this.slot(name)}</span>`;
           default:
             return wire(this)`
-              <span class="c-bolt-button__item">${this.slot('default')}</span>`;
+              <span class="${itemClasses}">${this.slot('default')}</span>`;
         }
       }
     };

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -109,7 +109,7 @@
   {% if size %} size="{{ size }}" {% endif %}
   {% if url %} url="{{ url }}" {% endif %}
   {% if width %} width="{{ width }}" {% endif %}
-  {% if rounded %} rounded=" {{ rounded }}" {% endif %}
+  {% if rounded %} rounded="{{ rounded }}" {% endif %}
   {% if iconOnly %} icon-only="true" {% endif %}
   {% if transform %} transform="{{ transform }}" {% endif %}
   {% if disabled == true %} disabled {% endif %}

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -61,6 +61,7 @@
   style in styleOptions ? "c-bolt-button--#{style}" : "c-bolt-button--#{schema.properties.style.default}",
   transform in transformOptions and transform != "none" ? "c-bolt-button--#{transform}": "",
   align in alignOptions ? baseClass ~ "--" ~ align : "",
+  iconOnly ? "c-bolt-button--icon-only": "",
 ] %}
 
 {% if disabled %}

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -25,10 +25,11 @@
 {% set transformOptions = schema.properties.transform.enum %}
 {% set widthOptions = schema.properties.width.enum %}
 {% set iconPositions = schema.properties.icon.properties.position.enum %}
+{% set iconOnlyOptions = schema.properties.iconOnly.enum %}
 
 {# check if the value set to a prop is allowed or defined. if not, default to the default value specified in the component's schema (if one exists) #}
 {% set align = align in alignOptions ? align : schema.properties.align.default %}
-{% set iconOnly = iconOnly | default(false) %}
+{% set iconOnly = iconOnly is sameas(true) or iconOnly is sameas(false) ? iconOnly : scheuma.properties.iconOnly.default %}
 {% set size = size in sizeOptions ? size : schema.properties.size.default %}
 {% set style = style in styleOptions ? style : schema.properties.style.default %}
 {% set tag = tag in tagOptions ? tag : schema.properties.tag.default %}


### PR DESCRIPTION
## Summary
Fixes a few things I noticed with the Button Component's `iconOnly` and `rounded` props (but mostly relating to the `iconOnly` prop). 

## Details
Besides fixing a whitespace issue I noticed in the button component's Twig template (causing issues with the `rounded` prop) and adding a missing visually hidden utility class inside the rendered web component, this PR includes two main changes:

1. Adds a new Pattern Lab demo showing the `icon-only` option that shipped in the Button component in Bolt v0.x but, for whatever reason I can't seem to figure out, doesn't appear to ever have been migrated over to Bolt v1.x's instance of Pattern Lab (even the earliest 1.x releases we've made)

2. Updates the classnames in the Button component's JS to all get run through the new `classnames` NPM package being introduced in Bolt 2.0. Why not just hard code these? 

Well this particular package includes a [nifty feature](https://github.com/JedWatson/classnames#alternate-bind-version-for-css-modules) that wires up our classnames to automatically support CSS Modules if / when we enable this feature in our Webpack build: https://github.com/webpack-contrib/css-loader#modules

## How to test
Review the button component demos in Pattern Lab to confirm the icon-only and rounded options work as expected -- both the Twig-based versions of these button component options but also the custom element version of these (that's how I first encountered this particular issue)


Side note @mikemai2awesome @remydenton -- I kinda think we should backport these fixes and updates back over to the Bolt v1.x branch after this gets merged in (all except for the changes made to the `packages/components/bolt-button/src/button.standalone.js` file -- since that was refactored as part of the Bolt v2.0 updates); thoughts?
