### PR TITLE
Bug: Fix Button JS `Rendered` Event Emitted + Update Button JS Demo

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/button/60-button-with-3rd-party-js.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/button/60-button-with-3rd-party-js.twig
@@ -6,7 +6,9 @@
       "theme:": "xdark",
       "text": "XDark Button w/ External JS Example",
       attributes: {
-        class: "js-button-theme-xdark",
+        class: [
+          "js-button-theme-xdark"
+        ]
       }
     } %}
   {% endblock %}
@@ -19,7 +21,7 @@
   var elementBeingTargeted = 'button';
   var selector;
 
-  if (element._wasInitiallyRendered){
+  if (element._wasInitiallyRendered === true){
     setupEventListener(false);
   } else {
     element.addEventListener('rendered', setupEventListener);
@@ -31,10 +33,11 @@
     } else {
       selector = element.querySelector(elementBeingTargeted);
     }
+
     ready();
 
     if (removeEventListener){
-      element.removeEventListener("rendered", setupEventListener, true);
+      element.removeEventListener('rendered', setupEventListener, true);
     }
   }
 
@@ -49,6 +52,6 @@
 
   function buttonClicked(){
     console.log('the button tag inside the rendered xdark bolt-button was clicked!');
+    document.body.classList.toggle('t-bolt-xdark');
   }
-
 </script>

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -79,6 +79,7 @@ class BoltButton extends withHyperHtml() {
   }
 
   rendered() {
+    super.rendered();
     const root = this;
     const slots = this.slots;
 


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-728

## Details
Fixes the Bolt button component's JS logic so the `ready` and `rendered` JavaScript events —recently added to the globally shared Bolt base component in v2.x when a component renders initially + re-renders, respectfully— fires as expected.

Note: a recent update made to improve the cross-browser rendering of dynamically injected buttons caused this event to stop working as expected (forgot to call `super.rendered()`, however it's worth mentioning that given the virtually undocumented nature of this update and how the how this feature was only just recently added, it's incredibly unlikely this update was getting used downstream just yet.

For reference, these events were added in the v2.x release as a possible new pattern to help with consistently binding / rebinding 3rd party JavaScript to a Bolt component in a number of different use cases and situations:
- Binding to a component that hasn't yet finished rendering (either based on the order JavaScript runs and/or if the component is async loaded)
- Binding to a component that renders differently based on browser support (natively supporting Shadow DOM vs non-Shadow DOM rendering)
- Binding to a component that automatically renders differently based on the context it's getting used (ex. components used in forms automatically never render to the Shadow DOM since Bolt v1.x)
- Binding to a component which, based on data, state, DOM mutations, and lifecycle event changes, re-renders 

## How to test
- Check out the existing button JS demo in Pattern Lab and confirm the console logged event + theme toggle work as expected.

CC @charginghawk and @krlucas 