### PR TITLE
Update Bolt version selector to optionally open in a new tab

### DIFF
--- a/apps/bolt-site/components/version-selector/version-selector.js
+++ b/apps/bolt-site/components/version-selector/version-selector.js
@@ -1,10 +1,24 @@
 import '../bolt-select/bolt-select';
 
 const boltSelect = document.querySelector('bolt-select');
+let shouldOpenInNewWindow = false;
+
+boltSelect.addEventListener('mousedown', function(e) {
+  if (e.metaKey === true) {
+    shouldOpenInNewWindow = true;
+  } else {
+    shouldOpenInNewWindow = false;
+  }
+});
 
 boltSelect.addEventListener('choice', function(e) {
   var url = e.detail.choice.value;
   if (url && window.location.href !== url) {
-    window.location = url; // redirect
+    // open Bolt version selected in a new tab (vs same tab) if the CMD / meta key is held
+    if (shouldOpenInNewWindow) {
+      window.open(url, '_blank');
+    } else {
+      window.location = url;
+    }
   }
 });


### PR DESCRIPTION
## Jira
N/A

## Summary
Updates the new Bolt version selector on the docs site to optionally allow the Bolt version being selected to open in a new tab if the ⌘ (CMD) / meta key is being pressed down at the same time. 

This is a small usability improvement to more easily allow multiple / different versions of Bolt to easily get pulled up side-by-side for comparison.

## How to test

**Bolt Version Selected Opens In A New Tab**
Navigate to the updated Bolt Design System site from this PR branch (link will be below in the comments once this deploys) and try clicking on a version of Bolt from the dropdown menu while holding down the ⌘ key on your keyboard. 

Confirm this opens in a new tab as expected.

<br>

**Bolt Version Selected Opens In The Same Tab**
Navigate to the updated Bolt Design System site from this PR branch (link will be below in the comments once this deploys) and try clicking on a version of Bolt from the dropdown menu without holding down any keys on your keyboard. 

Confirm the version selected is navigated to in the current tab open (same default behavior on the current https://master.boltdesignsystem.com site)

CC @remydenton @margoromo @mikemai2awesome 