### PR TITLE
Fix: make sure item styling doesn't trickle down in a nested bolt-list

### DIFF
--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -47,7 +47,7 @@
     margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
     margin-bottom: bolt-v-spacing(#{$spacing-value-name}) * -1;
 
-    .c-bolt-list__item {
+    > .c-bolt-list__item {
       @include bolt-margin-left(#{$spacing-value-name});
       @include bolt-margin-bottom(#{$spacing-value-name});
     }
@@ -57,7 +57,7 @@
     @include bolt-margin-left(0);
     @include bolt-margin-bottom(0);
 
-    .c-bolt-list__item {
+    > .c-bolt-list__item {
       @include bolt-margin-left(0);
       @include bolt-margin-bottom(0);
       @include bolt-padding(#{$spacing-value-name});
@@ -66,14 +66,14 @@
 
   .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class^='c-bolt-list--separator'],
   .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class*=' c-bolt-list--separator'] {
-    .c-bolt-list__item:not(:last-child) {
+    > .c-bolt-list__item:not(:last-child) {
       @include bolt-padding-bottom(#{$spacing-value-name});
     }
   }
 
   .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class^='c-bolt-list--separator'],
   .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class*=' c-bolt-list--separator'] {
-    .c-bolt-list__item:not(:last-child) {
+    > .c-bolt-list__item:not(:last-child) {
       @include bolt-padding-right(#{$spacing-value-name});
     }
   }
@@ -109,7 +109,7 @@ $bolt-list-separator-styles: solid, dashed;
 
 @each $separator-style in $bolt-list-separator-styles {
   .c-bolt-list--separator-#{$separator-style} {
-    .c-bolt-list__item:not(:last-child) {
+    > .c-bolt-list__item:not(:last-child) {
       border: 0;
       border-color: rgba(bolt-color(gray), 0.25);
       border-style: #{$separator-style};
@@ -120,13 +120,13 @@ $bolt-list-separator-styles: solid, dashed;
 [class^='c-bolt-list--separator'],
 [class*=' c-bolt-list--separator'] {
   &.c-bolt-list--display-block {
-    .c-bolt-list__item:not(:last-child) {
+    > .c-bolt-list__item:not(:last-child) {
       border-bottom-width: 1px;
     }
   }
 
   &.c-bolt-list--display-inline {
-    .c-bolt-list__item:not(:last-child) {
+    > .c-bolt-list__item:not(:last-child) {
       border-right-width: 1px;
     }
   }


### PR DESCRIPTION
## Jira

N/A. Found it as I was using the bolt-list component.

## Summary

Prevents item styling to trickle down in nested lists.

## Details

CSS for the items are not specific enough and it was causing the styles to apply to a list inside a list, for example, using the share component as an item for the list component (share component is built with the list component). 

## How to test

Pull down and run the branch locally. Try to build a page with a list component, then pass either a share component or another list component as an item. Change some prop settings on the parent list and make sure they don't affect the inner list.
