### PR TITLE
Chore: Update Default Webpack Sourcemap Config Used for Local Development

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -506,14 +506,14 @@ async function createWebpackConfig(buildConfig) {
       }),
     );
 
-    // @todo Evaluate best source map approach for production
+    // @todo evaluate best source map approach for production builds -- particularly source-map vs hidden-source-map
     webpackConfig.devtool =
       config.sourceMaps === false ? '' : 'hidden-source-map';
   } else {
     // not prod
     // @todo fix source maps
     webpackConfig.devtool =
-      config.sourceMaps === false ? '' : 'cheap-module-eval-source-map';
+      config.sourceMaps === false ? '' : 'eval-source-map';
   }
 
   if (config.wwwDir) {


### PR DESCRIPTION
## Jira
N/A

## Summary
Updates the default sourcemap config settings used in Bolt's Webpack's devtool configuration for local dev. 

## Details
This PR switches us over to use the even more detailed sourcemap data when doing dev work / debugging locally after out the extra processing time this adds with the added Hard Source Cache config updates.
