### PR TITLE
Add quick cache buster to Bolt docs site

### DIFF
--- a/apps/bolt-site/templates/_site-footer.twig
+++ b/apps/bolt-site/templates/_site-footer.twig
@@ -6,6 +6,8 @@
   {% set assets = [] %}
 {% endif %}
 
-<script src="{{ assets["bolt-global.js"] | default("/build/bolt-global.js") }}" async></script>
+{% set cacheBuster = bolt.data.config.prod ? "?v=" ~ bolt.data.fullManifest.version : "" %}
+
+<script src="{{ assets["bolt-global.js"] | default("/build/bolt-global.js") }}{{ cacheBuster }}" async></script>
   </body>
 </html>

--- a/apps/bolt-site/templates/_site-head.twig
+++ b/apps/bolt-site/templates/_site-head.twig
@@ -18,6 +18,7 @@
 {% endif %}
 {% set hasSidebar = nestedPages or sidebar %}
 
+{% set cacheBuster = bolt.data.config.prod ? "?v=" ~ bolt.data.fullManifest.version : "" %}
 
 <!DOCTYPE html>
 <html lang="en-US" class="{{ bolt.data.config.prod ? '' : 'js-fonts-loaded' }}">
@@ -56,7 +57,7 @@
     <meta name="twitter:image" content="https://boltdesignsystem.com/images/bolt-logo-480.png" />
     <meta name="twitter:site" content="@pega" />
 
-    <link rel="stylesheet" href="{{ assets["bolt-global.css"] | default("/build/bolt-global.css") }}" media="all" />
+    <link rel="stylesheet" href="{{ assets["bolt-global.css"] | default("/build/bolt-global.css") }}{{ cacheBuster }}" media="all" />
 
     {# @TODO: wire this up to use Critical CSS #}
     <style>


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds a quick cache buster query string to the Bolt docs site head and footer’s main CSS and JS bundles.

## Details
Quick workaround to the now.sh cache not always getting cleared in certain situations — namely when aliasing an existing deployment (like taking the existing deployment that’s running on the master.boltdesignsystem.com URL alias) and remapping it to another domain (like the live boltdesignsystem.com site).

Screenshots below show some of the old CSS showing up in the new version selector UI  (before manually clearing the browser cache):

![8b2dff4d-a393-461c-9e03-bb0d334b2f23](https://user-images.githubusercontent.com/1617209/47912490-40851600-de6f-11e8-8f97-1342b123107d.png)
![5d562407-bc28-45b3-9938-a749b3610ba6](https://user-images.githubusercontent.com/1617209/47912491-40851600-de6f-11e8-8395-42b312817d38.png)

Note: we already deal with cache busting hashes in async loaded bundles — this is specifically dealing with cache busting the main entry file loaded till we get a more advanced Webpack solution wired up for this.

## How to test
Confirm docs site JS and CSS loading as expected.
