### PR TITLE
Fix: correct button text and icon alignment

### DIFF
--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -150,14 +150,14 @@ bolt-button[width='full@small'],
 
 .c-bolt-button--start {
   text-align: left;
+  text-align: start;
   justify-content: flex-start;
-  justify-content: start;
 }
 
 .c-bolt-button--end {
   text-align: right;
+  text-align: end;
   justify-content: flex-end;
-  justify-content: end;
 }
 
 


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixes a bug where align right is not displaying correctly.

## Details

`justify-content: start` and `justify-content: end` are not working as intended. I've updated it to `text-align: start` and `text-align: end` with left and right fallback. That is working as intended now.

## How to test

Pull down and run the branch locally, navigate in Pattern Lab to the button alignment demos, make sure all alignments are displayed correctly.
