### PR TITLE
Fix: bolt-list margin overflow

### DIFF
--- a/packages/components/bolt-list/index.scss
+++ b/packages/components/bolt-list/index.scss
@@ -1,1 +1,2 @@
+@import '@bolt/core';
 @import 'src/list.scss';

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -1,5 +1,3 @@
-@import '@bolt/core';
-
 /* ------------------------------------ *\
    List
 \* ------------------------------------ */
@@ -46,21 +44,21 @@
 @each $spacing-value in $bolt-spacing-values {
   $spacing-value-name: nth($spacing-value, 1);
   .c-bolt-list--spacing-#{$spacing-value-name} {
-    margin-right: bolt-spacing(#{$spacing-value-name}) * -1;
+    margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
     margin-bottom: bolt-v-spacing(#{$spacing-value-name}) * -1;
 
     .c-bolt-list__item {
-      @include bolt-margin-right(#{$spacing-value-name});
+      @include bolt-margin-left(#{$spacing-value-name});
       @include bolt-margin-bottom(#{$spacing-value-name});
     }
   }
 
   .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--inset {
-    @include bolt-margin-right(0);
+    @include bolt-margin-left(0);
     @include bolt-margin-bottom(0);
 
     .c-bolt-list__item {
-      @include bolt-margin-right(0);
+      @include bolt-margin-left(0);
       @include bolt-margin-bottom(0);
       @include bolt-padding(#{$spacing-value-name});
     }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-634

## Summary

Remove margin overflow from bolt-list that breaks page layout.

## Details

Margin-right was used before to determine space between items, this actually pokes out of its container and messes up the layout. The method has been changed to margin-left instead and there is no overflow issue.

## How to test

Pull down the branch and navigate to the List component view all page, make sure there is no side scrolling whatsoever.
