### PR TITLE
Fix: Temporarily Disable “Pretty” HTML in Pattern Lab Code Viewer

### DIFF
--- a/apps/pattern-lab/composer.patches.json
+++ b/apps/pattern-lab/composer.patches.json
@@ -2,7 +2,6 @@
   "patches": {
     "pattern-lab/core": {
       "[FIX] Fix Psuedo Pattern Template Paths If Organized In Different Folder From Base Template. Addresses https://github.com/drupal-pattern-lab/patternlab-php-core/issues/22": ".patches/fixPsuedoPatternTemplatePaths.patch",
-      "[FEATURE] Beautify raw HTML output": ".patches/beautifyHTML.patch",
       "[FEATURE] Allow markdown files to specify associated pattern + also includes compiling embedded templates in .md files": ".patches/allowMarkdownFilesToSpecifyAssociatedPattern.patch",
       "[FIX] Allow PL to Ignore Certain Folders like Node Modules.": ".patches/ignoreCertainFolders.patch",
       "[FEATURE] Allow default Pattern Data configuration rules to be disabled. Also adds ability to add on extra Pattern Data rules to customize and extend default Pattern Lab behavior.": ".patches/configurablePatternDataRules.patch",


### PR DESCRIPTION
## Jira
N/A

## Summary
Temporarily disables the custom Pattern Lab patch that automatically indents HTML code previews in Pattern Lab + removes extra white space.

## Details
Workaround to address PHP CLI memory issues being encountered on Travis that have been causing Pattern Lab to semi-silently fail to finish compiling (resulting in 404 errors on the deployed now.sh site).

## How To Test
Confirm that Pattern Lab compiled as expected on the URL we grab from now.sh.

^ CC @danielamorse @adam2661 @remydenton 