### PR TITLE
Prevent escaping on SCSS code

### DIFF
--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -33,11 +33,14 @@ class BoltCodeSnippetClass extends withPreact() {
   };
 
   highlightHTML(code, lang) {
-    const escapedLangs = [
-      'scss'
-    ];
+    const escapedLangs = ['scss'];
 
-    code = escapedLangs.includes(lang) ? code.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>') : code;
+    code = escapedLangs.includes(lang)
+      ? code
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+      : code;
     const highlightedHTML = Prism.highlight(code, Prism.languages[lang]);
 
     return highlightedHTML;

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -33,7 +33,12 @@ class BoltCodeSnippetClass extends withPreact() {
   };
 
   highlightHTML(code, lang) {
-    let highlightedHTML = Prism.highlight(code, Prism.languages[lang]);
+    const escapedLangs = [
+      'scss'
+    ];
+
+    code = escapedLangs.includes(lang) ? code.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>') : code;
+    const highlightedHTML = Prism.highlight(code, Prism.languages[lang]);
 
     return highlightedHTML;
   }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-543

## Summary

Fix to prevent this special characters `&, <, >` be escaped.

## Details

Update `code-snippet` component.

## How to test

Run this code locally. Run `npm start` and go to `localhost:3000/pattern-lab`. Navigate: `Styleguide > Sassdocs > View All` then on right navigation `Tools: typhography > @mixin bolt-font-family` and/or `Tools: typhography > @mixin bolt-font-size` and check if `&, <, >` are showed unescaped.
