### PR TITLE
Fix: add transition to bolt-share link styles

### DIFF
--- a/packages/components/bolt-share/src/share.scss
+++ b/packages/components/bolt-share/src/share.scss
@@ -47,6 +47,7 @@ $bolt-share-opacity: 100, 80, 60, 40, 20;
   color: bolt-theme(link);
   text-decoration: none;
   white-space: nowrap;
+  transition: opacity $bolt-transition;
 
   &:hover {
     opacity: $bolt-global-link-hover-opacity;


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixes a bug that the `bolt-share` links don't have any transition defined.

## Details

Adding in the global transition for the `bolt-share` CSS, so that it feels consistent with other links.

## How to test

Pull down the branch and navigate to the Share view all page, hover over the links to see the smooth transition.
