### PR TITLE
Prevent escaping in all languages

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/code-snippet/10-code-snippet-display-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/code-snippet/10-code-snippet-display-variation.twig
@@ -1,10 +1,15 @@
 {% set schema = bolt.data.components['@bolt-components-code-snippet'].schema %}
+{% set code %}{%- verbatim -%}
+<header>
+  <h1>Headline</h1>
+</header>
+{%- endverbatim -%}{% endset %}
 
 {% for display in schema.properties.display.enum %}
   <h3>{{ display }}:</h3>
   {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": display
+    "display": display,
+    "content": code
   } only %}
-    {% block children %}{% verbatim %}<header><h1>Headline</h1></header>{% endverbatim %}{% endblock %}
   {% endembed %}
 {% endfor %}

--- a/apps/pattern-lab/src/_patterns/02-components/code-snippet/15-code-snippet-language-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/code-snippet/15-code-snippet-language-variation.twig
@@ -1,43 +1,69 @@
+{% set css %}{%- verbatim -%}
+.my-css {
+  display: block;
+}
+{%- endverbatim -%}{% endset %}
+
+{% set scss %}{%- verbatim -%}
+.my-scss {
+  @include my-mixin;
+}
+{%- endverbatim -%}{% endset %}
+
+{% set html %}{%- verbatim -%}
+<header>
+  <h1>Headline</h1>
+</header>
+{%- endverbatim -%}{% endset %}
+
+{% set js %}{%- verbatim -%}
+import { polyfillLoader } from '@bolt/core';
+{%- endverbatim -%}{% endset %}
+
+{% set twig %}{%- verbatim -%}
+{% include "@bolt-components-code-snippet/code-snippet.twig" with {
+  "display": "block",
+  "lang": "html",
+  "content": "Some code snippet"
+} only %}
+{%- endverbatim -%}{% endset %}
+
 <h3>css:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
   "display": "block",
-  "lang": "css"
+  "lang": "css",
+  "content": css
 } only %}
-{% block children %}{% verbatim %}.my-css { display: block; }{% endverbatim %}{% endblock %}
 {% endembed %}
 
 <h3>scss:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
   "display": "block",
-  "lang": "scss"
+  "lang": "scss",
+  "content": scss
 } only %}
-{% block children %}{% verbatim %}.my-scss { @include my-mixin; }{% endverbatim %}{% endblock %}
 {% endembed %}
 
 <h3>html:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
   "display": "block",
-  "lang": "html"
+  "lang": "html",
+  "content": html
 } only %}
-{% block children %}{% verbatim %}<header><h1>Headline</h1></header>{% endverbatim %}{% endblock %}
 {% endembed %}
 
 <h3>javascript:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
   "display": "block",
-  "lang": "js"
+  "lang": "js",
+  "content": js
 } only %}
-{% block children %}{% verbatim %}import { polyfillLoader } from '@bolt/core';{% endverbatim %}{% endblock %}
 {% endembed %}
 
 <h3>twig:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
   "display": "block",
-  "lang": "twig"
+  "lang": "twig",
+  "content": twig
 } only %}
-{% block children %}{% verbatim %}{% include "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "html",
-  "content": "Some code snippet"
-} only %}{% endverbatim %}{% endblock %}
 {% endembed %}

--- a/apps/pattern-lab/src/_patterns/02-components/code-snippet/20-code-snippet-syntax-variation.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/code-snippet/20-code-snippet-syntax-variation.twig
@@ -1,11 +1,16 @@
 {% set schema = bolt.data.components['@bolt-components-code-snippet'].schema %}
+{% set html %}{%- verbatim -%}
+<header>
+  <h1>Headline</h1>
+</header>
+{%- endverbatim -%}{% endset %}
 
 {% for syntax in schema.properties.syntax.enum %}
   <h3>{{ syntax }}:</h3>
   {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
     "display": "block",
-    "syntax": syntax
+    "syntax": syntax,
+    "content": html
   } only %}
