### PR TITLE
fix: Allow explicit icon color attributes to work in IE

### DIFF
--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -107,24 +107,38 @@ bolt-icon[size='xlarge'],
   $brand-color: bolt-color(teal);
   $contrast-color: bolt-text-contrast($brand-color);
 
+  // Fallback styles for browsers that don't support CSS variables.
   color: $contrast-color;
-
   .c-bolt-icon__background-shape {
     background-color: $brand-color;
     opacity: 1;
   }
+
+  // CSS variables for browsers that do support them.
+  @include bolt-css-vars((
+    --bolt-theme-icon: $contrast-color,
+    --bolt-theme-icon-background: $brand-color,
+    --bolt-theme-icon-background-opacity: 1,
+  ));
 }
 
 .c-bolt-icon--blue {
   $brand-color: bolt-color(blue);
   $contrast-color: bolt-text-contrast($brand-color);
 
+  // Fallback styles for browsers that don't support CSS variables.
   color: $brand-color;
-
   .c-bolt-icon__background-shape {
     color: $contrast-color;
     opacity: 1;
   }
+
+  // CSS variables for browsers that do support them.
+  @include bolt-css-vars((
+    --bolt-theme-icon: $brand-color,
+    --bolt-theme-icon-background: $contrast-color,
+    --bolt-theme-icon-background-opacity: 1,
+  ));
 }
 
 .c-bolt-icon__background {

--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -107,22 +107,24 @@ bolt-icon[size='xlarge'],
   $brand-color: bolt-color(teal);
   $contrast-color: bolt-text-contrast($brand-color);
 
-  @include bolt-css-vars((
-    --bolt-theme-icon: $contrast-color,
-    --bolt-theme-icon-background: $brand-color,
-    --bolt-theme-icon-background-opacity: 1,
-  ));
+  color: $contrast-color;
+
+  .c-bolt-icon__background-shape {
+    background-color: $brand-color;
+    opacity: 1;
+  }
 }
 
 .c-bolt-icon--blue {
   $brand-color: bolt-color(blue);
+  $contrast-color: bolt-text-contrast($brand-color);
+
   color: $brand-color;
 
-  @include bolt-css-vars((
-    --bolt-theme-icon: $brand-color,
-    --bolt-theme-icon-background: bolt-text-contrast($brand-color),
-    --bolt-theme-icon-background-opacity: 1,
-  ));
+  .c-bolt-icon__background-shape {
+    color: $contrast-color;
+    opacity: 1;
+  }
 }
 
 .c-bolt-icon__background {

--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -1,10 +1,5 @@
 @import '@bolt/core';
 
-// Dev Notes
-// 1. Fallback if CSS vars are not supported.
-// 2. Property is re-declared so that CSS variable values will take precedence over hard-coded values for fallback
-//    browsers.  Remove this line when support for browsers that don't support CSS vars is dropped.
-
 bolt-icon {
   display: inline-block;
   vertical-align: middle;
@@ -88,11 +83,14 @@ bolt-icon[size='xlarge'],
   padding-bottom: 100%;
   transform: translate3d(-50%, -50%, 0);
 
-  opacity: 0.1; // [1]
-  opacity: var(--bolt-theme-icon-background-opacity, 0.1);
+  // Fallback if CSS vars are not supported.
+  opacity: 0.1;
+  background-color: currentColor;
 
-  background-color: currentColor; // [1]
-  background-color: var(--bolt-theme-icon-background, var(--bolt-theme-primary-text-default, currentColor));
+  @supports(--css: variables) {
+    opacity: var(--bolt-theme-icon-background-opacity, 0.1);
+    background-color: var(--bolt-theme-icon-background, var(--bolt-theme-primary-text-default, currentColor));
+  }
 }
 
 .c-bolt-icon__background-shape--circle {
@@ -111,20 +109,29 @@ bolt-icon[size='xlarge'],
   $brand-color: bolt-color(teal);
   $contrast-color: bolt-text-contrast($brand-color);
 
+  // Fallbacks if CSS vars are not supported.
+  color: $contrast-color;
+
+  .c-bolt-icon__background-shape {
+    background-color: $brand-color;
+    opacity: 1;
+  }
+
   @include bolt-css-vars((
     --bolt-theme-icon: $contrast-color,
     --bolt-theme-icon-background: $brand-color,
     --bolt-theme-icon-background-opacity: 1,
   ));
 
-  color: $contrast-color; // [1]
-  color: var(--bolt-theme-icon); // [2]
+  // Properties must be re-declared here so that CSS variable values will take precedence over hard-coded values for
+  // fallback browsers.  Remove this when support for browsers that don't support CSS vars is dropped.
+  @supports(--css: variables) {
+    color: var(--bolt-theme-icon);
 
-  .c-bolt-icon__background-shape {
-    background-color: $brand-color; // [1]
-    background-color: var(--bolt-theme-icon-background); // [2]
-    opacity: 1; // [1]
-    opacity: var(--bolt-theme-icon-background-opacity); // [2]
+    .c-bolt-icon__background-shape {
+      background-color: var(--bolt-theme-icon-background);
+      opacity: var(--bolt-theme-icon-background-opacity);
+    }
   }
 }
 
@@ -132,20 +139,29 @@ bolt-icon[size='xlarge'],
   $brand-color: bolt-color(blue);
   $contrast-color: bolt-text-contrast($brand-color);
 
+  // Fallbacks if CSS vars are not supported.
+  color: $brand-color;
+
+  .c-bolt-icon__background-shape {
+    background-color: $contrast-color;
+    opacity: 1;
+  }
+
   @include bolt-css-vars((
     --bolt-theme-icon: $brand-color,
     --bolt-theme-icon-background: $contrast-color,
     --bolt-theme-icon-background-opacity: 1,
   ));
 
-  color: $brand-color; // [1]
-  color: var(--bolt-theme-icon); // [2]
+  // Properties must be re-declared here so that CSS variable values will take precedence over hard-coded values for
+  // fallback browsers.  Remove this when support for browsers that don't support CSS vars is dropped.
+  @supports(--css: variables) {
+    color: var(--bolt-theme-icon);
 
-  .c-bolt-icon__background-shape {
-    background-color: $contrast-color; // [1]
-    background-color: var(--bolt-theme-icon-background); // [2]
-    opacity: 1; // [1]
-    opacity: var(--bolt-theme-icon-background-opacity); // [2]
+    .c-bolt-icon__background-shape {
+      background-color: var(--bolt-theme-icon-background);
+      opacity: var(--bolt-theme-icon-background-opacity);
+    }
   }
 }
 

--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -1,5 +1,9 @@
 @import '@bolt/core';
 
+// Dev Notes
+// 1. Fallback if CSS vars are not supported.
+// 2. Property is re-declared so that CSS variable values will take precedence over hard-coded values for fallback
+//    browsers.  Remove this line when support for browsers that don't support CSS vars is dropped.
 
 bolt-icon {
   display: inline-block;
@@ -84,10 +88,10 @@ bolt-icon[size='xlarge'],
   padding-bottom: 100%;
   transform: translate3d(-50%, -50%, 0);
 
-  opacity: 0.1;
+  opacity: 0.1; // [1]
   opacity: var(--bolt-theme-icon-background-opacity, 0.1);
 
-  background-color: currentColor; // Fallback if CSS vars not supported
+  background-color: currentColor; // [1]
   background-color: var(--bolt-theme-icon-background, var(--bolt-theme-primary-text-default, currentColor));
 }
 
@@ -107,38 +111,42 @@ bolt-icon[size='xlarge'],
   $brand-color: bolt-color(teal);
   $contrast-color: bolt-text-contrast($brand-color);
 
-  // Fallback styles for browsers that don't support CSS variables.
-  color: $contrast-color;
-  .c-bolt-icon__background-shape {
-    background-color: $brand-color;
-    opacity: 1;
-  }
-
-  // CSS variables for browsers that do support them.
   @include bolt-css-vars((
     --bolt-theme-icon: $contrast-color,
     --bolt-theme-icon-background: $brand-color,
     --bolt-theme-icon-background-opacity: 1,
   ));
+
+  color: $contrast-color; // [1]
+  color: var(--bolt-theme-icon); // [2]
+
+  .c-bolt-icon__background-shape {
+    background-color: $brand-color; // [1]
+    background-color: var(--bolt-theme-icon-background); // [2]
+    opacity: 1; // [1]
+    opacity: var(--bolt-theme-icon-background-opacity); // [2]
+  }
 }
 
 .c-bolt-icon--blue {
   $brand-color: bolt-color(blue);
   $contrast-color: bolt-text-contrast($brand-color);
 
-  // Fallback styles for browsers that don't support CSS variables.
-  color: $brand-color;
-  .c-bolt-icon__background-shape {
-    color: $contrast-color;
-    opacity: 1;
-  }
-
-  // CSS variables for browsers that do support them.
   @include bolt-css-vars((
     --bolt-theme-icon: $brand-color,
     --bolt-theme-icon-background: $contrast-color,
     --bolt-theme-icon-background-opacity: 1,
   ));
+
+  color: $brand-color; // [1]
+  color: var(--bolt-theme-icon); // [2]
+
+  .c-bolt-icon__background-shape {
+    background-color: $contrast-color; // [1]
+    background-color: var(--bolt-theme-icon-background); // [2]
+    opacity: 1; // [1]
+    opacity: var(--bolt-theme-icon-background-opacity); // [2]
+  }
 }
 
 .c-bolt-icon__background {


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-704

## Summary

Fixes and provides full cross-browser parity for blue and teal icons in IE

## Details

These attributes should be the last conceivable stage at which a color CSS variable might be set, i.e. any contextual CSS variables shouldn't make a difference.  We might as well keep it simple AND have parity across browsers then by just setting color values normally.

## How to test

### Confirm the bug
- In IE 11, go to
https://boltdesignsystem.com/pattern-lab/patterns/02-components-icon-15-icon-theme-background-shape-variations/02-components-icon-15-icon-theme-background-shape-variations.html
- Confirm that the blue and teal icons do not match other browsers and have accessibility issues on dark backgrounds:
![screen shot 2018-10-09 at 9 28 50 am](https://user-images.githubusercontent.com/677668/46683750-d649c000-cba5-11e8-91bb-e8ea0266b81f.png)

### Confirm the fix
- In IE 11, go to `/pattern-lab/patterns/02-components-icon-15-icon-theme-background-shape-variations/02-components-icon-15-icon-theme-background-shape-variations.html` on this PR branch once it builds
- Confirm that the blue and teal icons have full parity with other browsers
![screen shot 2018-10-09 at 9 30 28 am](https://user-images.githubusercontent.com/677668/46683831-0729f500-cba6-11e8-9974-7da4689bbbb2.png)
