### PR TITLE
Fix: bolt-video play button icon subpixel bug

### DIFF
--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -73,8 +73,8 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
 
         display: block;
         position: absolute;
-        width: 100%;
-        height: 100%;
+        width: calc(100% + 4px);
+        height: calc(100% + 4px);
         content: '';
       }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2678

## Summary

Adjusts the size of the video play button icon to ensure it looks consistent across all screen sizes.

## Details

Due to the complexity of making the button scale with the video width, there was a subpixel issue where the play icon (drawn with CSS) was not displaying correctly at certain sizes. This is fixed by adjusting the width and height just a tiny bit.

## How to test

Pull down and run the branch locally. Go to any video demo page and adjust the screen size, make sure the play button does not break in any particular size.

cc @krlucas 
