### PR TITLE
Fix Bolt Build Tools Not Properly Logging Webpack Errors

### DIFF
--- a/packages/build-tools/utils/webpack-helpers.js
+++ b/packages/build-tools/utils/webpack-helpers.js
@@ -35,9 +35,7 @@ function boltWebpackMessages(originalCompiler) {
         const messages = formatWebpackMessages(stats.toJson({}, true));
         webpackSpinner.fail(chalk.red(`${getWebpackText()} Webpack failed!`));
         const prettyError = chalk.red(messages.errors.join('\n\n'));
-        console.log(
-          config.verbosity > 2 ? new Error(prettyError) : prettyError,
-        );
+        console.log(prettyError);
       } else {
         const output = stats.toString({
           all: false, // Makes the build much quieter


### PR DESCRIPTION
## Jira
N/A

## Summary
Fixes a small issue with the recent Webpack build updates / refactor that's causes the Webpack build process to not properly emit build errors as expected when the Bolt build tools verbosity config is set to a 1 or a 2.

Currently the progress spinner does indicate that a Webpack build error has occurred, however without this fix, it doesn't actually output the error text like it's supposed to.

**Without this fix in place:**
![image](https://user-images.githubusercontent.com/1617209/47585882-9ff19c00-d92c-11e8-9594-c2e1f056ce3b.png)

**With the fix in place, the error with file + line number outputs as expected:**
![image](https://user-images.githubusercontent.com/1617209/47585918-bf88c480-d92c-11e8-8995-2b8ec0205f7b.png)
