### PR TITLE
Opacity scale

### DIFF
--- a/apps/pattern-lab/src/_patterns/01-styleguide/40-utilities/opacity.twig
+++ b/apps/pattern-lab/src/_patterns/01-styleguide/40-utilities/opacity.twig
@@ -8,17 +8,17 @@
     <p>Add the utility class <code>.u-bolt-opacity-xx</code> where xx equals the opacity you wish to apply.</p>
     <p><strong><u>Possible values include:</u></strong></p>
     <ul>
-      {% for opacity in opacities %}
-        <li><code>{{ opacity * 100 }}</code></li>
+      {% for key, value in opacities %}
+        <li><code>{{ key }}</code></li>
       {% endfor %}
     </ul>
   {% endblock %}
 
   {% block utility_demo %}
-    {% for opacity in opacities|reverse %}
+    {% for key, value in opacities|reverse(true) %}
       <div class="c-bolt-docs__opacity-demo">
-        <h4>Opacity items: <code>{{ ".u-bolt-opacity-#{opacity * 100}" }}</code></h4>
-        <div class="c-bolt-docs__opacity-item {{ "u-bolt-opacity-#{opacity * 100}" }}">
+        <h4>Opacity class: <code>{{ ".u-bolt-opacity-#{key}" }}</code></h4>
+        <div class="c-bolt-docs__opacity-item {{ "u-bolt-opacity-#{key}" }}">
           {% include "@bolt-components-teaser/teaser.twig" with {
             content: "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin vel ante a orci tempus eleifend ut et magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             buttons: [

--- a/packages/components/bolt-action-blocks/src/action-blocks.scss
+++ b/packages/components/bolt-action-blocks/src/action-blocks.scss
@@ -61,13 +61,13 @@ $bolt-action-block-background: bolt-color(indigo, light);
     content: '';
     pointer-events: none;
     background-color: $bolt-action-block-background;
-    opacity: 0;
+    opacity: bolt-opacity(0);
     transition: all $bolt-action-block-transition-timing cubic-bezier(0.25, 0.8, 0.25, 1);
   }
 
   &:hover, &:focus {
     &:before {
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
   }
 

--- a/packages/components/bolt-background/src/background.scss
+++ b/packages/components/bolt-background/src/background.scss
@@ -93,13 +93,13 @@ $bolt-bg-shape-offset-side-large: $bolt-bg-shape-offset-bottom-large * 1.2;
   }
 
   .is-collapsed & {
-    opacity: 0;
+    opacity: bolt-opacity(0);
     pointer-events: none;
     visibility: hidden;
   }
 
   .is-expanded & {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     pointer-events: auto;
     visibility: visible;
   }
@@ -133,7 +133,7 @@ $bolt-bg-shape-offset-side-large: $bolt-bg-shape-offset-bottom-large * 1.2;
   left: -9999px;
 
   .is-expanded & {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     filter: blur(10px);
   }
 }

--- a/packages/components/bolt-button/src/_button.mixins.scss
+++ b/packages/components/bolt-button/src/_button.mixins.scss
@@ -13,7 +13,7 @@
 
     &:hover:before,
     &.is-hover:before {
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
 
     &:active,
@@ -23,7 +23,7 @@
 
     &:active:before,
     &.is-active:before {
-      opacity: 0;
+      opacity: bolt-opacity(0);
     }
   }
 }
