### PR TITLE
Update `@bolt/build-tools` to skip Bolt version check during non-prod builds

### DIFF
--- a/packages/build-tools/utils/bolt-versions.js
+++ b/packages/build-tools/utils/bolt-versions.js
@@ -30,9 +30,26 @@ async function writeVersionDataToJson(versionData) {
 }
 
 async function gatherBoltVersions() {
+  const config = await getConfig();
+
   const versionSpinner = ora(
     chalk.blue('Gathering data on the latest Bolt Design System releases...'),
   ).start();
+
+  // Skip over checking for Bolt releases when not in prod mode to speed up the initial build
+  if (!config.prod) {
+    versionSpinner.succeed(
+      chalk.green('Skipped gathering data on every Bolt release -- dev build!'),
+    );
+    return [
+      {
+        label: 'Local Dev',
+        type: 'option',
+        value: `http://localhost:${config.port}/${config.startPath}`,
+      },
+    ];
+  }
+
   const tags = await gitSemverTags();
 
   const tagUrls = [];


### PR DESCRIPTION
## Jira
N/A

## Summary
Defers running the check for available Bolt versions (the info that we display in the new version selector) if the build isn't being run in `prod` mode -- speeds up the initial boot up process when doing local dev work so no-one has to wait around unnecessarily.

## How to test
- Confirm version selector logic continues to work on the staged version of the Bolt site (`prod` mode)
- Confirm that locally the check for Bolt versions that are available runs almost instantly (`dev` mode) 
