### PR TITLE
Translatable share text

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/video/65-video-with-custom-share-text.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/video/65-video-with-custom-share-text.twig
@@ -1,0 +1,10 @@
+<p>
+  This video has <code>share_description</code> set to <code>Share me!</code>.
+</p>
+
+{% include "@bolt/video.twig" with {
+  "videoId": "3861325118001",
+  "accountId": "1900410236",
+  "playerId": "r1CAdLzTW",
+  "share_description": "Share me!"
+} only %}

--- a/packages/components/bolt-video/__tests__/__snapshots__/video.js.snap
+++ b/packages/components/bolt-video/__tests__/__snapshots__/video.js.snap
@@ -18,7 +18,7 @@ exports[`<bolt-video> Component <bolt-video> compiles 1`] = `
 
   
 
-<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta player-id=\\"r1CAdLzTW\\" controls v=\\"2.2.0\\"></bolt-video>
+<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta player-id=\\"r1CAdLzTW\\" controls share-description=\\"Share This Video\\" v=\\"2.2.0\\"></bolt-video>
   
   </bolt-ratio>"
 `;
@@ -41,7 +41,7 @@ exports[`<bolt-video> Component <bolt-video> compiles with a different \`video-i
 
   
 
-<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"5609376179001\\" account-id=\\"1900410236\\" show-meta player-id=\\"r1CAdLzTW\\" controls v=\\"2.2.0\\"></bolt-video>
+<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"5609376179001\\" account-id=\\"1900410236\\" show-meta player-id=\\"r1CAdLzTW\\" controls share-description=\\"Share This Video\\" v=\\"2.2.0\\"></bolt-video>
   
   </bolt-ratio>"
 `;
@@ -64,7 +64,7 @@ exports[`<bolt-video> Component <bolt-video> compiles with a meta description + 
 
   
 
-<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta show-meta-title player-id=\\"r1CAdLzTW\\" controls v=\\"2.2.0\\"></bolt-video>
+<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta show-meta-title player-id=\\"r1CAdLzTW\\" controls share-description=\\"Share This Video\\" v=\\"2.2.0\\"></bolt-video>
   
   </bolt-ratio>"
 `;
@@ -87,7 +87,7 @@ exports[`<bolt-video> Component <bolt-video> compiles with a meta description 1`
 
   
 
-<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta player-id=\\"r1CAdLzTW\\" controls v=\\"2.2.0\\"></bolt-video>
+<bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta player-id=\\"r1CAdLzTW\\" controls share-description=\\"Share This Video\\" v=\\"2.2.0\\"></bolt-video>
   
   </bolt-ratio>"
 `;

--- a/packages/components/bolt-video/__tests__/__snapshots__/video.js.snap
+++ b/packages/components/bolt-video/__tests__/__snapshots__/video.js.snap
@@ -15,6 +15,7 @@ exports[`<bolt-video> Component <bolt-video> compiles 1`] = `
 
   
 
+
   
 
 <bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta player-id=\\"r1CAdLzTW\\" controls v=\\"2.2.0\\"></bolt-video>
@@ -36,6 +37,7 @@ exports[`<bolt-video> Component <bolt-video> compiles with a different \`video-i
   
 
   
+
 
   
 
@@ -59,6 +61,7 @@ exports[`<bolt-video> Component <bolt-video> compiles with a meta description + 
 
   
 
+
   
 
 <bolt-video  class=\\"js-bolt-video-uuid--12345\\" data-setup=\\"{&quot;techOrder&quot;: [&quot;Html5&quot;], &quot;resizeManager&quot;: false}\\" video-id=\\"3861325118001\\" account-id=\\"1900410236\\" show-meta show-meta-title player-id=\\"r1CAdLzTW\\" controls v=\\"2.2.0\\"></bolt-video>
@@ -80,6 +83,7 @@ exports[`<bolt-video> Component <bolt-video> compiles with a meta description 1`
   
 
   
+
 
   
 

--- a/packages/components/bolt-video/src/_video-tag.twig
+++ b/packages/components/bolt-video/src/_video-tag.twig
@@ -60,6 +60,10 @@ https://github.com/videojs/video.js/blob/22fd327076cb044c135c747086b58b7be64a747
   {% set attributes = attributes.setAttribute("loop", true) %}
 {% endif %}
 
+{% if share_description %}
+  {% set attributes = attributes.setAttribute("share-description", share_description) %}
+{% endif %}
+
 {% if isBackgroundVideo %}
   {% set attributes = attributes.setAttribute("is-background-video", isBackgroundVideo) %}
 {% else %}

--- a/packages/components/bolt-video/src/_video-tag.twig
+++ b/packages/components/bolt-video/src/_video-tag.twig
@@ -60,9 +60,7 @@ https://github.com/videojs/video.js/blob/22fd327076cb044c135c747086b58b7be64a747
   {% set attributes = attributes.setAttribute("loop", true) %}
 {% endif %}
 
-{% if share_description %}
-  {% set attributes = attributes.setAttribute("share-description", share_description) %}
-{% endif %}
+{% set attributes = attributes.setAttribute("share-description", share_description|default('Share This Video'|t)) %}
 
 {% if isBackgroundVideo %}
   {% set attributes = attributes.setAttribute("is-background-video", isBackgroundVideo) %}

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -9,7 +9,7 @@
 // 5. Required so videos with intrinsic ratio (used in the <bolt-ratio> object) properly fill the space available in IE 11.
 // 6. [Mai] These gradients cover up part of the squre to form a triangle. A triangle had to be formed this way because % width has to be used to determine a flexible triangle based on the video size.
 // 7. [Mai] This optically centers the triangle.
-// 8. [Denton] Hide the title and description when sharing to minimize the chances that you'll see a scrollbar, which is undesirable.  Replace it will the CSS content "Share This Video"
+// 8. [Denton] Hide the title when sharing to minimize the chances that you'll see a scrollbar, which is undesirable.  The description field will take its place.
 
 
 $bolt-video-js-button-text-color: bolt-color(indigo);
@@ -157,25 +157,21 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         justify-content: center;
       }
 
-      .vjs-social-title,
-      .vjs-social-description {
+      .vjs-social-title {
         @include bolt-visuallyhidden; // [8]
+      }
+
+      .vjs-social-description {
+        @include bolt-margin-bottom(0.5rem);
+        @include bolt-font-size(small, tight);
+        @include bolt-font-weight(bold);
+        white-space: nowrap;
       }
 
       .vjs-social-share-links {
         @include bolt-font-size(small, tight);
         margin-right: -0.25rem;
         margin-left: -0.25rem;
-
-        &:before {
-          @include bolt-margin(0.25rem);
-          @include bolt-font-size(small, tight);
-          @include bolt-font-weight(bold);
-          content: "Share This Video"; // [8]
-
-          display: block;
-          white-space: nowrap;
-        }
       }
 
       .vjs-social-share-link {

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -68,6 +68,7 @@ class BoltVideo extends withPreact() {
     showMeta: props.boolean,
     showMetaTitle: props.boolean,
     closeButtonText: props.string,
+    shareDescription: props.string,
     loop: props.boolean,
     // onError: null,
     // onPlay: null,
@@ -117,6 +118,8 @@ class BoltVideo extends withPreact() {
       directToFullscreen: false,
       resetOnFinish: false,
     };
+
+    this.shareDescription = this.shareDescription || 'Share This Video';
 
     // Ensure that 'this' inside the _onWindowResize event handler refers to <bolt-nav-link>
     // even if the handler is attached to another element (window in this case)
@@ -212,6 +215,8 @@ class BoltVideo extends withPreact() {
     if (elem.controls === false) {
       elem.player.muted(true);
     }
+
+    player.socialOverlay.options_.description = elem.props.shareDescription;
 
     player.on('loadedmetadata', function() {
       const duration = player.mediainfo.duration;

--- a/packages/components/bolt-video/video.schema.yml
+++ b/packages/components/bolt-video/video.schema.yml
@@ -17,6 +17,10 @@ properties:
   videoUuid:
     type: string
     description: A unique identifying string, randomly generated if not provided.
+  share_description:
+    type: string
+    description: A custom title to use in the share overlay
+    default: Share This Video
   ratio:
     type: boolean
     description: Maintain video ratio.


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-519

## Summary

Makes "Share This Video" text translatable by creating a new property for the `bolt-video` component

## Details

With the new `share_description` parameter, "Share This Video" could be translated on the Drupal side in either of these two ways:

```html
<bolt-video share-description="partage cette vidéo">
```

```twig
{% include "@bolt/video.twig" with {
  "videoId": "3861325118001",
  "accountId": "1900410236",
  "playerId": "r1CAdLzTW",
  "share_description": "Custom Share Text"|t
} only %}
```
Note that in the second example, if you just want to use "Share This Video", you don't need to pass a custom value for `share_description` because it will be set by default to a translatable string (i.e. one that's passed through the t function in twig).

## How to test

- Go to the videos demo page (`pattern-lab/?p=viewall-components-video`)
- Play any video, then click the share icon
- Confirm that the text "Share This Video" appears and matches the previous style
- Confirm that for the new demo (`pattern-lab/?p=components-video-with-custom-share-text`), the custom share text says "Share me!" instead
