### PR TITLE
WIP: Add example of navbar without links (BDS-748)

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/navbar/40-navbar--no-links.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/navbar/40-navbar--no-links.twig
@@ -1,0 +1,10 @@
+{% include "@bolt-components-navbar/navbar.twig" with {
+  "title": {
+    "tag": "h2",
+    "text": "Navbar without links",
+    "icon": {
+      "name": "marketing-gray"
+    }
+  },
+  "links": []
+} %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-2764
http://vjira2:8080/browse/BDS-748

## Summary

TBD

## Details

TBD

## How to test

### Confirm the issue
- In iPhone 6s Plus Safari, go to the newly created example of navbar without links on this branch: https://boltdesignsystem-atauusuzzv.now.sh/pattern-lab/?p=components-navbar--no-links
- Confirm that a chevron shows despite there not being nav links
