### PR TITLE
Hotfix: WWWD-2711 duplicate submissions

### DIFF
--- a/packages/components/bolt-band/src/band.twig
+++ b/packages/components/bolt-band/src/band.twig
@@ -49,6 +49,8 @@
 
         {# merge together array of items with the content / band_content block so each item can get wrapped properly #}
         {% set items = items | default([]) %}
+
+        {# Note: using block('band_content') to check for emptiness can cause duplicate rendering issues and should be avoided.  #}
         {% if block_band_content is not empty %}
           {% set items = items | merge([{
             content: block_band_content,

--- a/packages/components/bolt-band/src/band.twig
+++ b/packages/components/bolt-band/src/band.twig
@@ -49,7 +49,7 @@
 
         {# merge together array of items with the content / band_content block so each item can get wrapped properly #}
         {% set items = items | default([]) %}
-        {% if  block('band_content') | length > 0 %}
+        {% if block_band_content is not empty %}
           {% set items = items | merge([{
             content: block_band_content,
             position: {


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2711

## Summary

Prevent double rendering of legacy content variable/block in bands

## Details

Using the conditional statement `{% if  block('band_content') | length > 0 %}` appears to require the `band_content` band to get rendered in order to perform the check, which results in the Drupal render system thinking it is rendering the content twice.  This results in bugs like the one described in http://vjira2:8080/browse/WWWD-2711.

This is unfortunately one of those things we'll probably just have to be aware of when writing future code.

## How to test

I tested by applying this same fix directly in Drupal and confirming that it fixes the bug described in http://vjira2:8080/browse/WWWD-2711.  I don't know of a good way to test in Bolt directly.
