### PR TITLE
Refactor: Break Apart Component Mutation Observer Logic

### DIFF
--- a/packages/core/utils/contains-any.js
+++ b/packages/core/utils/contains-any.js
@@ -1,0 +1,7 @@
+// helper function to let you quickly check if an array of elements is inside a component
+export function containsAny(source, target) {
+  const result = source.filter(function(item) {
+    return target.indexOf(item) > -1;
+  });
+  return result.length > 0;
+}

--- a/packages/core/utils/index.js
+++ b/packages/core/utils/index.js
@@ -1,4 +1,5 @@
 export * from './color-contrast';
+export * from './contains-any';
 export * from './css';
 export * from './declarative-click-handler';
 export * from './environment';
@@ -10,6 +11,7 @@ export * from './supports-css-vars';
 export * from './supports-passive-event-listener';
 export * from './which-transition-event';
 export * from './wait-for-transition-end';
+export * from './watch-for-component-mutations';
 
 // https://www.polymer-project.org/3.0/docs/devguide/custom-elements#defer-work
 export { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';

--- a/packages/core/utils/watch-for-component-mutations.js
+++ b/packages/core/utils/watch-for-component-mutations.js
@@ -1,0 +1,45 @@
+import { containsAny } from './contains-any';
+
+export function watchForComponentMutations(element) {
+  // Automatically re-render if the component's children get externally modified (ex. a new icon gets injected)
+  const observer = new MutationObserver(mutations => {
+    mutations.forEach(function(mutation) {
+      if (mutation.removedNodes.length > 0) {
+        const itemsRemoved = [].slice.call(mutation.removedNodes); // grab items removed + convert to array
+
+        for (let i = 0; i < element.slots.length; i++) {
+          if (containsAny(element.slots[slot[i]], itemsRemoved)) {
+            for (let j = 0; j < itemsRemoved.length; j++) {
+              const itemRemoved = itemsRemoved[j];
+              element.slots[slot] = element.slots[slot].filter(
+                slottedItem => slottedItem !== itemRemoved,
+              );
+            }
+          }
+        }
+      } else {
+        const itemsAdded = [].slice.call(mutation.addedNodes); // grab items added + convert to array
+
+        for (let i = 0; i < itemsAdded.length; i++) {
+          const itemAdded = itemsAdded[i];
+          const slotName = itemAdded.getAttribute
+            ? itemAdded.getAttribute('slot')
+            : null;
+
+          if (!slotName) {
+            element.slots.default.push(itemAdded);
+          } else if (element.slots[slotName]) {
+            element.slots[slotName].push(itemAdded);
+          } else {
+            element.slots[slotName] = [];
+            element.slots[slotName].push(itemAdded);
+          }
+        }
+      }
+
+      element.triggerUpdate(); // automatically trigger an update with the component when externally mutated so slots + classes added re-render as expected.
+    });
+  });
+
+  return observer;
+}


### PR DESCRIPTION
## Jira
N/A

## Summary
Slightly refactors + breaks out the mutation observer logic currently used in the button component into it's own standalone JS utility library for reuse in Bolt core.

## How to test
Confirm button components rendering to the Shadow DOM re-render as expected when slotted content added (including the correct slot classes change accordingly).

### Create a new button on the page and confirm the before / after works as expected.  
```javascript
const buttonIconBefore = document.createElement('bolt-icon');
buttonIconBefore.setAttribute('name', 'arrow-left');
buttonIconBefore.setAttribute('slot', 'before');

const buttonIconAfter = document.createElement('bolt-icon');
buttonIconAfter.setAttribute('name', 'chevron-right');
buttonIconAfter.setAttribute('slot', 'after');

const buttonElement = document.querySelector('bolt-button'); 
buttonElement.textContent = 'Hello world!';
buttonElement.appendChild(buttonIconAfter);

document.body.appendChild(buttonElement); // confirm the before slot has the `is-empty` CSS class.

buttonElement.appendChild(buttonIconBefore); // now confirm the before slot contains the new icon and no longer displays the `is-empty` CSS class.
```

<hr>

![image](https://user-images.githubusercontent.com/1617209/47581172-b42e9c80-d91e-11e8-8e85-e6fc7e0d15d1.png)
> Screenshot before the "before" slot is populated with content

![image](https://user-images.githubusercontent.com/1617209/47581268-ed670c80-d91e-11e8-9d67-19e4d281cb2e.png)
> Screenshot after the "before" slot is populated with content
