### PR TITLE
WWWD-2633 Ensure background overlay covers entire background

### DIFF
--- a/packages/components/bolt-background/src/background.scss
+++ b/packages/components/bolt-background/src/background.scss
@@ -158,11 +158,14 @@ $bolt-bg-shape-offset-side-large: $bolt-bg-shape-offset-bottom-large * 1.2;
 .c-bolt-background__overlay {
   display: block;
   position: absolute;
-  top: 0;
-  left: 0;
-  transform: translate3d(0, 0, 0); // Help prevent rounding errors when rendering (ie. gaps)
-  width: 100%;
-  height: 100%;
+
+  // This overlay has a history of rounding errors (which can leave a stripe on one side of the background that's not
+  // covered by the overlay).  The following is a hack that all but guarantees that can't happen.
+  top: -1px;
+  left: -1px;
+  right:  -1px;
+  bottom: -1px;
+
   content: '';
 }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2633

## Summary

Ensure background overlay covers entire background

## Details

This feels like a legitimate bug in Chrome, but I wasn't able to find any reports of it.  The solution is certainly hacky-- I'm open to other suggestions.

## How to test

The most reliable way to reproduce the issue for me was to go to these three pages in Chrome version 69 (you may have to adjust the width of your browser as it comes and goes). 

https://www.pega.com/
https://www1.pega.com/products/crm-applications/marketing
https://www1.pega.com/services/partnerships

The brief test is to manually apply the CSS updates from this PR using developer tools.  For full testing, review Bolt pages that have backgrounds with overlays across different browsers.