### PR TITLE
fix: Allow any class not starting with "c-bolt-" in button component

### DIFF
--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -86,7 +86,7 @@
     {% set outerClasses = outerClasses|merge([class]) %}
   {% elseif class starts with "is-" or class starts with "has-" %}
     {% set innerClasses = innerClasses|merge([class]) %}
-  {% elseif not class starts with "c-bolt-" %}
+  {% elseif class starts with "c-bolt-" == false %}
     {% set outerClasses = outerClasses|merge([class]) %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2643

## Summary

Fix button CSS class logic to allow classes not starting with `c-bolt-` to be added 

## How to test

### Confirm the bug
Create a button with the following markup on the master branch.  Confirm that "my-test-class" is not added to the button:
```
{% include '@bolt/button.twig' with {
  text: 'test',
  attributes: {
    class: 'my-test-class'
  }
} only %}
```

### Confirm the fix
Use the same markup as above on this branch.  Confirm that "my-test-class" appears on the `<bolt-button>` custom element.