@@ -142,12 +142,12 @@
   }
 
   & {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     color: bolt-theme(headline-link);
   }
 
   &:visited {
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   &:hover:not([disabled]) {
@@ -175,7 +175,7 @@
   &:before,
   &:hover:before,
   &:active:before {
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   &,

--- a/packages/components/bolt-card/src/card.scss
+++ b/packages/components/bolt-card/src/card.scss
@@ -58,7 +58,7 @@ bolt-card {
     background-color: bolt-theme(background, 0.8);
 
     &:before {
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
 
     @supports (backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px)) {

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.scss
@@ -24,12 +24,12 @@ $bolt-copy-to-clipboard-transition: all $bolt-copy-to-clipboard-animation-durati
   &.is-animating {
     .c-bolt-copy-to-clipboard__trigger {
       pointer-events: none;
-      opacity: 0;
+      opacity: bolt-opacity(0);
       transition-delay: 0s; // [2]
     }
 
     .c-bolt-copy-to-clipboard__transition {
-      opacity: 1;
+      opacity: bolt-opacity(100);
       transition-delay: $bolt-copy-to-clipboard-animation-duration; // [1]
     }
 
@@ -54,12 +54,12 @@ $bolt-copy-to-clipboard-transition: all $bolt-copy-to-clipboard-animation-durati
 
   &.is-animating.is-successful {
     .c-bolt-copy-to-clipboard__transition {
-      opacity: 0;
+      opacity: bolt-opacity(0);
       transition-delay: 0s; // [2]
     }
 
     .c-bolt-copy-to-clipboard__confirmation {
-      opacity: 1;
+      opacity: bolt-opacity(100);
       transition-delay: $bolt-copy-to-clipboard-animation-duration; // [1]
     }
   }
@@ -80,7 +80,7 @@ $bolt-copy-to-clipboard-transition: all $bolt-copy-to-clipboard-animation-durati
   font-weight: inherit;
   border: none;
   background: none;
-  opacity: 1;
+  opacity: bolt-opacity(100);
   transition: $bolt-copy-to-clipboard-transition;
   transition-delay: $bolt-copy-to-clipboard-animation-duration; // [1]
 }
@@ -114,7 +114,7 @@ $bolt-copy-to-clipboard-transition: all $bolt-copy-to-clipboard-animation-durati
 
 .c-bolt-copy-to-clipboard__info {
   color: bolt-theme(text);
-  opacity: 0.4;
+  opacity: bolt-opacity(40);
 }
 
 .c-bolt-copy-to-clipboard__transition,
@@ -125,7 +125,7 @@ $bolt-copy-to-clipboard-transition: all $bolt-copy-to-clipboard-animation-durati
   left: 0;
   width: 100%;
   pointer-events: none;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   transition: $bolt-copy-to-clipboard-transition;
 }
 

--- a/packages/components/bolt-device-viewer/src/device-viewer.scss
+++ b/packages/components/bolt-device-viewer/src/device-viewer.scss
@@ -91,29 +91,29 @@ $bolt-magnifier-size: 350px;
 @keyframes pulseFadeIn {
   0% {
     transform: scale(1.5) translate3d(-50%, -50%, 0);
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 
   100% {
     transform: scale(1) translate3d(-50%, -50%, 0);
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 }
 
 @keyframes pulseFadeOut {
   0% {
     transform: scale(1) translate3d(-50%, -50%, 0);
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   15% {
     transform: scale(1.1) translate3d(-50%, -50%, 0);
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   100% {
     transform: scale(4) translate3d(-50%, -50%, 0);
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 }
 
@@ -123,24 +123,24 @@ $bolt-magnifier-size: 350px;
 @keyframes drift-fadeZoomIn {
   0% {
     transform: scale(0.5);
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 
   100% {
     transform: scale(1);
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 }
 
 @keyframes drift-fadeZoomOut {
   0% {
     transform: scale(1);
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   100% {
     transform: scale(0.5);
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 }
 
@@ -183,7 +183,7 @@ $bolt-magnifier-size: 350px;
   left: 0%;
   width: 100%;
   height: 100%;
-  opacity: 1;
+  opacity: bolt-opacity(100);
   transition: all 0.2s linear;
   pointer-events: none;
   color: bolt-color(white);
@@ -198,7 +198,7 @@ $bolt-magnifier-size: 350px;
     width: 200%;
     height: 200%;
     content: '';
-    opacity: 1;
+    opacity: bolt-opacity(100);
     transition: all 0.2s linear;
     pointer-events: none;
     transform: translate3d(-50%, -50%, 0);
@@ -237,7 +237,7 @@ $bolt-magnifier-size: 350px;
 
 .c-bolt-image-zoom__tilt {
   display: block;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   position: absolute;
   z-index: bolt-z-index('content');
   width: 33.33%;
@@ -375,7 +375,7 @@ bolt-device-viewer .c-bolt-device-viewer__screen--magnify {
 
 
 bolt-image-zoom:hover > .c-bolt-image-zoom__overlay {
-  opacity: 0;
+  opacity: bolt-opacity(0);
 }
 
 

--- a/packages/components/bolt-dropdown/dropdown.scss
+++ b/packages/components/bolt-dropdown/dropdown.scss
@@ -64,7 +64,7 @@ bolt-dropdown {
     display: block;
     background-color: transparent;
     transition: opacity .1s ease;
-    opacity: 0;
+    opacity: bolt-opacity(0);
     background-color: bolt-theme(headline-link);
   }
 }
@@ -268,14 +268,14 @@ bolt-dropdown {
 }
 
 // .c-bolt-dropdown__header-icon--close {
-//   // opacity: 1;
+//   // opacity: bolt-opacity(100);
 //   transform: rotate(180deg);
 //   z-index: 900;
 // }
 
 
 // .c-bolt-dropdown__header-icon--open {
-//   // opacity: 0;
+//   // opacity: bolt-opacity(0);
 //   // float: none;
 //   // position: absolute;
 //   // top: 0;
@@ -295,10 +295,10 @@ bolt-dropdown {
     transform: rotate(0deg);
   }
   .c-bolt-dropdown__header-icon--open {
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
   .c-bolt-dropdown__header-icon--close {
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 }
 
@@ -308,12 +308,12 @@ bolt-dropdown {
   }
 
   .c-bolt-dropdown__header-icon--open {
-    opacity: 0;
+    opacity: bolt-opacity(0);
     // transform: translate3d(-50%, -50%, 0px) rotate(179deg);
   }
 
   .c-bolt-dropdown__header-icon--close {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     // transform: translate3d(-50%, -50%, 0px) rotate(360deg);
   }
 }
@@ -325,20 +325,20 @@ bolt-dropdown {
 // .c-bolt-dropdown[role="presentation"]{
 //   .c-bolt-dropdown__header--open {
 //     .c-bolt-dropdown__header-icon--close {
-//       opacity: 0;
+//       opacity: bolt-opacity(0);
 //     }
 
 //     .c-bolt-dropdown__header-icon--open {
-//       opacity: 1;
+//       opacity: bolt-opacity(100);
 //     }
 //   }
 
 //   .c-bolt-dropdown__header--open {
 //     .c-bolt-dropdown__header-icon--close {
-//       opacity: 0;
+//       opacity: bolt-opacity(0);
 //     }
 //     .c-bolt-dropdown__header-icon--open {
-//       opacity: 1;
+//       opacity: bolt-opacity(100);
 //     }
 //   }
 // }
@@ -379,12 +379,12 @@ bolt-dropdown {
   // padding-bottom: 13px;
   // padding-left: 16px;
   // padding-right: 16px;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   transition: opacity .1s ease;
 
   .c-bolt-dropdown--collapse\@small & {
     @include bolt-mq(small) {
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
   }
   // transition: opacity 0.2s cubic-bezier(0, 0, 0.3, 1) 0.1s;
@@ -402,7 +402,7 @@ bolt-dropdown {
     background-color: transparent;
     transition: opacity 0.1s ease;
     background-color: bolt-theme(background);
-    opacity: 1;
+    opacity: bolt-opacity(100);
 
     filter: contrast(80%) brightness(110%);
   }
@@ -411,7 +411,7 @@ bolt-dropdown {
 .c-bolt-dropdown__state:target + .c-bolt-dropdown .c-bolt-dropdown__content-inner,
 .c-bolt-dropdown__state:checked + .c-bolt-dropdown .c-bolt-dropdown__content-inner,
 .c-bolt-dropdown__content--opened .c-bolt-dropdown__content-inner {
-  opacity: 1;
+  opacity: bolt-opacity(100);
   transition: opacity 0.3s ease;
 }
 
@@ -434,7 +434,7 @@ bolt-dropdown {
 // .c-bolt-dropdown_
 //   height: 44px;
 //   border-bottom: 1px solid #333;
-//   opacity: 0;
+//   opacity: bolt-opacity(0);
 //   pointer-events: none;
 // transform: scale(1.2, 1.2) translateY(-55px);
 // transition: opacity .35s ease-out,
@@ -473,7 +473,7 @@ bolt-dropdown {
 
   .c-bolt-dropdown--collapse\@small & {
     @include bolt-mq(small) {
-      opacity: 1;
+      opacity: bolt-opacity(100);
       transform: translateY(0);
     }
   }
@@ -504,7 +504,7 @@ bolt-dropdown {
 .c-bolt-dropdown__state:target + .c-bolt-dropdown .c-bolt-nav__item,
 .c-bolt-dropdown__state:checked + .c-bolt-dropdown .c-bolt-nav__item,
 .c-bolt-dropdown__content--opened .c-bolt-nav__item {
-  // opacity: 1;
+  // opacity: bolt-opacity(100);
   // transform: none;
   @include bolt-css-vars((
     --bolt-nav-item-opacity: 1,
@@ -515,7 +515,7 @@ bolt-dropdown {
 .c-bolt-dropdown__state:target + .c-bolt-dropdown .c-bolt-nav__indicator,
 .c-bolt-dropdown__state:checked + .c-bolt-dropdown .c-bolt-nav__indicator,
 .c-bolt-dropdown__content--opened .c-bolt-nav__indicator {
-  // opacity: 1;
+  // opacity: bolt-opacity(100);
 }
 
 
@@ -565,7 +565,7 @@ bolt-dropdown {
 // .c-bolt-block-list__item {
 //   // height: 43px;
 //   // border-bottom: 1px solid #333;
-//   // opacity: 0;
+//   // opacity: bolt-opacity(0);
 //   // pointer-events: none;
 
 // }

--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -111,7 +111,7 @@ $bolt-input-transition: $bolt-transition;
 
     // Workaround for pega.com Drupal, which currently uses sanitize.css.  Once that's
     // removed, the following line will be unnecessary.
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   &::-moz-placeholder { /* Firefox 19+ */
@@ -144,7 +144,7 @@ $bolt-input-transition: $bolt-transition;
   border-width: $bolt-input-border-width;
   border-radius: $bolt-input-border-radius;
   background-color: $bolt-input-background-color;
-  opacity: 1; // [Mai] Reset mobile Safari browser default.
+  opacity: bolt-opacity(100); // [Mai] Reset mobile Safari browser default.
   outline: none;
   transition: all $bolt-input-transition;
 
@@ -223,7 +223,7 @@ $bolt-input-transition: $bolt-transition;
   white-space: nowrap;
   user-select: none;
   pointer-events: none;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   transform: translate3d(0, -50%, 0) translateY(.4rem);
   transform-origin: 0 100%;
   transition: all $bolt-floating-label-transition;
@@ -234,7 +234,7 @@ $bolt-input-transition: $bolt-transition;
 .c-bolt-custom-input.is-active {
   // [Mai] A custom input is considered active if the regular input inside is filled or in focus.
   & ~ .c-bolt-floating-label {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     transform: translate3d(0, -100%, 0) translateY(.1rem) scale($bolt-floating-label-text-scale);
   }
 }
@@ -276,7 +276,7 @@ $bolt-input-transition: $bolt-transition;
 
   &:after {
     content: '';
-    opacity: 0;
+    opacity: bolt-opacity(0);
     transform-origin: center;
   }
 }
@@ -335,7 +335,7 @@ $bolt-input-transition: $bolt-transition;
     }
 
     &:after {
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
 
     .c-bolt-inline-label__emphasize {

--- a/packages/components/bolt-icon/src/icon.scss
+++ b/packages/components/bolt-icon/src/icon.scss
@@ -114,13 +114,13 @@ bolt-icon[size='xlarge'],
 
   .c-bolt-icon__background-shape {
     background-color: $brand-color;
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   @include bolt-css-vars((
     --bolt-theme-icon: $contrast-color,
     --bolt-theme-icon-background: $brand-color,
-    --bolt-theme-icon-background-opacity: 1,
+    --bolt-theme-icon-background-opacity: bolt-opacity(100),
   ));
 
   // Properties must be re-declared here so that CSS variable values will take precedence over hard-coded values for
@@ -144,13 +144,13 @@ bolt-icon[size='xlarge'],
 
   .c-bolt-icon__background-shape {
     background-color: $contrast-color;
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   @include bolt-css-vars((
     --bolt-theme-icon: $brand-color,
     --bolt-theme-icon-background: $contrast-color,
-    --bolt-theme-icon-background-opacity: 1,
+    --bolt-theme-icon-background-opacity: bolt-opacity(100),
   ));
 
   // Properties must be re-declared here so that CSS variable values will take precedence over hard-coded values for

--- a/packages/components/bolt-image/src/image.scss
+++ b/packages/components/bolt-image/src/image.scss
@@ -17,10 +17,10 @@ bolt-image {
 }
 
 .c-bolt-image__lazyload--fade {
-  opacity: 0;
+  opacity: bolt-opacity(0);
 
   &.is-lazyloaded {
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 }
 

--- a/packages/components/bolt-link/src/link.scss
+++ b/packages/components/bolt-link/src/link.scss
@@ -24,7 +24,7 @@ $bolt-link-transition: $bolt-transition;
   text-decoration: underline;
   border: none;  // [1]
   background: none;  // [1]
-  opacity: 1;
+  opacity: bolt-opacity(100);
   transition: all $bolt-link-transition;
   color: bolt-theme(link);
 

--- a/packages/components/bolt-nav-indicator/nav-indicator.scss
+++ b/packages/components/bolt-nav-indicator/nav-indicator.scss
@@ -20,7 +20,7 @@ bolt-nav-indicator {
   width: 0;
   height: ($bolt-nav-indicator-border-size);
   background-color: bolt-theme(primary);
-  opacity: 1; // [Mai] This is interrelated with the dropdown component.
+  opacity: bolt-opacity(100); // [Mai] This is interrelated with the dropdown component.
   opacity: var(--bolt-nav-indicator-opacity, 1); // [Mai] This is interrelated with the dropdown component.
   transform: translateY(var(--bolt-nav-indicator-transform)); // [Mai] This is interrelated with the dropdown component.
   transition:

--- a/packages/components/bolt-nav-priority/nav-priority.scss
+++ b/packages/components/bolt-nav-priority/nav-priority.scss
@@ -115,12 +115,12 @@ bolt-nav-priority {
     @include bolt-padding-right(xsmall);
   }
 
-  opacity: 0;
+  opacity: bolt-opacity(0);
   transform: translate3d(0, bolt-spacing(medium) * -1, 0);
   transition: transform 0.3s cubic-bezier(0.23, 1, 0.32, 1) 0s, opacity 0.2s cubic-bezier(0.23, 1, 0.32, 1) 0.1s;
 
   .c-bolt-nav-priority--show-dropdown & {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     transform: translate3d(0, 0, 0);
     transition-delay: 0.2s, 0.1s;
     pointer-events: auto;
@@ -188,11 +188,11 @@ bolt-nav-priority {
 // keyframes
 @keyframes nav-dropdown {
   0% {
-    opacity: 0;
+    opacity: bolt-opacity(0);
     transform: translateY(-1em);
   }
   100% {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     transform: translateY(0);
   }
 }
@@ -230,7 +230,7 @@ bolt-nav-priority {
     left: 0;
     top: 0;
     pointer-events: none;
-    opacity: 0;
+    opacity: bolt-opacity(0);
     pointer-events: none;
     transition: opacity 0.3s ease;
     background-color: bolt-theme(
@@ -325,7 +325,7 @@ bolt-nav-priority {
 .c-bolt-nav-priority__dropdown-list > .c-bolt-nav-priority__item {
   transition: opacity 0.3s cubic-bezier(0.28, 0.11, 0.32, 1), transform 0.3s cubic-bezier(0.28, 0.11, 0.32, 1); // transition:
   transform: translate3d(0, bolt-spacing(large) * -1, 0);
-  opacity: 0;
+  opacity: bolt-opacity(0);
   transition-property: transform, opacity;
 }
 
@@ -348,6 +348,6 @@ bolt-nav-priority {
 }
 
 .c-bolt-nav-priority--show-dropdown .c-bolt-nav-priority__dropdown-list > .c-bolt-nav-priority__item {
-  opacity: 1;
+  opacity: bolt-opacity(100);
   transform: translate3d(0, 0, 0);
 }

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -184,7 +184,7 @@ bolt-navbar {
 
 .c-bolt-navbar__title--link {
   text-decoration: none;
-  opacity: 1;
+  opacity: bolt-opacity(100);
   transition: all $bolt-navbar-title-transition;
   display: flex;
   align-self: center;

--- a/packages/components/bolt-navlink/navlink.scss
+++ b/packages/components/bolt-navlink/navlink.scss
@@ -50,7 +50,7 @@ bolt-navlink {
   &.is-active {
     color: bolt-theme(headline-link);
     border-color: transparent;
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 
   &:before {

--- a/packages/components/bolt-page-header/src/page-header.scss
+++ b/packages/components/bolt-page-header/src/page-header.scss
@@ -604,12 +604,12 @@
   }
 
   .c-mega-nav__level-1.c-mega-nav__list .c-mega-nav__level-2.c-mega-nav__list.is-hidden {
-    opacity: 0;
+    opacity: bolt-opacity(0);
     visibility: hidden;
   }
 
   .c-mega-nav__level-1.c-mega-nav__list .c-mega-nav__level-2.c-mega-nav__list.is-hidden:before {
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 
   .c-mega-nav__level-1.c-mega-nav__list .c-mega-nav__level-2.c-mega-nav__list > .c-mega-nav__item {
@@ -688,7 +688,7 @@
     background-color: #333;
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 
   .c-mega-nav__level-1.c-mega-nav__list > .has-children > .c-mega-nav__link:before {
@@ -782,7 +782,7 @@
 }
 
 .c-header-dropdown__level-1 {
-  opacity: 0;
+  opacity: bolt-opacity(0);
   visibility: hidden;
   border-radius: 4px;
   background: #fff;
@@ -821,7 +821,7 @@
   right: 0;
   white-space: nowrap;
   visibility: visible;
-  opacity: 1;
+  opacity: bolt-opacity(100);
   position: absolute;
   right: 0;
   top: 50%;
@@ -900,7 +900,7 @@
 }
 
 .c-hamburger__button--open {
-  opacity: 1;
+  opacity: bolt-opacity(100);
   z-index: bolt-z-index('content') + 5;
 }
 
@@ -920,7 +920,7 @@
   right: 0;
   width: 100%;
   background-color: white;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   visibility: hidden;
   z-index: bolt-z-index('content');
   padding: 0 1rem;
@@ -956,7 +956,7 @@
   padding: 0;
   border: 0;
   outline: 0;
-  opacity: 0;
+  opacity: bolt-opacity(0);
 }
 
 .c-global-search__submit {
@@ -968,7 +968,7 @@
   padding: 12px;
   font-size: 1em;
   left: 0;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   visibility: hidden;
 }
 
@@ -1077,7 +1077,7 @@
   -webkit-transform: none;
   transform: none;
   position: relative;
-  opacity: 1;
+  opacity: bolt-opacity(100);
   visibility: visible;
 }
 
@@ -1090,7 +1090,7 @@
   left: 0;
   background-color: rgba(0,0,0,0.1);
   visibility: hidden;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   -webkit-transform: translateX(0);

--- a/packages/components/bolt-pagination/pagination.scss
+++ b/packages/components/bolt-pagination/pagination.scss
@@ -65,7 +65,7 @@ $bolt-pagination-item-size: bolt-spacing(medium);
   &.is-current {
     color: bolt-theme(background);
     background-color: bolt-theme(headline-link);
-    opacity: 1;  // Current item is not a link so its styling shouldn't change based on state.
+    opacity: bolt-opacity(100);  // Current item is not a link so its styling shouldn't change based on state.
   }
 }
 
@@ -104,6 +104,6 @@ $bolt-pagination-item-size: bolt-spacing(medium);
   &:hover,
   &:active,
   &:focus:active {
-    opacity: 1;
+    opacity: bolt-opacity(100);
   }
 }

--- a/packages/components/bolt-search-filter/search-filter.scss
+++ b/packages/components/bolt-search-filter/search-filter.scss
@@ -41,7 +41,7 @@ $bolt-search-filter-transition: $bolt-transition;
 
     &:not(:target) {
       pointer-events: none;
-      opacity: 0;
+      opacity: bolt-opacity(0);
 
       .c-bolt-search-filter__panel-content,
       .c-bolt-search-filter__panel-controls--close,
@@ -51,7 +51,7 @@ $bolt-search-filter-transition: $bolt-transition;
     }
 
     &:target {
-      opacity: 1;
+      opacity: bolt-opacity(100);
 
       .c-bolt-search-filter__panel-content,
       .c-bolt-search-filter__panel-controls--close,

--- a/packages/components/bolt-share/src/share.scss
+++ b/packages/components/bolt-share/src/share.scss
@@ -12,15 +12,13 @@ $bolt-share-block-link-inline-spacing: 'xsmall';
   display: block;
 }
 
-$bolt-share-opacity: 100, 80, 60, 40, 20;
-
-@each $opacity in $bolt-share-opacity {
-  .c-bolt-share--opacity-#{$opacity} {
-    opacity: #{$opacity / 100};
+@each $key, $value in $bolt-opacities {
+  .c-bolt-share--opacity-#{$key} {
+    @include bolt-opacity($key);
     transition: opacity $bolt-transition;
 
     &:hover {
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
   }
 }
@@ -29,7 +27,7 @@ $bolt-share-opacity: 100, 80, 60, 40, 20;
   @include bolt-font-size(xsmall);
 
   color: bolt-theme(text);
-  opacity: 0.6;
+  opacity: bolt-opacity(60);
 }
 
 .c-bolt-share__label--medium {

--- a/packages/components/bolt-text/src/text.scss
+++ b/packages/components/bolt-text/src/text.scss
@@ -39,7 +39,7 @@ $bolt-text-v2--plus-letter-spacing: 0.05rem;
   @include bolt-padding(0);
 
   a {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     transition: all $bolt-transition;
 
     &:link,
@@ -260,20 +260,10 @@ $bolt-text-v2--plus-letter-spacing: 0.05rem;
   }
 
   // Opacity
-  &--opacity-100 {
-    opacity: 1;
-  }
-  &--opacity-80 {
-    opacity: 0.8;
-  }
-  &--opacity-60 {
-    opacity: 0.6;
-  }
-  &--opacity-40 {
-    opacity: 0.4;
-  }
-  &--opacity-20 {
-    opacity: 0.2;
+  @each $key, $value in $bolt-opacities {
+    &--opacity-#{$key} {
+      opacity: bolt-opacity($key);
+    }
   }
 
   // Icon Alignment

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -51,12 +51,12 @@ $bolt-tooltip-transition: $bolt-transition;
 
   // Aria tags for accessibility.
   [aria-hidden="true"] {
-    opacity: 0;
+    opacity: bolt-opacity(0);
     pointer-events: none;
   }
 
   [aria-hidden="false"] {
-    opacity: 1;
+    opacity: bolt-opacity(100);
     pointer-events: auto;
   }
 
@@ -411,21 +411,21 @@ $bolt-tooltip-transition: $bolt-transition;
     top: 0; // For IE 11
     bottom: 0; // For IE 11
     left: 50%; // For IE 11 
-    opacity: 0;
+    opacity: bolt-opacity(0);
     transform: translate3d(-50%, -200%, 0);
 
     .is-active & {
-      opacity: 1;
+      opacity: bolt-opacity(100);
       transform: translate3d(-50%, 0, 0);
     }
   }
 
   .toggle--closed {
     transform: translate3d(0, 0, 0);
-    opacity: 1;
+    opacity: bolt-opacity(100);
 
     .is-active & {
-      opacity: 0;
+      opacity: bolt-opacity(0);
       transform: translate3d(0, 200%, 0);
     }
   }
@@ -442,7 +442,7 @@ $bolt-tooltip-transition: $bolt-transition;
     pointer-events: none;
 
     .is-active+& {
-      opacity: 1 !important; // Brings us back only when active
+      opacity: bolt-opacity(100) !important; // Brings us back only when active
       pointer-events: auto !important; // Brings back the ability to click links within the tooltip only when active
     }
   }
@@ -474,13 +474,13 @@ $bolt-tooltip-transition: $bolt-transition;
 // Show and hide effects
 .c-bolt-tooltip:not(:hover) > .c-bolt-tooltip__content,
 .c-bolt-tooltip__trigger + .c-bolt-tooltip__content {
-  opacity: 0;
+  opacity: bolt-opacity(0);
   pointer-events: none;
 }
 
 .c-bolt-tooltip:hover > .c-bolt-tooltip__content,
 .c-bolt-tooltip__trigger.is-active + .c-bolt-tooltip__content {
-  opacity: 1;
+  opacity: bolt-opacity(100);
   pointer-events: auto;
 }
 

--- a/packages/components/bolt-video/src/_video-meta.scss
+++ b/packages/components/bolt-video/src/_video-meta.scss
@@ -34,7 +34,7 @@ $bolt-video-meta-transition: $bolt-transition;
   color: bolt-color(white);
   border-radius: $bolt-video-meta-border-radius;
   background-color: rgba(bolt-color(black), 0.8);
-  opacity: 1;
+  opacity: bolt-opacity(100);
   transition: opacity $bolt-video-meta-transition;
 }
 
@@ -53,7 +53,7 @@ $bolt-video-meta-transition: $bolt-transition;
 // [Mai] Hide the duration (which covers the controls) video is started or when paused.
 #{$bolt-namespace}-video.is-paused {
   .c-#{$bolt-namespace}-video-meta__item--duration {
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 }
 
@@ -61,13 +61,13 @@ $bolt-video-meta-transition: $bolt-transition;
 #{$bolt-namespace}-video.is-playing,
 #{$bolt-namespace}-video.is-finished {
   .c-#{$bolt-namespace}-video-meta__item {
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 }
 
 // [Mai] Hide the title and duration when user opens the share dialog.
 .vjs-controls-disabled ~ #{$bolt-namespace}-video-meta {
   .c-#{$bolt-namespace}-video-meta__item {
-    opacity: 0;
+    opacity: bolt-opacity(0);
   }
 }

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -20,7 +20,7 @@ $bolt-video-js-button-shadow-color: bolt-color(black);
 $bolt-video-js-button-shadow-level: 'level-20';
 $bolt-video-js-button-shadow-level-hover: 'level-40';
 
-@mixin bolt-video-js-button($opacity: 1) {
+@mixin bolt-video-js-button($opacity: bolt-opacity(100)) {
   color: $bolt-video-js-button-text-color;
   background-color: $bolt-video-js-button-background-color;
   transition: all $bolt-video-js-button-transition;
@@ -40,7 +40,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
   .vjs-big-play-button {
     @include bolt-margin(0);
     @include bolt-padding(0);
-    @include bolt-video-js-button($opacity: 1);
+    @include bolt-video-js-button($opacity: bolt-opacity(100));
     @include bolt-shadow($key: $bolt-video-js-button-shadow-level, $base-color: $bolt-video-js-button-shadow-color);
 
     position: absolute;

--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -23,7 +23,7 @@ $bolt-video-background-max-height: 50.625vw;
     transition: opacity 0.3s ease, min-height 0.3s ease;
     background-color: $bolt-video-background-color;
     pointer-events: none;
-    opacity: 0;
+    opacity: bolt-opacity(0);
     height: calc((90vw * (9 / 16)) - 4rem);
     max-width: 100vh;
     max-height: 56.25vh;
@@ -34,7 +34,7 @@ $bolt-video-background-max-height: 50.625vw;
 
     .is-expanded & {
       pointer-events: auto;
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
 
     .video-js {
@@ -103,27 +103,27 @@ $bolt-video-background-max-height: 50.625vw;
   top: bolt-spacing(xsmall);
   right: bolt-spacing(xsmall);
   transition: all 0.3s ease;
-  opacity: 0; // Initial state before brightcove video player kicks in
+  opacity: bolt-opacity(0); // Initial state before brightcove video player kicks in
 
   @include bolt-mq(small) {
     right: (bolt-spacing(large) / -2) - bolt-spacing(xsmall);
   }
 
   &:hover {
-    opacity: 1;
+    @include bolt-opacity(100);
   }
 
   &:active {
-    opacity: 0.6;
+    @include bolt-opacity(60);
   }
 
   .is-collapsed & {
-    opacity: 0;
+    @include bolt-opacity(0);
     pointer-events: none;
   }
 
   .is-expanded & {
-    opacity: 0.8;
+    @include bolt-opacity(80);
     pointer-events: auto;
   }
 }

--- a/packages/core/styles/01-settings/_settings-z-index.scss
+++ b/packages/core/styles/01-settings/_settings-z-index.scss
@@ -12,7 +12,7 @@
 /// @see {mixin} bolt-z-index
 /// @see bolt-z-index
 $bolt-z-indexes: (
-  'utility-class-prefix': 'u-bolt-z-index--',
+  'utility-class-prefix': 'u-bolt-z-index--', // @TODO Utility classes should not contain "--"
   sets: (
     fab: 300,
     modal: 200,

--- a/packages/core/styles/01-settings/settings-global/_settings-global.scss
+++ b/packages/core/styles/01-settings/settings-global/_settings-global.scss
@@ -6,6 +6,9 @@
 @import '../settings-colors/settings-colors';
 @import '../../02-tools/tools-color-palette/tools-color-palette';
 
+@import '../settings-opacity/settings-opacity';
+@import '../../02-tools/tools-opacity/tools-opacity';
+
 /* ------------------------------------ *\
    Global Settings
 \* ------------------------------------ */
@@ -64,12 +67,12 @@ $bolt-translate-raised--large: translate3d(0, -0.25rem, 0);
 
 // Global theming defaults -- TODO: move to standalone setting
 /// Bolt default global link hover opacity
-$bolt-global-link-hover-opacity: 0.7 !default;
+$bolt-global-link-hover-opacity: bolt-opacity(80) !default;
 /// Bolt default global link active opacity
-$bolt-global-link-active-opacity: 0.5 !default;
+$bolt-global-link-active-opacity: bolt-opacity(60) !default;
 
 /// Bolt default global border opacity
-$bolt-global-border-opacity: 0.2 !default;
+$bolt-global-border-opacity: bolt-opacity(20) !default;
 /// Bolt default global border color
 $bolt-global-border-color: bolt-color(gray);
 

--- a/packages/core/styles/01-settings/settings-opacity/_settings-opacity.scss
+++ b/packages/core/styles/01-settings/settings-opacity/_settings-opacity.scss
@@ -1,0 +1,23 @@
+////
+/// @group Settings: Opacity
+/// @author Remy Denton
+////
+
+/* ------------------------------------ *\
+  Opacity Scale
+\* ------------------------------------ */
+
+/// Bolt's opacity scale.
+/// The keys in this array are the opacity value names and not necessarily numeric.  For example, a valid key could be
+/// "semi-transparent". However, the values in this array must be valid numeric values for the CSS 'opacity' property.
+/// @type Map
+$bolt-opacities: (
+  0: 0,
+  20: .2,
+  40: .4,
+  60: .6,
+  80: .8,
+  100: 1
+);
+
+@include export-data('opacity.bolt.json', $bolt-opacities);

--- a/packages/core/styles/01-settings/settings-shadow/_settings-shadow.scss
+++ b/packages/core/styles/01-settings/settings-shadow/_settings-shadow.scss
@@ -16,7 +16,7 @@
 ///   $shadows: map-get(bolt-get-shadows-map(), 'sets');
 @function bolt-get-shadows-map($base-color: rgb(6, 10, 36)) {
   $bolt-shadows: (
-    'utility-class-prefix': 'u-bolt-shadow--',
+    'utility-class-prefix': 'u-bolt-shadow--', // @TODO Utility classes should not contain "--"
     'sets': (
       //'b1': (
       //  'base': 'inset 0 1px 3px rgba(0,0,0,0.12), inset 0 1px 2px rgba(0,0,0,0.24)',

--- a/packages/core/styles/02-tools/tools-opacity/_tools-opacity.scss
+++ b/packages/core/styles/02-tools/tools-opacity/_tools-opacity.scss
@@ -1,0 +1,42 @@
+////
+/// @group Tools: Utilities
+////
+
+/* ------------------------------------ *\
+  see `_settings-opacity.scss`
+\* ------------------------------------ */
+
+/// Bolt Opacity mixin
+/// @param {string} $value
+/// @param {boolean} $important [false]
+/// @example scss - bolt-opacity mixin
+/// .element {
+///    @include bolt-opacity(80);
+/// }
+@mixin bolt-opacity($value, $utility: false) {
+  $important: '';
+
+  @if $utility {
+    $important: '!important';
+  }
+
+  @if map-has-key($bolt-opacities, $value) {
+    opacity: map-get($bolt-opacities, $value) #{$important};
+  } @else {
+    @error 'A value, #{$value}, was passed into @include bolt-opacity() that is not defined in $bolt-opacities';
+  }
+}
+
+/// Bolt Opacity function
+/// @param {string} $value
+/// @example scss - bolt-opacity function
+/// .element {
+///    opacity: bolt-opacity(80);
+/// }
+@function bolt-opacity($value) {
+  @if map-has-key($bolt-opacities, $value) {
+    @return map-get($bolt-opacities, $value)
+  } @else {
+    @error 'A value, #{$value}, was passed into bolt-opacity() that is not defined in $bolt-opacities';
+  }
+}

--- a/packages/core/styles/index.scss
+++ b/packages/core/styles/index.scss
@@ -45,6 +45,7 @@
 @import '02-tools/tools-map-recursive-merge/tools-map-recursive-merge';
 @import '02-tools/tools-map-sort/_tools-map-sort';
 @import '02-tools/tools-no-select/_tools-no-select';
+@import '02-tools/tools-opacity/_tools-opacity';
 @import '02-tools/tools-poly-fluid-sizing/_tools-poly-fluid-sizing';
 @import '02-tools/tools-px-to-rem/_tools-px-to-rem';
 @import '02-tools/tools-sass-json-export/_tools.sass-json-export';

--- a/packages/core/styles/index.scss
+++ b/packages/core/styles/index.scss
@@ -16,6 +16,7 @@
 @import '01-settings/settings-font-size/_settings-font-size';
 @import '01-settings/settings-font-weight/_settings-font-weight';
 @import '01-settings/settings-global/_settings-global';
+@import '01-settings/settings-opacity/_settings-opacity';
 @import '01-settings/settings-shadow/_settings-shadow';
 @import '01-settings/settings-spacing/_settings-spacing';
 @import '01-settings/settings-themes/_constants';

--- a/packages/global/styles/07-utilities/_utilities-opacity.scss
+++ b/packages/global/styles/07-utilities/_utilities-opacity.scss
@@ -1,28 +1,23 @@
 /* ------------------------------------ *\
-  #VISUALLY HIDDEN UTILITIES
+  OPACITY UTILITIES
+  see `_settings-opacity.scss`
 \* ------------------------------------ */
 
 @import '@bolt/core';
 
-$bolt-opacity-props: (0, .25, .50, .75, 1);
-
 @mixin bolt-opacity-utils($breakpoint: null) {
-  @each $value in $bolt-opacity-props {
-    $name: $value * 100;
+  @each $name, $value in $bolt-opacities {
     .u-bolt-opacity-#{$name}#{$breakpoint} {
-      opacity: $value !important;
+      @include bolt-opacity($name, $utility: true);
     }
   }
 }
 
 @include bolt-opacity-utils;
 
-// Loop over our breakpoints
 @each $breakpoint in $bolt-breakpoints {
   $breakpointName: nth($breakpoint, 1);
   @include bolt-mq($breakpointName) {
     @include bolt-opacity-utils(\@#{$breakpointName});
   }
 }
-
-@include export-data('opacity.bolt.json', $bolt-opacity-props);

--- a/packages/global/styles/07-utilities/_utilities-opacity.scss
+++ b/packages/global/styles/07-utilities/_utilities-opacity.scss
@@ -21,3 +21,29 @@
     @include bolt-opacity-utils(\@#{$breakpointName});
   }
 }
+
+
+// DEPRECATED. These opacity values will be removed in Bolt 3.0.  See $bolt-opacities for valid opacity values.
+// To remove support, delete all the code below this line.
+$bolt-deprecated-opacities-map: (
+  25: 20,
+  50: 60,
+  75: 80,
+);
+
+@mixin bolt-opacity-utils-deprecated($breakpoint: null) {
+  @each $key, $value in $bolt-deprecated-opacities-map {
+    .u-bolt-opacity-#{$key}#{$breakpoint} {
+      @include bolt-opacity($value, $utility: true);
+    }
+  }
+}
+
+@include bolt-opacity-utils-deprecated;
+
+@each $breakpoint in $bolt-breakpoints {
+  $breakpointName: nth($breakpoint, 1);
+  @include bolt-mq($breakpointName) {
+    @include bolt-opacity-utils-deprecated(\@#{$breakpointName});
+  }
+}

--- a/packages/global/styles/07-utilities/_utilities-opacity.scss
+++ b/packages/global/styles/07-utilities/_utilities-opacity.scss
@@ -5,23 +5,19 @@
 
 @import '@bolt/core';
 
-@mixin bolt-opacity-utils($breakpoint: null) {
-  @each $name, $value in $bolt-opacities {
-    .u-bolt-opacity-#{$name}#{$breakpoint} {
-      @include bolt-opacity($name, $utility: true);
+@each $opacity-name, $opacity-value in $bolt-opacities {
+  .u-bolt-opacity-#{$opacity-name} {
+    @include bolt-opacity($opacity-name);
+  }
+
+  @each $breakpoint-name, $breakpoint-value in $bolt-breakpoints {
+    .u-bolt-opacity-#{$opacity-name}\@#{$breakpoint-name} {
+      @include bolt-mq($breakpoint-name) {
+        @include bolt-opacity($opacity-name);
+      }
     }
   }
 }
-
-@include bolt-opacity-utils;
-
-@each $breakpoint in $bolt-breakpoints {
-  $breakpointName: nth($breakpoint, 1);
-  @include bolt-mq($breakpointName) {
-    @include bolt-opacity-utils(\@#{$breakpointName});
-  }
-}
-
 
 // DEPRECATED. These opacity values will be removed in Bolt 3.0.  See $bolt-opacities for valid opacity values.
 // To remove support, delete all the code below this line.
@@ -31,19 +27,16 @@ $bolt-deprecated-opacities-map: (
   75: 80,
 );
 
-@mixin bolt-opacity-utils-deprecated($breakpoint: null) {
-  @each $key, $value in $bolt-deprecated-opacities-map {
-    .u-bolt-opacity-#{$key}#{$breakpoint} {
-      @include bolt-opacity($value, $utility: true);
-    }
+@each $old-opacity, $new-opacity in $bolt-deprecated-opacities-map {
+  .u-bolt-opacity-#{$old-opacity} {
+    @include bolt-opacity($new-opacity);
   }
-}
 
-@include bolt-opacity-utils-deprecated;
-
-@each $breakpoint in $bolt-breakpoints {
-  $breakpointName: nth($breakpoint, 1);
-  @include bolt-mq($breakpointName) {
-    @include bolt-opacity-utils-deprecated(\@#{$breakpointName});
+  @each $breakpoint-name, $breakpoint-value in $bolt-breakpoints {
+    .u-bolt-opacity-#{$old-opacity}\@#{$breakpoint-name} {
+      @include bolt-mq($breakpoint-name) {
+        @include bolt-opacity($new-opacity);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-615

## Summary

Adds a new opacity scale setting to standardize opacities

## Details

The first three commits break the new work down into the three parts that make up the new opacity scale (new setting, new tools, and new utilities).  The remaining commits update documentation and usage.

Questions/comments:
- Should the utility classes be formatted with `--`?  There is inconsistency in the existing ones (e.g. `.u-bolt-text-align-left` and `u-bolt-text-decoration-underline` vs. `u-bolt-shadow--level-10` and `u-bolt-z-index--tooltip`)
- Does the way this PR handles the deprecation of the existing (most likely unused) utility classes make sense?
- Most of the opacities I updated were already in the new scale (0, .2, .4, .6, .8, 1).  However, I replaced the existing link opacities of .7 (hover) and .5 (active) with the closest values from this new scale (.8 and .6 respectively).  My rationale was that the difference should be hardly noticeable and the consistency is an improvement.
- Furthermore, there are a number of existing places, especially those using rgba(), that use various opacities that don't appear in the new scale.  Should we:
  - Update these to fit the new scale?
  - Expand the new scale to include more values?
  - Accept that exceptions like this are to be expected?

## How to test
- Review the utility class demo at https://feature-opacity-scale.boltdesignsystem.com/pattern-lab/?p=styleguide-opacity
- Confirm parity for existing patterns that have been updated to use the new opacity scale, such as Share (https://feature-opacity-scale.boltdesignsystem.com//pattern-lab/?p=viewall-components-share)

## Deprecations
Three opacity-related utility classes are deprecated and will be removed in the next major Bolt release.  Replace them with the recommended classes shown in the table below or one of the other classes documented at https://feature-opacity-scale.boltdesignsystem.com/pattern-lab/?p=styleguide-opacity

| Deprecated utility classes | Suggested replacement
| --------------------- | -----
| `.u-bolt-opacity-75` |`.u-bolt-opacity-80`
| `.u-bolt-opacity-50` |`.u-bolt-opacity-60`
| `.u-bolt-opacity-25` |`.u-bolt-opacity-20`