### PR TITLE
WWWD-2642 Prevent icon from overlapping background video

### DIFF
--- a/apps/pattern-lab/src/_patterns/04-pages/05-homepage/-01-homepage-w-background-video.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/05-homepage/-01-homepage-w-background-video.twig
@@ -182,7 +182,7 @@
       text: "What's Trending",
       size: "xlarge",
       tag: "h3",
-      iconName: "marketing"
+      icon: "marketing"
     } only %}
     {% include "@bolt/button.twig" with {
       text: "Toggle video",

--- a/apps/pattern-lab/src/_patterns/04-pages/05-homepage/-01-homepage-w-background-video.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/05-homepage/-01-homepage-w-background-video.twig
@@ -181,7 +181,8 @@
     {% include "@bolt/headline.twig" with {
       text: "What's Trending",
       size: "xlarge",
-      tag: "h3"
+      tag: "h3",
+      iconName: "marketing"
     } only %}
     {% include "@bolt/button.twig" with {
       text: "Toggle video",

--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -7,6 +7,7 @@ bolt-icon {
   transition: inherit;
   width: 1em; // Default icon size if size prop not specified
   height: 1em; // Default icon size if size prop not specified
+  transform: translate3d(0, 0, 0); // Create a stacking context to scope internal z-index values.
 
   &:not(:resolved){
     padding-bottom: 100%; // Default square icons


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2642

## Summary

Prevent icons from overlapping background video

## Details

This creates a stacking context for icons.  Approach is based on #864 where a similar issue was seen with device viewer overlapping the background video.

## How to test

### Reproduce the issue
- On this branch, go to `/pattern-lab/?p=pages-homepage-w-background-video`.  Confirm that you see a `marketing` icon to the right of the text "What's Trending".
- In browser developer tools, inspect the icon and disable the line "transform: translate3d(0, 0, 0);" on the `<bolt-icon>` element (the fix in this PR's second commit).
- Click "Toggle Video" to open the video
- Confirm that the marketing icon displays on top of the video

### Confirm the fix
- Reload `/pattern-lab/?p=pages-homepage-w-background-video` to clear the changes made in developer tools
- Click "Toggle Video" to open the video
- Confirm that the marketing icon does NOT display on top of the video
