### PR TITLE
Fix: Add Default `row_start` Band Component's `content`

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/band/band-w-pinned-content/70-band-w-pinned-content--via-combined-content-and-items-data-example.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/band/band-w-pinned-content/70-band-w-pinned-content--via-combined-content-and-items-data-example.twig
@@ -13,17 +13,22 @@
       },
       content: include("@pl/_share-component-for-event-example.twig"),
     },
-    [
-      include("@pl/_band-for-event-example.twig"),
-      include("@bolt-components-headline/text.twig", {
-        text: "^ via Twig Include, combined content into single items array, doesn't use <code>content</code> field",
-        tag: "p",
-        attributes: {
-          class: [
-            "u-bolt-margin-top-medium"
-          ]
-        }
-      }),
-    ] | join("")
+    {
+      position: {
+        row_start: 2,
+      },
+      content: [
+        include("@pl/_band-for-event-example.twig"),
+        include("@bolt-components-headline/text.twig", {
+          text: "^ via Twig Include, combined content into single items array, doesn't use <code>content</code> field",
+          tag: "p",
+          attributes: {
+            class: [
+              "u-bolt-margin-top-medium"
+            ]
+          }
+        }),
+      ] | join("")  
+    },
   ]
 } only %}

--- a/packages/components/bolt-band/band.schema.yml
+++ b/packages/components/bolt-band/band.schema.yml
@@ -50,6 +50,10 @@ properties:
       - small
       - medium
       - large
+  content_row_start:
+    description: "Configures which row the Band Component's legacy <code>content</code> Twig block should be 'automatically' displayed on. Under the hood, this identical to the <a href='https://github.com/bolt-design-system/bolt/blob/master/packages/components/bolt-grid/grid-item.schema.yml#L34' target='_blank'>Grid Item's</a> <code>row_start</code> config."
+    type: string
+    default: 2
   items:
     type: array
     description: "Array of content items to display inside the band component. Internally this uses the new <code>&lt;bolt-grid&gt;</code> component to handle layout."

--- a/packages/components/bolt-band/src/band.twig
+++ b/packages/components/bolt-band/src/band.twig
@@ -50,7 +50,12 @@
         {# merge together array of items with the content / band_content block so each item can get wrapped properly #}
         {% set items = items | default([]) %}
         {% if  block('band_content') | length > 0 %}
-          {% set items = items | merge([block_band_content]) %}
+          {% set items = items | merge([{
+            content: block_band_content,
+            position: {
+              row_start: content_row_start ? content_row_start : schema.properties.row_start.default
+            }
+          }]) %}
         {% endif %}
 
         {% if items is not empty %}


### PR DESCRIPTION
## Jira
Related to http://vjira2:8080/browse/WWWD-2674

## Summary
Adds a default `row_start` position value if no `content_row_start` config option is specified in the Band component.  

## How to test
Test band + social share examples using the new CSS Grid to confirm proper placement in IE 11 + Chrome.