### PR TITLE
Fix Vue.js - Exmaple Integration

### DIFF
--- a/example-integrations/vue/package.json
+++ b/example-integrations/vue/package.json
@@ -39,7 +39,7 @@
     "vue": "^2.5.17",
     "vue-loader": "^15.4.1",
     "vuex": "^3.0.1",
-    "webpack": "^4.18.1",
+    "webpack": "4.18.1",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.8"
   },


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-532

## Summary

Update package.json to be working with vue.js

## Details

Nohoist configuration doesn't give expected results and i can run this integration by removing caret from a version of webpack. From my perspective, that is only a workaround but at this moment i don't see a better solution.

## How to test

Run this code locally, go to `example-integrations > vue` if `node_modules` exists please remove them and then run `yarn` command. After this steps please run `npm start` and check if compilation is ended with success.
