### PR TITLE
Support row_gutter in IE

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/grid/10-grid-row-gutter-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/grid/10-grid-row-gutter-variations.twig
@@ -15,7 +15,7 @@
     },
     items: [
       {
-        row_start: "1",
+        row_start: "2",
         column_start: "1",
         column_span: "12",
         content: "Grid Item 1",
@@ -27,7 +27,7 @@
         }
       },
       {
-        row_start: "2",
+        row_start: "3",
         column_start: "1",
         column_span: "12",
         content: "Grid Item 2",
@@ -39,7 +39,7 @@
         }
       },
       {
-        row_start: "3",
+        row_start: "4",
         column_start: "1",
         column_span: "12",
         content: "Grid Item 3",

--- a/apps/pattern-lab/src/_patterns/02-components/grid/10-grid-row-gutter-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/grid/10-grid-row-gutter-variations.twig
@@ -1,0 +1,55 @@
+{% set schema = bolt.data.components["@bolt-components-grid"].schema %}
+
+{% set row_gutters = schema.properties.row_gutter.enum %}
+
+{% for row_gutter in row_gutters %}
+  Row Gutter: {{ row_gutter }}
+
+  {% include "@bolt-components-grid/grid.twig" with {
+    vinset: "medium",
+    row_gutter: row_gutter,
+    attributes: {
+      class: [
+        "t-bolt-light"
+      ]
+    },
+    items: [
+      {
+        row_start: "1",
+        column_start: "1",
+        column_span: "12",
+        content: "Grid Item 1",
+        attributes: {
+          class: [
+            "t-bolt-dark",
+            "u-bolt-padding-medium",
+          ]
+        }
+      },
+      {
+        row_start: "2",
+        column_start: "1",
+        column_span: "12",
+        content: "Grid Item 2",
+        attributes: {
+          class: [
+            "t-bolt-dark",
+            "u-bolt-padding-medium",
+          ]
+        }
+      },
+      {
+        row_start: "3",
+        column_start: "1",
+        column_span: "12",
+        content: "Grid Item 3",
+        attributes: {
+          class: [
+            "t-bolt-dark",
+            "u-bolt-padding-medium",
+          ]
+        }
+      },
+    ]
+  } only %}
+{% endfor %}

--- a/apps/pattern-lab/src/_patterns/02-components/grid/20-grid-vinset-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/grid/20-grid-vinset-variations.twig
@@ -1,0 +1,55 @@
+{% set schema = bolt.data.components["@bolt-components-grid"].schema %}
+
+{% set vinsets = schema.properties.vinset.enum %}
+
+{% for vinset in vinsets %}
+  Vinset: {{ vinset }}
+
+  {% include "@bolt-components-grid/grid.twig" with {
+    vinset: vinset,
+    row_gutter: "small",
+    attributes: {
+      class: [
+        "t-bolt-light"
+      ]
+    },
+    items: [
+      {
+        row_start: "1",
+        column_start: "1",
+        column_span: "12",
+        content: "Grid Item 1",
+        attributes: {
+          class: [
+            "t-bolt-dark",
+            "u-bolt-padding-medium",
+          ]
+        }
+      },
+      {
+        row_start: "2",
+        column_start: "1",
+        column_span: "12",
+        content: "Grid Item 2",
+        attributes: {
+          class: [
+            "t-bolt-dark",
+            "u-bolt-padding-medium",
+          ]
+        }
+      },
+      {
+        row_start: "3",
+        column_start: "1",
+        column_span: "12",
+        content: "Grid Item 3",
+        attributes: {
+          class: [
+            "t-bolt-dark",
+            "u-bolt-padding-medium",
+          ]
+        }
+      },
+    ]
+  } only %}
+{% endfor %}

--- a/apps/pattern-lab/src/_patterns/02-components/grid/20-grid-vinset-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/grid/20-grid-vinset-variations.twig
@@ -5,6 +5,8 @@
 {% for vinset in vinsets %}
   Vinset: {{ vinset }}
 
+  {% set starting_row = vinset == 'none' ? 1 : 2 %}
+
   {% include "@bolt-components-grid/grid.twig" with {
     vinset: vinset,
     row_gutter: "small",
@@ -15,7 +17,7 @@
     },
     items: [
       {
-        row_start: "1",
+        row_start: starting_row,
         column_start: "1",
         column_span: "12",
         content: "Grid Item 1",
@@ -27,7 +29,7 @@
         }
       },
       {
-        row_start: "2",
+        row_start: starting_row + 1,
         column_start: "1",
         column_span: "12",
         content: "Grid Item 2",
@@ -39,7 +41,7 @@
         }
       },
       {
-        row_start: "3",
+        row_start: starting_row + 2,
         column_start: "1",
         column_span: "12",
         content: "Grid Item 3",

--- a/packages/components/bolt-grid/src/grid.scss
+++ b/packages/components/bolt-grid/src/grid.scss
@@ -49,7 +49,20 @@ bolt-grid {
     }
 
     &[row-gutter='#{$name}'] {
-      grid-row-gap: bolt-v-spacing(#{$name});
+      // Use margin to replicate grid-row-gap when not natively supported by the browser.
+      &:before,
+      > bolt-grid-item {
+        @include bolt-margin-bottom(#{$name});
+
+        @supports (grid-row-gap: 1px) {
+          // When grid-row-gap is natively supported, reset this workaround.
+          @include bolt-margin-bottom(0);
+        }
+      }
+
+      @supports (grid-row-gap: 1px) {
+        grid-row-gap: bolt-v-spacing(#{$name});
+      }
     }
   }
 }

--- a/packages/components/bolt-grid/src/grid.scss
+++ b/packages/components/bolt-grid/src/grid.scss
@@ -32,101 +32,25 @@ bolt-grid {
     }
   }
 
-  // @todo: refactor to auto-generate sizes here from spacing scale
-  &[vinset='xlarge'] {
-    grid-template-rows: minmax(#{bolt-v-spacing(xlarge)}, max-content);
-    grid-auto-rows: minmax(#{bolt-v-spacing(xlarge)}, max-content);
-    
-    // temporary workaround for forcing the auto-generated rows before/after the grid to be a minimum height in IE 11 
-    &:before, &:after {
-      min-height: bolt-v-spacing(xlarge);
-    }
-    
-    @supports (grid-auto-rows: auto){
-      grid-template-rows: auto;
-    }
-  }
 
-  &[vinset='large'] {
-    grid-template-rows: minmax(#{bolt-v-spacing(large)}, max-content);
-    grid-auto-rows: minmax(#{bolt-v-spacing(large)}, max-content);
+  @each $name, $value in $bolt-spacing-values {
+    &[vinset='#{$name}'] {
+      grid-template-rows: minmax(#{bolt-v-spacing(#{$name})}, max-content);
+      grid-auto-rows: minmax(#{bolt-v-spacing(#{$name})}, max-content);
 
-    // temporary workaround for forcing the auto-generated rows before/after the grid to be a minimum height in IE 11
-    &:before, &:after {
-      min-height: bolt-v-spacing(large);
+      // temporary workaround for forcing the auto-generated rows before/after the grid to be a minimum height in IE 11
+      &:before, &:after {
+        min-height: bolt-v-spacing(#{$name});
+      }
+
+      @supports (grid-auto-rows: auto) {
+        grid-template-rows: auto;
+      }
     }
 
-    @supports (grid-auto-rows: auto){
-      grid-template-rows: auto;
+    &[row-gutter='#{$name}'] {
+      grid-row-gap: bolt-v-spacing(#{$name});
     }
-  }
-  
-  &[vinset='medium'] {
-    grid-template-rows: minmax(#{bolt-v-spacing(medium)}, max-content);
-    grid-auto-rows: minmax(#{bolt-v-spacing(medium)}, max-content);
-
-    // temporary workaround for forcing the auto-generated rows before/after the grid to be a minimum height in IE 11
-    &:before, &:after {
-      min-height: bolt-v-spacing(medium);
-    }
-
-    @supports (grid-auto-rows: auto){
-      grid-template-rows: auto;
-    }
-  }
-  
-  &[vinset='small'] {
-    grid-template-rows: minmax(#{bolt-v-spacing(small)}, max-content);
-    grid-auto-rows: minmax(#{bolt-v-spacing(small)}, max-content);
-
-    // temporary workaround for forcing the auto-generated rows before/after the grid to be a minimum height in IE 11
-    &:before, &:after {
-      min-height: bolt-v-spacing(small);
-    }
-
-    @supports (grid-auto-rows: auto){
-      grid-template-rows: auto;
-    }
-  }
-
-  &[vinset='xsmall'] {
-    grid-template-rows: minmax(#{bolt-v-spacing(xsmall)}, max-content);
-    grid-auto-rows: minmax(#{bolt-v-spacing(xsmall)}, max-content);
-
-    // temporary workaround for forcing the auto-generated rows before/after the grid to be a minimum height in IE 11
-    &:before, &:after {
-      min-height: bolt-v-spacing(xsmall);
-    }
-
-    @supports (grid-auto-rows: auto){
-      grid-template-rows: auto;
-    }
-  }
-
-
-  // @todo: refactor to auto-generate sizes here from spacing scale -- same as above ^
-  &[row-gutter='xlarge']{
-    grid-row-gap: bolt-v-spacing(xlarge);
-  }
-
-  &[row-gutter='large']{
-    grid-row-gap: bolt-v-spacing(large);
-  }
-
-  &[row-gutter='medium']{
-    grid-row-gap: bolt-v-spacing(medium);
-  }
-
-  &[row-gutter='small']{
-    grid-row-gap: bolt-v-spacing(small);
-  }
-
-  &[row-gutter='xsmall']{
-    grid-row-gap: bolt-v-spacing(xsmall);
-  }
-
-  &[row-gutter='xxsmall']{
-    grid-row-gap: bolt-v-spacing(xxsmall);
   }
 }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-719

## Summary

Adds support for the grid component's row_gutter parameter in IE 11.

## Details

Notes:
- I did not add CSS for `row_gutter=none` since it works by default.

Questions that should be resolved before merging:
- Is it correct to use the `$bolt-spacing-values` variable for the scss loop?
- vinset doesn't appear to work as I would have expected in the examples (`pattern-lab/?p=components-grid-row-vinset-variations`).  Namely, It only adds an inset to the bottom of the grid.  Am I doing something wrong or is this a separate bug?

## How to test

- On the this branch, go to `/pattern-lab/?p=components-grid-row-gutter-variations`
- Confirm that the row gutter have parity between IE-11 and other modern browsers
