### PR TITLE
fix: Update schema syntax when multiple props are deprecated

### DIFF
--- a/apps/pattern-lab/src/_patterns/04-pages/20-d8-press-and-media/00-d8-news-landing.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-d8-press-and-media/00-d8-news-landing.twig
@@ -94,8 +94,7 @@
           name: "email",
           url: "mailto:?&body=Sample%20Text%20--%20https%3A//bolt-design-system.com"
         }
-      ],
-      inline: true
+      ]
     } only %}
 </div>
 

--- a/apps/pattern-lab/src/_patterns/04-pages/20-d8-press-and-media/05-d8-browse-page.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-d8-press-and-media/05-d8-browse-page.twig
@@ -169,8 +169,7 @@
           name: "email",
           url: "mailto:?&body=Sample%20Text%20--%20https%3A//bolt-design-system.com"
         }
-      ],
-      inline: true
+      ]
     } only %}
   </div>
 

--- a/apps/pattern-lab/src/_patterns/04-pages/20-d8-press-and-media/20-d8-details-page-press.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/20-d8-press-and-media/20-d8-details-page-press.twig
@@ -119,7 +119,6 @@
               {# share widget #}
               <div class="u-bolt-margin-bottom-medium">
                 {% include '@bolt-components-share/share.twig' with {
-                  inline: true,
                   text: 'Share this page',
                   sources: [
                     {

--- a/apps/pattern-lab/src/_patterns/04-pages/40-d8-content-hub/00-sticky-navbar.twig
+++ b/apps/pattern-lab/src/_patterns/04-pages/40-d8-content-hub/00-sticky-navbar.twig
@@ -492,7 +492,6 @@
 
   
     {% include '@bolt-components-share/share.twig' with {
-      inline: true,
       text: 'Custom label',
       sources: [
         {

--- a/packages/components/bolt-copy-to-clipboard/copy-to-clipboard.schema.yml
+++ b/packages/components/bolt-copy-to-clipboard/copy-to-clipboard.schema.yml
@@ -43,8 +43,12 @@ properties:
 required:
   - text_to_copy
 not:
-  required:
-    - iconSize
-    - copiedText
-    - text
-    - url
+  anyOf:
+    - required:
+      - iconSize
+    - required:
+      - copiedText
+    - required:
+      - text
+    - required:
+      - url

--- a/packages/components/bolt-share/share.schema.yml
+++ b/packages/components/bolt-share/share.schema.yml
@@ -2,9 +2,11 @@ $schema: http://json-schema.org/draft-04/schema#
 title: Share
 type: object
 not:
-  required:
-    - inline
-    - copyToClipboard
+  anyOf:
+    - required:
+      - inline
+    - required:
+      - copyToClipboard
 properties:
   attributes:
     type: object


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-836

## Summary

Fixes schema formatting for components with multiple deprecated props

## Details
In addition to fixing the issue, I've also updated the [deprecations wiki page](https://github.com/bolt-design-system/bolt/wiki/Deprecating-component-properties).

## How to test

### Reproduce the bug

On master, add a copy-to-clipboard component anywhere in pattern lab using the following deprecated syntax, then start pattern lab:

```
{% include "@bolt-components-copy-to-clipboard/copy-to-clipboard.twig" with {
  text_to_copy: "this property is required",
  url: "this property shouldn't be here since it's deprecated"
} only %}
```

The command line will not fail with an error-- it should.

### Confirm the fix

On this PR branch, repeat the above.  Pattern lab should fail when building with a warning about invalid schema usage.