### PR TITLE
chore: update `npm run clean` task to remove `composer.lock` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "postbootstrap": "yarn run build:icons && yarn run build:uikit && node scripts/monorepo-tests.js",
     "Xpredeploy": "yarn run build",
     "deploy": "./scripts/deploy.js",
-    "clean:git": "git clean -xdf && rm -rf apps/**/vendor apps/**/node_modules && find . -empty -type d -delete",
+    "clean:git": "git clean -xdf && rm -rf apps/**/vendor apps/**/node_modules apps/**/composer.lock && find . -empty -type d -delete",
     "clean:lerna": "npx lerna clean --yes",
     "clean": "npm run clean:lerna && npm run clean:git",
     "prepublishOnly": "yarn run build && node scripts/monorepo-tests.js",


### PR DESCRIPTION
Update for this was based on an error @margoromo and I encountered (relating to a missing composer dependency) while we were doing a fresh from-scratch install of Bolt locally.

CC @remydenton 