-    {% block children %}{% verbatim %}<header><h1>Headline</h1></header>{% endverbatim %}{% endblock %}
   {% endembed %}
 {% endfor %}

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -32,18 +32,12 @@ class BoltCodeSnippetClass extends withPreact() {
     syntax: props.string,
   };
 
+  replaceEntities(string) {
+    return string.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+  }
+
   highlightHTML(code, lang) {
-    const escapedLangs = ['scss'];
-
-    code = escapedLangs.includes(lang)
-      ? code
-          .replace(/&amp;/g, '&')
-          .replace(/&lt;/g, '<')
-          .replace(/&gt;/g, '>')
-      : code;
-    const highlightedHTML = Prism.highlight(code, Prism.languages[lang]);
-
-    return highlightedHTML;
+    return Prism.highlight(this.replaceEntities(code), Prism.languages[lang]);
   }
 
   constructor(self) {

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -49,7 +49,7 @@ class BoltCodeSnippetClass extends withPreact() {
   }
 
   connecting() {
-    if (this.querySelector('[is*=shadow-root]')) {
+    if(this.querySelector('[is*=shadow-root]')) {
       const parentElement = this.querySelector('[is*=shadow-root]');
       this.innerHTML = parentElement.innerHTML;
     }

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -33,7 +33,10 @@ class BoltCodeSnippetClass extends withPreact() {
   };
 
   replaceEntities(string) {
-    return string.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+    return string
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>');
   }
 
   highlightHTML(code, lang) {

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -49,7 +49,7 @@ class BoltCodeSnippetClass extends withPreact() {
   }
 
   connecting() {
-    if(this.querySelector('[is*=shadow-root]')) {
+    if (this.querySelector('[is*=shadow-root]')) {
       const parentElement = this.querySelector('[is*=shadow-root]');
       this.innerHTML = parentElement.innerHTML;
     }

--- a/packages/components/bolt-code-snippet/src/code-snippet.twig
+++ b/packages/components/bolt-code-snippet/src/code-snippet.twig
@@ -23,11 +23,9 @@
   baseClass
 ] %}
 
-{% set codeContent %}{% spaceless %}
+{% set codeContent %}
   <code class="{{ "#{baseClass}__code #{baseClass}__code--#{display}" }} nohighlight" is="shadow-root">{% block children %}{{ content }}{% endblock %}</code>
-{% endspaceless %}{% endset %}
-
-
+{% endset %}
 
 
 <bolt-{{ componentName }}
@@ -37,7 +35,9 @@
   bolt-component
 >
   {% if display == "inline" %}
-    {{ codeContent }}
+    {% spaceless %}
+      {{ codeContent }}
+    {% endspaceless %}
   {% else %}
     <pre {{ attributes.addClass(classes) }}>{{ codeContent }}</pre>
   {% endif %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-543

## Summary

Apply escaping to all languages in code snippet component.

## Details

Changes are only in a js file. It's simple remove of variable and escape without checking language.

## How to test

Run this code locally. Go to `localhost:3000/pattern-lab`. Navigate: `Styleguide > Sassdocs > View All `then on right navigation Tools: `typhography > @mixin bolt-font-family` and/or `Tools: typhography > @mixin bolt-font-size` and check if `&, <, >` are showed unescaped. You can create new pattern-lab page and apply to it: `{% include "@bolt-components-code-snippet/code-snippet.twig" with {
  display: "block",
  lang: "html",
  content: "&lt;bolt-list&gt;
  &lt;bolt-list-item&gt;&lt;/bolt-list-item&gt;
  &lt;bolt-list-item&gt;&lt;/bolt-list-item&gt;
  &lt;bolt-list-item&gt;&lt;/bolt-list-item&gt;
&lt;/bolt-list&gt;"
} only %}` to check if all languages are escaped please chenge `lang` and `content` variable. 