### PR TITLE
fix: update now.sh deploy script

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "static": {
     "trailingSlash": true,
     "cleanUrls": false,

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jest": "^23.5.0",
     "lerna": "^3.4.3",
     "node-fetch": "^2.2.0",
-    "now": "^11.4.6",
+    "now": "^12.1.0",
     "npm-run-all": "^4.1.3",
     "yaml-lint": "^1.2.4",
     "git-semver-tags": "^2.0.0",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -62,6 +62,7 @@ async function init() {
     console.log(`Branch Name: ${branchName}`);
 
     const baseNowArgs = [
+      '--platform-version=1',
       '--team=boltdesignsystem',
       '--local-config=../now.json',
     ];


### PR DESCRIPTION
## Jira
N/A

## Summary
Updates now.sh CLI to latest version + switch Bolt’s deployment config to still use the previous version of the API (v1)

## Details
Should at least help a little with addressing missing deployment links on Github + avoid breaking the build till we’re ready to update to now.sh’s new platform.

## How to test
Confirm now.sh deploy + url alias portion of the build process completes successfully.
