### PR TITLE
Feature/deprecate utility classes

### DIFF
--- a/apps/pattern-lab/src/_patterns/01-styleguide/40-utilities/shadow.twig
+++ b/apps/pattern-lab/src/_patterns/01-styleguide/40-utilities/shadow.twig
@@ -8,7 +8,7 @@
   ]
 } only %}
 
-{% set class_prefix = bolt.data.shadows["utility-class-prefix"] %}
+  {% set class_prefix = "u-bolt-shadow-" %}
 
   {% block utility_description %}
     <p>Add the utility class <code>{{ class_prefix }}xx</code> where xx equals the level of shadow you wish to apply.</p>
@@ -26,13 +26,13 @@
     {% endfor %}
 
     <h5>Hoverable</h5>
-    <p>To add an animated shadow that "lifts" on hover, add the <code>{{ class_prefix }}xx--hoverable</code> where xx equals the level of shadow you wish to use.</p>
-    <p><strong>For example</strong>: <code>.{{ class_prefix ~ bolt.data.shadows.sets|keys|first ~ "--hoverable" }}</code></p>
+    <p>To add an animated shadow that "lifts" on hover, add the <code>{{ class_prefix }}xx-hoverable</code> where xx equals the level of shadow you wish to use.</p>
+    <p><strong>For example</strong>: <code>.{{ class_prefix ~ bolt.data.shadows.sets|keys|first ~ "-hoverable" }}</code></p>
 
     {% for key, value in bolt.data.shadows.sets %}
-      <div class="bolt-shadow-demo__card {{ class_prefix }}{{ key }}--hoverable">{{ key }}
+      <div class="bolt-shadow-demo__card {{ class_prefix }}{{ key }}-hoverable">{{ key }}
         <br>Utility Class
-        <br><code>.{{ class_prefix }}{{ key }}--hoverable</code>
+        <br><code>.{{ class_prefix }}{{ key }}-hoverable</code>
         <br>Scss Mixin
         <br><code>@include bolt-shadow("{{ key }}", true);</code>
       </div>

--- a/apps/pattern-lab/src/_patterns/01-styleguide/40-utilities/z-index.twig
+++ b/apps/pattern-lab/src/_patterns/01-styleguide/40-utilities/z-index.twig
@@ -9,7 +9,7 @@
 } only %}
 
   {% macro recursive_zindex_demo(list) %}
-    {% set utility_class = bolt.data.zIndexes["utility-class-prefix"] ~ list|keys|last %}
+    {% set utility_class = "u-bolt-z-index-" ~ list|keys|last %}
     <div class="bolt-z-index-demo {{ utility_class }}">
       {% if list|slice(0, -1)|length  %}
         {{ _self.recursive_zindex_demo(list|slice(0, -1)) }}
@@ -18,7 +18,7 @@
     </div>
   {% endmacro %}
 
-  {% set class_prefix = bolt.data.zIndexes["utility-class-prefix"] %}
+  {% set class_prefix = "u-bolt-z-index-" %}
 
   {% block utility_description %}
     <p>Add the utility class <code>{{ class_prefix }}xx</code> where xx equals the z index level you wish to apply.</p>

--- a/packages/core/styles/01-settings/_settings-z-index.scss
+++ b/packages/core/styles/01-settings/_settings-z-index.scss
@@ -12,7 +12,6 @@
 /// @see {mixin} bolt-z-index
 /// @see bolt-z-index
 $bolt-z-indexes: (
-  'utility-class-prefix': 'u-bolt-z-index--', // @TODO Utility classes should not contain "--"
   sets: (
     fab: 300,
     modal: 200,

--- a/packages/core/styles/01-settings/settings-shadow/_settings-shadow.scss
+++ b/packages/core/styles/01-settings/settings-shadow/_settings-shadow.scss
@@ -16,7 +16,6 @@
 ///   $shadows: map-get(bolt-get-shadows-map(), 'sets');
 @function bolt-get-shadows-map($base-color: rgb(6, 10, 36)) {
   $bolt-shadows: (
-    'utility-class-prefix': 'u-bolt-shadow--', // @TODO Utility classes should not contain "--"
     'sets': (
       //'b1': (
       //  'base': 'inset 0 1px 3px rgba(0,0,0,0.12), inset 0 1px 2px rgba(0,0,0,0.24)',

--- a/packages/global/styles/07-utilities/_utilities-shadow.scss
+++ b/packages/global/styles/07-utilities/_utilities-shadow.scss
@@ -6,11 +6,19 @@
 $shadows: map-get($bolt-shadows, 'sets');
 
 @each $key, $value in $shadows {
-  $prefix: map-get($bolt-shadows, 'utility-class-prefix');
+  $prefix: 'u-bolt-shadow-';
+
+  // DEPRECATED.  These utility classes have been renamed to not include double dashes.  The old versions will be
+  // removed in the next major version of Bolt.
+  // To remove them, remove the lines in this file that include the variable "$prefix-deprecated"
+  $prefix-deprecated: 'u-bolt-shadow--';
+
+  .#{$prefix-deprecated}#{$key},
   .#{$prefix}#{$key} {
     @include bolt-shadow($key, $lifted: false, $utility: true);
   }
-  .#{$prefix}#{$key}--hoverable {
+  .#{$prefix-deprecated}#{$key}--hoverable,
+  .#{$prefix}#{$key}-hoverable {
     @include bolt-shadow($key, $lifted: false, $utility: true);
     &:hover {
       @include bolt-shadow($key, $lifted: true, $utility: true);

--- a/packages/global/styles/07-utilities/_utilities-z-index.scss
+++ b/packages/global/styles/07-utilities/_utilities-z-index.scss
@@ -6,8 +6,8 @@
 $indexes: map-get($bolt-z-indexes, 'sets');
 
 @each $key, $value in $indexes {
-  $prefix: map-get($bolt-z-indexes, 'utility-class-prefix');
-  .#{$prefix}#{$key} {
+  .u-bolt-z-index--#{$key}, // DEPRECATED.  Utility classes with double dashes will be removed in the next major release.
+  .u-bolt-z-index-#{$key} {
     @include bolt-z-index($key, $utility: true);
   }
 }


### PR DESCRIPTION
## Jira

N/A

## Summary

Deprecates utility classes that have a double dash (`--`) in the name

## How to test

- There should be no visual changes in pattern lab.
- All utility classes in pattern lab that previously matched the patterns in the left column in the table below should have been replaced with a pattern in the right column.
- Utility classes in the left and right columns below should currently function identically (classes on the left will be removed in the next major release)

## Deprecations

| Replace utility class names in these formats | With utility classes matching these formats
| ---------- | ------
| `u-bolt-z-index--xx` | `u-bolt-z-index-xx`
| `u-bolt-shadow--xx` | `u-bolt-shadow-xx`
| `u-bolt-shadow--xx--hoverable` | `u-bolt-shadow-xx-hoverable`