### PR TITLE
fix: revert auto-indenting Twig code in PL code viewer

### DIFF
--- a/apps/pattern-lab/.patches/beautifyHTML.patch
+++ b/apps/pattern-lab/.patches/beautifyHTML.patch
@@ -22,7 +22,7 @@ index 4c9bc6173..a5df38c00 100644
 +							'indentation_character' => '  '
 +						));
 +						$markup = $indenter->indent($markup);
-+						$markupEngine = $indenter->indent($markupEngine);
++						//$markupEngine = $indenter->indent($markupEngine);
 +					}
 +
 +					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixMarkupOnly.".html",$markup);


### PR DESCRIPTION
Disables part of our custom patch that handles auto-indenting the code displayed in Pattern Lab’s code viewer (now more closely matches the v1.x version of this: https://github.com/bolt-design-system/bolt/blob/release/1.x/apps/pattern-lab/.patches/beautifyHTML.patch)

Twig markup displayed in Pattern Lab’s code viewer should at least not be flattened to a single line while we look for a better PHP library to handle automatically removing excess white space / indents!

Before:
![image](https://user-images.githubusercontent.com/1617209/47084212-e0d90a80-d1e0-11e8-8b0f-7ceeb089dac4.png)

After:
![image](https://user-images.githubusercontent.com/1617209/47084224-e6ceeb80-d1e0-11e8-85c2-8f976b539993.png)


CC @charginghawk 