### PR TITLE
Fix: enable bolt-list display prop to interact perfectly with other props

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/list/50-list-tag-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/list/50-list-tag-variations.twig
@@ -1,0 +1,25 @@
+{% set schema = bolt.data.components["@bolt-components-list"].schema %}
+
+<p><mark>Use the semantically correct tag based on the context of your page layout.</mark></p>
+
+{% for tag in schema.properties.tag.enum %}
+  <h3>{{ tag }}</h3>
+  {% include "@bolt-components-list/list.twig" with {
+    display: "inline",
+    tag: tag,
+    items: [
+      include("@bolt-components-link/link.twig", {
+        text: "Item 1",
+        url: "#!",
+      }),
+      include("@bolt-components-link/link.twig", {
+        text: "Item 2",
+        url: "#!",
+      }),
+      include("@bolt-components-link/link.twig", {
+        text: "Item 3",
+        url: "#!",
+      }),
+    ]
+  } only %}
+{% endfor %}

--- a/packages/components/bolt-list/list.schema.yml
+++ b/packages/components/bolt-list/list.schema.yml
@@ -21,6 +21,8 @@ properties:
     enum:
       - ul
       - ol
+      - div
+      - span
   display:
     type: string
     description: Display either an inline list of items or a block (stacked) list of items. Responsive options are also available for transforming from block to inline at specific breakpoints.

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -26,7 +26,7 @@
 }
 
 .c-bolt-list--display-inline {
-  display: flex;
+  display: inline-flex;
   flex-flow: row wrap;
 }
 
@@ -38,7 +38,7 @@
     flex-flow: column wrap;
 
     @include bolt-mq($breakpoint-name) {
-      display: flex;
+      display: inline-flex;
       flex-flow: row wrap;
     }
   }

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -180,14 +180,12 @@ $bolt-list-separator-styles: solid, dashed;
   @each $spacing-value in $bolt-spacing-values {
     $spacing-value-name: nth($spacing-value, 1);
 
-    &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block,
     &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block {
       > .c-bolt-list__item:not(:last-child) {
         @include bolt-padding-bottom(#{$spacing-value-name});
       }
     }
 
-    &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline,
     &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline {
       > .c-bolt-list__item:not(:last-child) {
         @include bolt-padding-right(#{$spacing-value-name});
@@ -198,7 +196,6 @@ $bolt-list-separator-styles: solid, dashed;
       @each $breakpoint in $bolt-breakpoints {
         $breakpoint-name: nth($breakpoint, 1);
 
-        &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name},
         &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name} {
           > .c-bolt-list__item:not(:last-child) {
             @include bolt-padding-bottom(#{$spacing-value-name});

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -18,31 +18,37 @@
   display: block;
 }
 
+
+// Display Prop
 .c-bolt-list--display-block {
   display: flex;
   flex-flow: column wrap;
 }
 
 .c-bolt-list--display-inline {
-  display: inline-flex;
+  display: flex;
   flex-flow: row wrap;
 }
 
 @each $breakpoint in $bolt-breakpoints {
   $breakpoint-name: nth($breakpoint, 1);
+
   .c-bolt-list--display-inline\@#{$breakpoint-name} {
     display: flex;
     flex-flow: column wrap;
 
     @include bolt-mq($breakpoint-name) {
-      display: inline-flex;
+      display: flex;
       flex-flow: row wrap;
     }
   }
 }
 
+
+// Spacing Prop
 @each $spacing-value in $bolt-spacing-values {
   $spacing-value-name: nth($spacing-value, 1);
+
   .c-bolt-list--spacing-#{$spacing-value-name} {
     margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
     margin-bottom: bolt-v-spacing(#{$spacing-value-name}) * -1;
@@ -63,22 +69,10 @@
       @include bolt-padding(#{$spacing-value-name});
     }
   }
-
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class^='c-bolt-list--separator'],
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class*=' c-bolt-list--separator'] {
-    > .c-bolt-list__item:not(:last-child) {
-      @include bolt-padding-bottom(#{$spacing-value-name});
-    }
-  }
-
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class^='c-bolt-list--separator'],
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class*=' c-bolt-list--separator'] {
-    > .c-bolt-list__item:not(:last-child) {
-      @include bolt-padding-right(#{$spacing-value-name});
-    }
-  }
 }
 
+
+// Align and Valign Props
 $bolt-list-alignments: start, center, end;
 
 @each $alignment in $bolt-list-alignments {
@@ -89,6 +83,21 @@ $bolt-list-alignments: start, center, end;
       }
       @else {
         justify-content: #{$alignment};
+      }
+    }
+
+    @each $breakpoint in $bolt-breakpoints {
+      $breakpoint-name: nth($breakpoint, 1);
+
+      &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+        @include bolt-mq($breakpoint-name) {
+          @if $alignment != 'center' {
+            justify-content: flex-#{$alignment};
+          }
+          @else {
+            justify-content: #{$alignment};
+          }
+        }
       }
     }
   }
