### PR TITLE
Fix: typo in the bolt-list twig

### DIFF
--- a/packages/components/bolt-list/src/list.twig
+++ b/packages/components/bolt-list/src/list.twig
@@ -23,7 +23,7 @@
 {% set display = display in display_options ? display : schema.properties.display.default %}
 {% set spacing = spacing in spacing_options ? spacing : schema.properties.spacing.default %}
 {% set separator = separator in separator_options ? separator : schema.properties.separator.default %}
-{% set inset = inset in spacing_options ? inset : schema.properties.inset.default %}
+{% set inset = inset in inset_options ? inset : schema.properties.inset.default %}
 {% set align = align in align_options ? align : schema.properties.align.default %}
 {% set valign = valign in valign_options ? valign : schema.properties.valign.default %}
 


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixed a typo in the bolt-list twig file about the inset prop. 

## Details

The inset prop line had a typo:

```
{% set inset = inset in spacing_options ? inset : schema.properties.inset.default %}
```

Fixed it to be `inset_options`.

## How to test

Pull down and run the branch locally. Make sure the inset doc pages on bolt-list are displaying correctly.
