### PR TITLE
fix: update all link colors on dark themes to be white

### DIFF
--- a/apps/pattern-lab/src/styles/_docs.scss
+++ b/apps/pattern-lab/src/styles/_docs.scss
@@ -108,16 +108,6 @@
   }
 }
 
-.c-bolt-docs__readme {
-  a {
-    color: var(--bolt-theme-link-default, var(--bolt-theme-link, #545da6));
-
-    &:hover {
-      color: var(--bolt-theme-link-hover, var(--bolt-theme-link, #545da6))
-    }
-  }
-}
-
 .c-bolt-docs__page-nav {
   -ms-grid-row: 2; /* [1] */
   -ms-grid-row-span: 1; /* [1] */

--- a/packages/core/styles/01-settings/settings-themes/index.scss
+++ b/packages/core/styles/01-settings/settings-themes/index.scss
@@ -11,7 +11,7 @@ $bolt-theme-ui-colors: (
     disabled: bolt-color(gray, light),
     headline-link: bolt-color(white),
     headline: bolt-color(white),
-    link: bolt-color(yellow),
+    link: bolt-color(white),
     primary: bolt-color(yellow),
     secondary: bolt-color(white),
     text-disabled: bolt-color(gray),


### PR DESCRIPTION
Updates all link colors on dark themes to be white (not just headline links). 

This was an intentional design decision made on the v1.x version of Bolt that needs to carry over to the v2.x version.