### PR TITLE
WIP: Improve Reliability of Button Component Re-rendering

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/card/__tests__/personalized-card--client-rendered/personalized-card-example--client-rendered-tests--in-form.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/__tests__/personalized-card--client-rendered/personalized-card-example--client-rendered-tests--in-form.twig
@@ -1,0 +1,114 @@
+<form>
+<div class="o-bolt-wrapper">
+  
+  {% include "@bolt-components-headline/headline.twig" with {
+    text: "Personalized card test, client-rendered, with a large delay",
+  } only %}
+
+  {% grid "u-bolt-margin-bottom-medium" %}
+    {% cell "u-bolt-width-1/2" %}
+      {% include "@bolt-components-headline/eyebrow.twig" with {
+        text: "Before:",
+      } only %}
+      <div class="js-disable-extra-slot-check">
+        {% include "@pl/_personalized-card-example.twig" with {
+          attributes: {
+            class: [
+              "js-personalized-card--client-rendered--with-large-delay",
+            ],
+          },
+          headline_demo_text: "Personalized card, client-rendered, with a large delay (before)"
+        } only %}
+      </div>
+    {% endcell %}
+
+    {% cell "u-bolt-width-1/2" %}
+      {% include "@bolt-components-headline/eyebrow.twig" with {
+        text: "After:",
+      } only %}
+      {% include "@pl/_personalized-card-example.twig" with {
+        attributes: {
+          class: [
+            "js-personalized-card--client-rendered--with-large-delay"
+          ],
+        },
+        headline_demo_text: "Personalized card, client-rendered, with a large delay (after)"
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+
+
+  {% include "@bolt-components-headline/headline.twig" with {
+    text: "Personalized card test, client-rendered, with a small delay",
+  } only %}
+
+  {% grid "u-bolt-margin-bottom-medium" %}
+    {% cell "u-bolt-width-1/2" %}
+      {% include "@bolt-components-headline/eyebrow.twig" with {
+        text: "Before:",
+      } only %}
+      <div class="js-disable-extra-slot-check">
+        {% include "@pl/_personalized-card-example.twig" with {
+          attributes: {
+            class: [
+              "js-personalized-card--client-rendered--with-small-delay",
+            ],
+          },
+          headline_demo_text: "Personalized card, client-rendered, with a small delay (before)"
+        } only %}
+      </div>
+    {% endcell %}
+
+    {% cell "u-bolt-width-1/2" %}
+      {% include "@bolt-components-headline/eyebrow.twig" with {
+        text: "After:",
+      } only %}
+      {% include "@pl/_personalized-card-example.twig" with {
+        attributes: {
+          class: [
+            "js-personalized-card--client-rendered--with-small-delay"
+          ],
+        },
+        headline_demo_text: "Personalized card, client-rendered, with a small delay (after)"
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+
+
+  {% include "@bolt-components-headline/headline.twig" with {
+    text: "Personalized card test, client-rendered, without a delay",
+  } only %}
+
+  {% grid "u-bolt-margin-bottom-medium" %}
+    {% cell "u-bolt-width-1/2" %}
+      {% include "@bolt-components-headline/eyebrow.twig" with {
+        text: "Before:",
+      } only %}
+      <div class="js-disable-extra-slot-check">
+        {% include "@pl/_personalized-card-example.twig" with {
+          attributes: {
+            class: [
+              "js-personalized-card--client-rendered--without-delay",
+            ],
+          },
+          headline_demo_text: "Personalized card, client-rendered, without a delay (before)"
+        } only %}
+      </div>
+    {% endcell %}
+
+    {% cell "u-bolt-width-1/2" %}
+      {% include "@bolt-components-headline/eyebrow.twig" with {
+        text: "After:",
+      } only %}
+      {% include "@pl/_personalized-card-example.twig" with {
+        attributes: {
+          class: [
+            "js-personalized-card--client-rendered--without-delay"
+          ],
+        },
+        headline_demo_text: "Personalized card, client-rendered, without a delay (after)"
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+</div>
+</form>

--- a/apps/pattern-lab/src/_patterns/02-components/card/__tests__/personalized-card--server-rendered/personalized-card-example--server-rendered--in-form.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/card/__tests__/personalized-card--server-rendered/personalized-card-example--server-rendered--in-form.twig
@@ -1,0 +1,118 @@
+<form>
+
+  <div class="o-bolt-wrapper">
+
+    {% include "@bolt-components-headline/headline.twig" with {
+      text: "Personalized card test, server-rendered, with a large delay",
+    } only %}
+
+    {% grid "u-bolt-margin-bottom-medium" %}
+      {% cell "u-bolt-width-1/2" %}
+        {% include "@bolt-components-headline/eyebrow.twig" with {
+          text: "Before:",
+        } only %}
+        <div class="js-disable-extra-slot-check">
+          {% include "@pl/_personalized-card-example.twig" with {
+            attributes: {
+              class: [
+                "js-personalized-card--server-rendered--with-large-delay",
+              ],
+            },
+            headline_demo_text: "Personalized card, server-rendered, w/ a large delay (before)"
+          } only %}
+        </div>
+      {% endcell %}
+
+      {% cell "u-bolt-width-1/2" %}
+        {% include "@bolt-components-headline/eyebrow.twig" with {
+          text: "After:",
+        } only %}
+        {% include "@pl/_personalized-card-example.twig" with {
+          attributes: {
+            class: [
+              "js-personalized-card--server-rendered--with-large-delay"
+            ]
+          },
+          headline_demo_text: "Personalized card, server-rendered, w/ a large delay (after)"
+        } only %}
+      {% endcell %}
+    {% endgrid %}
+
+
+    {% include "@bolt-components-headline/headline.twig" with {
+      text: "Personalized card test, server-rendered, with a small delay",
+    } only %}
+
+    {% grid "u-bolt-margin-bottom-medium" %}
+      {% cell "u-bolt-width-1/2" %}
+        {% include "@bolt-components-headline/eyebrow.twig" with {
+          text: "Before:",
+        } only %}
+
+        <div class="js-disable-extra-slot-check">
+          {% include "@pl/_personalized-card-example.twig" with {
+            attributes: {
+              class: [
+                "js-personalized-card--server-rendered--with-small-delay",
+              ],
+            },
+            headline_demo_text: "Personalized card, server-rendered, w/ a small delay (before)"
+          } only %}
+        </div>
+      {% endcell %}
+
+      {% cell "u-bolt-width-1/2" %}
+        {% include "@bolt-components-headline/eyebrow.twig" with {
+          text: "After:",
+        } only %}
+        {% include "@pl/_personalized-card-example.twig" with {
+          attributes: {
+            class: [
+              "js-personalized-card--server-rendered--with-small-delay"
+            ]
+          },
+          headline_demo_text: "Personalized card, server-rendered, w/ a small delay (after)"
+        } only %}
+      {% endcell %}
+    {% endgrid %}
+
+
+
+    {% include "@bolt-components-headline/headline.twig" with {
+      text: "Personalized card test, server-rendered, without delay",
+    } only %}
+
+    {% grid "u-bolt-margin-bottom-medium" %}
+      {% cell "u-bolt-width-1/2" %}
+        {% include "@bolt-components-headline/eyebrow.twig" with {
+          text: "Before:",
+        } only %}
+
+        <div class="js-disable-extra-slot-check">
+          {% include "@pl/_personalized-card-example.twig" with {
+            attributes: {
+              class: [
+                "js-personalized-card--server-rendered--without-delay",
+              ],
+            },
+            headline_demo_text: "Personalized card, server-rendered, without a delay (before)"
+          } only %}
+        </div>
+      {% endcell %}
+
+      {% cell "u-bolt-width-1/2" %}
+        {% include "@bolt-components-headline/eyebrow.twig" with {
+          text: "After:",
+        } only %}
+        {% include "@pl/_personalized-card-example.twig" with {
+          attributes: {
+            class: [
+              "js-personalized-card--server-rendered--without-delay"
+            ]
+          },
+          headline_demo_text: "Personalized card, server-rendered, without a delay (after)"
+        } only %}
+      {% endcell %}
+    {% endgrid %}
+  </div>
+</form>

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "address": "^1.0.3",
-    "hard-source-webpack-plugin": "git+https://github.com/talkable/hard-source-webpack-plugin.git#e774ef34ac7de7badf83f8560cca13861e76f23c",
+    "hard-source-webpack-plugin": "git+https://github.com/mzgoddard/hard-source-webpack-plugin.git#fix-missing-hash",
     "@bolt/babel-preset-bolt": "^2.1.6",
     "@bolt/config-browserlist": "^2.1.6",
     "@bolt/fast-sass-loader": "github:bolt-design-system/fast-sass-loader#master",

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -155,6 +155,8 @@ class BoltButton extends withHyperHtml() {
   }
 
   render() {
+    const { iconOnly, target, url } = this.props;
+
     const classes = cx('c-bolt-button', {
       'c-bolt-button--rounded': this.props.rounded,
       'c-bolt-button--disabled': this.props.disabled,
@@ -170,7 +172,7 @@ class BoltButton extends withHyperHtml() {
     });
 
     // Decide on if the rendered button tag should be a <button> or <a> tag, based on if a URL exists OR if a link was passed in from the getgo
-    const hasUrl = this.props.url.length > 0 && this.props.url !== 'null';
+    const hasUrlProp = url.length > 0 && url !== 'null';
 
     // Assign default target attribute value if one isn't specified
     const urlTarget = this.props.target && hasUrl ? this.props.target : '_self';
@@ -222,6 +224,7 @@ class BoltButton extends withHyperHtml() {
       }
       return elementToAppendTo;
     }
+    const urlTarget = target && hasUrlProp ? target : '_self';
 
     if (this.rootElement) {
       buttonElement = this.rootElement.firstChild.cloneNode(true);

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -47,29 +47,33 @@ class BoltButton extends withHyperHtml() {
     const root = this;
 
     // If the initial <bolt-button> element contains a button or link, break apart the original HTML so we can retain any button or a tags but swap out the inner content with slots.
-    this.childNodes.forEach((childElement, i) => {
-      if (childElement.tagName === 'BUTTON' || childElement.tagName === 'A') {
-        root.rootElement = document.createDocumentFragment();
 
-        // Take any existing buttons and links and move them to the root of the custom element
-        while (childElement.firstChild) {
-          root.appendChild(childElement.firstChild);
+    // Make sure the button component ONLY ever reuses any existing HTML ONCE. This, in part, helps to prevent rendering diff errors in HyperHTML after booting up!
+    if (this._wasInitiallyRendered === false) {
+      this.childNodes.forEach((childElement, i) => {
+        if (childElement.tagName === 'BUTTON' || childElement.tagName === 'A') {
+          root.rootElement = document.createDocumentFragment();
+
+          // Take any existing buttons and links and move them to the root of the custom element
+          while (childElement.firstChild) {
+            root.appendChild(childElement.firstChild);
+          }
+
+          if (childElement.className) {
+            childElement.className = sanitizeBoltClasses(childElement);
+          }
+
+          if (
+            childElement.getAttribute('is') &&
+            childElement.getAttribute('is') === 'shadow-root'
+          ) {
+            childElement.removeAttribute('is');
+          }
+
+          root.rootElement.appendChild(childElement);
         }
-
-        if (childElement.className) {
-          childElement.className = sanitizeBoltClasses(childElement);
-        }
-
-        if (
-          childElement.getAttribute('is') &&
-          childElement.getAttribute('is') === 'shadow-root'
-        ) {
-          childElement.removeAttribute('is');
-        }
-
-        root.rootElement.appendChild(childElement);
-      }
-    });
+      });
+    }
 
     // When possible, use afterNextRender to defer non-critical work until after first paint.
     afterNextRender(this, function() {

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -71,8 +71,7 @@ class BoltButton extends withHyperHtml() {
       }
     });
 
-    // When possible, use afterNextRender to defer non-critical
-    // work until after first paint.
+    // When possible, use afterNextRender to defer non-critical work until after first paint.
     afterNextRender(this, function() {
       this.addEventListener('click', this.clickHandler);
     });
@@ -160,7 +159,7 @@ class BoltButton extends withHyperHtml() {
       [`c-bolt-button--${this.props.align}`]: this.props.align,
       'c-bolt-button--primary': !this.props.color, // default color prop
       [`c-bolt-button--${this.props.color}`]: this.props.color,
-      'c-bolt-button--medium': !this.props.size,
+      'c-bolt-button--medium': !this.props.size, // default size prop
       [`c-bolt-button--${this.props.size}`]: this.props.size,
       [`c-bolt-button--${this.props.width}`]: this.props.width,
       [`c-bolt-button--${this.props.transform}`]: this.props.transform,

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -177,8 +177,6 @@ class BoltButton extends withHyperHtml() {
     // Assign default target attribute value if one isn't specified
     const urlTarget = this.props.target && hasUrl ? this.props.target : '_self';
 
-    // The buttonElement to render, based on the initial HTML passed alone.
-    let buttonElement = null;
     const self = this;
 
     const slotMarkup = name => {
@@ -226,19 +224,19 @@ class BoltButton extends withHyperHtml() {
     }
     const urlTarget = target && hasUrlProp ? target : '_self';
 
-    if (this.rootElement) {
-      buttonElement = this.rootElement.firstChild.cloneNode(true);
-      // render(inner, buttonElement); // lit-html syntax
-      buttonElement.className += ' ' + classes;
-    } else if (hasUrl) {
-      buttonElement = wire()`<a href="${
-        this.props.url
-      }" class="${classes}" target="${urlTarget}"></a>`;
-    } else {
-      buttonElement = wire()`<button class="${classes}"></button>`;
-    }
+    // Placeholder for the  buttonElement to render, based on the initial HTML passed alone.
+    let existingButton = null;
 
-    buttonElement = renderInnerSlots(buttonElement);
+    if (this.rootElement) {
+      existingButton = this.rootElement.firstChild.cloneNode(true);
+      existingButton.className += ' ' + classes;
+
+      const slotsForExistingButton = document.createDocumentFragment();
+      for (let i = 0; i < slots.length; i++) {
+        slotsForExistingButton.appendChild(slots[i]);
+      }
+      existingButton.appendChild(slotsForExistingButton);
+    }
 
     return this.html`
       ${this.addStyles([styles, visuallyhiddenUtils])}

--- a/packages/core/renderers/bolt-base.js
+++ b/packages/core/renderers/bolt-base.js
@@ -27,7 +27,7 @@ export function BoltBase(Base = HTMLElement) {
     setupSlots() {
       // Automatically adjust which inner element inside the custom element gets used as the base when evaluating slotted children. Necessary when including deeply nested slots in the initial HTML being rendered, which might include a few wrapping containers that get removed when the JavaScript kicks in. <-- this is how we get slotted buttons to work!
       const isShadowRootSelector = this.querySelector('[is="shadow-root"]');
-      if (isShadowRootSelector && isShadowRootSelector.childNodes) {
+      if (isShadowRootSelector) {
         if (isShadowRootSelector.childNodes) {
           this.slots = this._checkSlots(isShadowRootSelector.childNodes);
         } else {

--- a/packages/core/renderers/bolt-base.js
+++ b/packages/core/renderers/bolt-base.js
@@ -13,7 +13,9 @@ export function BoltBase(Base = HTMLElement) {
     connectedCallback() {
       // NOTE: it's SUPER important that setupSlots is run during the component's connectedCallback lifecycle event
       // Without this, browsers like IE 11 won't re-render as expected when props change!
-      this.setupSlots();
+      if (!this.slots) {
+        this.setupSlots();
+      }
 
       // Automatically force a component to render if no props exist BUT props are defined.
       if (
@@ -55,11 +57,10 @@ export function BoltBase(Base = HTMLElement) {
       // this ensures that things work as expected, even when a component gets removed / re-added to the page
       this.setupShadow();
 
-      // @todo: rework to disable this extra check here (used for demoing before/after behavior), unless a specific feature flag is used (debug mode?)
-      // @todo: Uncommment the following conditional when we have a debug flag or similar solution in place to re-enable test examples.
-      // if (!this.closest('.js-disable-extra-slot-check')) {
-      this.setupSlots(); // hotfix to ensure heavily nested elements containing text-nodes like <replace-with-children> re-render consistently in browsers that don't natively support custom elements Fixes wwwd8-2678
-      // }
+      // @todo: add debug flag the build to allow conditionally enabling / disabling this extra slot setup check here.
+      if (!this.slots) {
+        this.setupSlots(); // hotfix to ensure heavily nested elements containing text-nodes like <replace-with-children> re-render consistently in browsers that don't natively support custom elements Fixes wwwd8-2678
+      }
 
       if (hasNativeShadowDomSupport && this.useShadow === true) {
         return super.renderRoot || shadow(this);

--- a/packages/core/renderers/renderer-hyperhtml.js
+++ b/packages/core/renderers/renderer-hyperhtml.js
@@ -1,5 +1,5 @@
 // HyperHTML Renderer ported to SkateJS
-import { hyper, wire, bind } from 'hyperhtml/cjs';
+import { hyper, wire, bind } from 'hyperhtml';
 import {
   withComponent,
   // shadow,
@@ -8,7 +8,7 @@ import {
 } from '../utils';
 import { BoltBase } from './bolt-base';
 
-export { hyper as html, wire, bind as render } from 'hyperhtml/cjs';
+export { hyper as html, wire, bind as render } from 'hyperhtml';
 
 export function withHyperHtml(Base = HTMLElement) {
   return class extends withComponent(BoltBase(Base)) {

--- a/packages/core/renderers/renderer-hyperhtml.js
+++ b/packages/core/renderers/renderer-hyperhtml.js
@@ -23,7 +23,7 @@ export function withHyperHtml(Base = HTMLElement) {
 
     renderStyles(styles) {
       if (styles) {
-        return wire(this)`
+        return wire()`
           <style>${styles}</style>
         `;
       }
@@ -32,25 +32,26 @@ export function withHyperHtml(Base = HTMLElement) {
     slot(name) {
       if (this.useShadow && hasNativeShadowDomSupport) {
         if (name === 'default') {
-          return wire(this)`
+          return wire()`
             <slot />
           `;
         } else {
-          return wire(this)`
+          return wire()`
             <slot name="${name}" />
           `;
         }
       } else {
         if (name === 'default') {
-          return wire(this)`
+          return wire()`
              ${this.slots.default}
           `;
         } else if (this.slots[name]) {
-          return wire(this)`
+          return wire()`
              ${this.slots[name]}
           `;
         } else {
-          console.log(`The ${name} slot doesn't appear to exist...`);
+          // @todo: update to perhaps still log this when a "debug" mode flag is set.
+          // console.log(`The ${name} slot doesn't appear to exist...`);
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8596,9 +8596,9 @@ har-validator@~5.1.0:
     ajv "^5.3.0"
     har-schema "^2.0.0"
 
-"hard-source-webpack-plugin@git+https://github.com/talkable/hard-source-webpack-plugin.git#e774ef34ac7de7badf83f8560cca13861e76f23c":
+"hard-source-webpack-plugin@git+https://github.com/mzgoddard/hard-source-webpack-plugin.git#fix-missing-hash":
   version "0.12.0"
-  resolved "git+https://github.com/talkable/hard-source-webpack-plugin.git#e774ef34ac7de7badf83f8560cca13861e76f23c"
+  resolved "git+https://github.com/mzgoddard/hard-source-webpack-plugin.git#e774ef34ac7de7badf83f8560cca13861e76f23c"
   dependencies:
     chalk "^2.4.1"
     find-cache-dir "^2.0.0"


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-732

## Summary
This PR includes several component rendering-related updates to proactively address some very specific HyperHTML-related [domdiff](https://github.com/WebReflection/domdiff) library errors observed in Pattern Lab when heavily stress testing Bolt's component rendering / re-rendering behavior in a large variety of different situations and use cases.

## Details
1. Added additional test examples of button and icon components used in dynamically injected cards with varying time delays, but used inside of <form> elements to force the inner components to not render to the Shadow DOM

2. Updates the Bolt Base component internal processing / setup work to fix one of the domdiff errors thrown when dynamically injected `<bolt-button>`s that are not rendered to the Shadow DOM are then moved around the page after initially rendering

3. Updates the HyperHTML base component renderer to not pass in any params to the HyperHTML `wire()` function which fixes another HyperHTML domdiff-related JavaScript error observed

4. Updates the Bolt button component's internal JS logic that's responsible for handling the initial button and link HTML that max exist when the component initially boots up. 

This PR specifically updates this logic to only run once (before the component has rendered) to prevent an occasional error from getting thrown relating to inner DOM changes that HyperHTML isn't expected.

5. This PR also further simplifies and consolidates the button component's inner slot related JavaScript logic to help simplify the number of moving parts, make the code a bit more manageable, fix a JS error related to slot names not existing (observed in Node.js jest testing) and flatten out some of the internal template logic required.

## How to test
TBD -- this PR is the reference point being used for additional testing coverage being worked on