### PR TITLE
hotfix: swap out document-register-element with custom-elements polyfill

### DIFF
--- a/packages/core/polyfills/index.js
+++ b/packages/core/polyfills/index.js
@@ -45,7 +45,7 @@ export const polyfillLoader = new Promise(resolve => {
   // Based on https://github.com/webcomponents/webcomponentsjs/blob/master/entrypoints/webcomponents-hi-sd-ce-pf-index.js
   // Used in: IE 11
   if (polyfills.includes('lite')) {
-    Promise.all([import('document-register-element')]).then(() => {
+    Promise.all([import('@webcomponents/custom-elements')]).then(() => {
       resolve();
     });
   }
@@ -55,7 +55,7 @@ export const polyfillLoader = new Promise(resolve => {
   else if (polyfills.includes('sd') && polyfills.includes('ce')) {
     Promise.all([
       import('@webcomponents/shadydom/src/shadydom.js'),
-      import('document-register-element'),
+      import('@webcomponents/custom-elements'),
     ]).then(() => {
       resolve();
     });
@@ -80,7 +80,7 @@ export const polyfillLoader = new Promise(resolve => {
       },
     );
 
-    import('document-register-element').then(() => {
+    import('@webcomponents/custom-elements').then(() => {
       resolve();
     });
   }


### PR DESCRIPTION
Workaround to address extreme edge case of dynamically injected, server-side prerendered buttons not hydrating properly if delay added in rendering process. 

I’m still working on a Nightwatch test + example demoing how this update appears to fix the issue — that will need to be added in a separate commit.

## Jira
http://vjira2:8080/browse/WWWD-2628


## How to test

> Note: This polyfill update only applies to browsers not currently shipping with custom element support — IE 11, Edge, and Firefox v62 and lower (v63+ ships with support for custom elements and Shadow DOM out of the box): https://caniuse.com/#search=Custom%20elements%20v1