@@ -102,9 +111,26 @@ $bolt-list-alignments: start, center, end;
         align-items: #{$alignment};
       }
     }
+
+    @each $breakpoint in $bolt-breakpoints {
+      $breakpoint-name: nth($breakpoint, 1);
+
+      &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+        @include bolt-mq($breakpoint-name) {
+          @if $alignment != 'center' {
+            align-items: flex-#{$alignment};
+          }
+          @else {
+            align-items: #{$alignment};
+          }
+        }
+      }
+    }
   }
 }
 
+
+// Separator Prop
 $bolt-list-separator-styles: solid, dashed;
 
 @each $separator-style in $bolt-list-separator-styles {
@@ -128,6 +154,55 @@ $bolt-list-separator-styles: solid, dashed;
   &.c-bolt-list--display-inline {
     > .c-bolt-list__item:not(:last-child) {
       border-right-width: 1px;
+    }
+  }
+
+  @each $breakpoint in $bolt-breakpoints {
+    $breakpoint-name: nth($breakpoint, 1);
+
+    &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+      > .c-bolt-list__item:not(:last-child) {
+        border-bottom-width: 1px;
+
+        @include bolt-mq($breakpoint-name) {
+          border-right-width: 1px;
+          border-bottom-width: 0;
+        }
+      }
+    }
+  }
+}
+
+// Specific settings for when the seperator prop interacts with other props.
+@each $spacing-value in $bolt-spacing-values {
+  $spacing-value-name: nth($spacing-value, 1);
+
+  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class^='c-bolt-list--separator'],
+  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class*=' c-bolt-list--separator'] {
+    > .c-bolt-list__item:not(:last-child) {
+      @include bolt-padding-bottom(#{$spacing-value-name});
+    }
+  }
+
+  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class^='c-bolt-list--separator'],
+  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class*=' c-bolt-list--separator'] {
+    > .c-bolt-list__item:not(:last-child) {
+      @include bolt-padding-right(#{$spacing-value-name});
+    }
+  }
+
+  @each $breakpoint in $bolt-breakpoints {
+    $breakpoint-name: nth($breakpoint, 1);
+    .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name}[class^='c-bolt-list--separator'],
+    .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name}[class*=' c-bolt-list--separator'] {
+      > .c-bolt-list__item:not(:last-child) {
+        @include bolt-padding-bottom(#{$spacing-value-name});
+
+        @include bolt-mq($breakpoint-name) {
+          @include bolt-padding-right(#{$spacing-value-name});
+          @include bolt-padding-bottom(0);
+        }
+      }
     }
   }
 }

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -66,7 +66,10 @@
     > .c-bolt-list__item {
       @include bolt-margin-left(0);
       @include bolt-margin-bottom(0);
-      @include bolt-padding(#{$spacing-value-name});
+      @include bolt-padding-top(#{$spacing-value-name});
+      @include bolt-padding-right(#{$spacing-value-name});
+      @include bolt-padding-bottom(#{$spacing-value-name});
+      @include bolt-padding-left(#{$spacing-value-name});
     }
   }
 }
@@ -143,8 +146,7 @@ $bolt-list-separator-styles: solid, dashed;
   }
 }
 
-[class^='c-bolt-list--separator'],
-[class*=' c-bolt-list--separator'] {
+[class*='c-bolt-list--separator'] {
   &.c-bolt-list--display-block {
     > .c-bolt-list__item:not(:last-child) {
       border-bottom-width: 1px;
@@ -173,34 +175,39 @@ $bolt-list-separator-styles: solid, dashed;
   }
 }
 
-// Specific settings for when the seperator prop interacts with other props.
-@each $spacing-value in $bolt-spacing-values {
-  $spacing-value-name: nth($spacing-value, 1);
+// Specific settings for when the seperator prop interacts with other props. This is where things get really crazy.
+[class*='c-bolt-list--separator'] {
+  @each $spacing-value in $bolt-spacing-values {
+    $spacing-value-name: nth($spacing-value, 1);
 
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class^='c-bolt-list--separator'],
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block[class*=' c-bolt-list--separator'] {
-    > .c-bolt-list__item:not(:last-child) {
-      @include bolt-padding-bottom(#{$spacing-value-name});
-    }
-  }
-
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class^='c-bolt-list--separator'],
-  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline[class*=' c-bolt-list--separator'] {
-    > .c-bolt-list__item:not(:last-child) {
-      @include bolt-padding-right(#{$spacing-value-name});
-    }
-  }
-
-  @each $breakpoint in $bolt-breakpoints {
-    $breakpoint-name: nth($breakpoint, 1);
-    .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name}[class^='c-bolt-list--separator'],
-    .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name}[class*=' c-bolt-list--separator'] {
+    &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block,
+    &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-block {
       > .c-bolt-list__item:not(:last-child) {
         @include bolt-padding-bottom(#{$spacing-value-name});
+      }
+    }
 
-        @include bolt-mq($breakpoint-name) {
-          @include bolt-padding-right(#{$spacing-value-name});
-          @include bolt-padding-bottom(0);
+    &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline,
+    &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline {
+      > .c-bolt-list__item:not(:last-child) {
+        @include bolt-padding-right(#{$spacing-value-name});
+      }
+    }
+
+    &:not(.c-bolt-list--inset) {
+      @each $breakpoint in $bolt-breakpoints {
+        $breakpoint-name: nth($breakpoint, 1);
+
+        &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name},
+        &.c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--display-inline\@#{$breakpoint-name} {
+          > .c-bolt-list__item:not(:last-child) {
+            @include bolt-padding-bottom(#{$spacing-value-name});
+
+            @include bolt-mq($breakpoint-name) {
+              @include bolt-padding-right(#{$spacing-value-name});
+              @include bolt-padding-bottom(0);
+            }
+          }
         }
       }
     }

--- a/packages/components/bolt-list/src/list.twig
+++ b/packages/components/bolt-list/src/list.twig
@@ -62,7 +62,11 @@
   <{{ tag }} {{ inner_attributes.addClass(classes) }}>
     {% for item in items %}
       <{{ item_tag }} class="{{ "#{base_class}__item" }}">
-        {{ item }}
+        {% if item is iterable %}
+          {{ item.content | join }}
+        {% else %}
+          {{ item }}
+        {% endif %}
       </{{ item_tag }}>
     {% endfor %}
   </{{ tag }}>

--- a/packages/components/bolt-list/src/list.twig
+++ b/packages/components/bolt-list/src/list.twig
@@ -19,13 +19,19 @@
 {% set valign_options = schema.properties.valign.enum %}
 
 {# Check that the component's current prop values are valid. If not, default to the schema default #}
-{% set tag = tag in display_options ? tag : schema.properties.tag.default %}
+{% set tag = tag in tag_options ? tag : schema.properties.tag.default %}
 {% set display = display in display_options ? display : schema.properties.display.default %}
 {% set spacing = spacing in spacing_options ? spacing : schema.properties.spacing.default %}
 {% set separator = separator in separator_options ? separator : schema.properties.separator.default %}
 {% set inset = inset in spacing_options ? inset : schema.properties.inset.default %}
 {% set align = align in align_options ? align : schema.properties.align.default %}
 {% set valign = valign in valign_options ? valign : schema.properties.valign.default %}
+
+{% if tag == "div" or tag == "span" %}
+  {% set item_tag = "span" %}
+{% else %}
+  {% set item_tag = "li" %}
+{% endif %}
 
 {# List component's custom element wrapper. #}
 <bolt-list
@@ -55,9 +61,9 @@
 
   <{{ tag }} {{ inner_attributes.addClass(classes) }}>
     {% for item in items %}
-      <li class="{{ "#{base_class}__item" }}">
+      <{{ item_tag }} class="{{ "#{base_class}__item" }}">
         {{ item }}
-      </li>
+      </{{ item_tag }}>
     {% endfor %}
   </{{ tag }}>
 </bolt-list>

--- a/packages/components/bolt-list/src/list.twig
+++ b/packages/components/bolt-list/src/list.twig
@@ -27,6 +27,7 @@
 {% set align = align in align_options ? align : schema.properties.align.default %}
 {% set valign = valign in valign_options ? valign : schema.properties.valign.default %}
 
+{# Conditions for the semantic tag usage #}
 {% if tag == "div" or tag == "span" %}
   {% set item_tag = "span" %}
 {% else %}


### PR DESCRIPTION
## Jira

N/A. This is discovered as I built out pages.

## Summary

Fixes visual bugs when the `bolt-list`'s display prop is used in conjunction with other props such as spacing and border.

## Details

The spacing and border were not displaying correctly when `inline@whatever` display is defined, I updated the CSS to accommodate those scenarios.

Also there was a bug with the tag prop that was always making it a `ul`, now you can use the correct tag as needed.

## How to test

Pull down the branch and run it locally. Go wild with a test page and try to use all the prop combos you can think off. Make sure all props are displaying as expected.
