### PR TITLE
fix: Fix icon color in Edge

### DIFF
--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -34,8 +34,7 @@ bolt-icon {
   height: 1em;
   box-sizing: border-box;
   z-index: bolt-z-index('content');
-  color: currentColor;
-  color: var(--bolt-theme-icon, inherit);
+  color: var(--bolt-theme-icon);
   pointer-events: none;
 }
 

--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -35,7 +35,7 @@ bolt-icon {
   box-sizing: border-box;
   z-index: bolt-z-index('content');
   color: currentColor;
-  color: var(--bolt-theme-icon, currentColor);
+  color: var(--bolt-theme-icon, inherit);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2624
http://vjira2:8080/browse/WWWD-2625

## Summary

Fix incorrect icon color in Edge

## How to test

### Reproduce the bug
- In Edge, go to `pattern-lab/?p=components-headline-link-variations` on the 2.x branch before this commit.  Confirm the icons are missing.

![screen shot 2018-09-25 at 11 06 01 am](https://user-images.githubusercontent.com/677668/46033422-088df480-c0b3-11e8-857f-1e34280b634a.png)


### Confirm the fix
- In Edge, go to `pattern-lab/?p=components-headline-link-variations` on this branch.  Confirm the icons are present.

![screen shot 2018-09-25 at 11 05 17 am](https://user-images.githubusercontent.com/677668/46033440-104d9900-c0b3-11e8-8aba-fb200e08f36d.png)

