### PR TITLE
Hotfix: Bolt Core Rendering Updates

### DIFF
--- a/packages/core/elements/replace-with-children/index.js
+++ b/packages/core/elements/replace-with-children/index.js
@@ -16,10 +16,7 @@ class ReplaceWithChildren extends HTMLElement {
 
     // Originally was this.replaceWith(...this.childNodes) but IE11 doesn't like that
     while (this.firstChild) {
-      // double-check to confirm the parent element still exists
-      if (parentElement) {
-        parentElement.appendChild(this.firstChild);
-      }
+      parentElement.appendChild(this.firstChild);
     }
     if (parentElement) {
       parentElement.removeChild(this);

--- a/packages/core/elements/replace-with-children/index.js
+++ b/packages/core/elements/replace-with-children/index.js
@@ -2,14 +2,10 @@ import { define } from '@bolt/core/utils';
 import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
 
 @define
-class ReplaceWithChildren extends withLitHtml() {
+class ReplaceWithChildren extends HTMLElement {
   static is = 'replace-with-children';
 
-  connecting() {
-    this.replaceElementWithChildren();
-  }
-
-  replaceElementWithChildren() {
+  connectedCallback() {
     const parentElement = this.parentElement;
 
     if (!parentElement) {
@@ -20,7 +16,10 @@ class ReplaceWithChildren extends withLitHtml() {
 
     // Originally was this.replaceWith(...this.childNodes) but IE11 doesn't like that
     while (this.firstChild) {
-      parentElement.appendChild(this.firstChild);
+      // double-check to confirm the parent element still exists
+      if (parentElement) {
+        parentElement.appendChild(this.firstChild);
+      }
     }
     if (parentElement) {
       parentElement.removeChild(this);

--- a/packages/core/polyfills/index.js
+++ b/packages/core/polyfills/index.js
@@ -48,7 +48,7 @@ export const polyfillLoader = new Promise(resolve => {
   // Based on https://github.com/webcomponents/webcomponentsjs/blob/master/entrypoints/webcomponents-hi-sd-ce-pf-index.js
   // Used in: IE 11
   if (polyfills.includes('lite')) {
-    Promise.all([import('@webcomponents/custom-elements')]).then(() => {
+    Promise.all([import('document-register-element')]).then(() => {
       resolve();
     });
   }
@@ -58,7 +58,7 @@ export const polyfillLoader = new Promise(resolve => {
   else if (polyfills.includes('sd') && polyfills.includes('ce')) {
     Promise.all([
       import('@webcomponents/shadydom/src/shadydom.js'),
-      import('@webcomponents/custom-elements'),
+      import('document-register-element'),
     ]).then(() => {
       resolve();
     });
@@ -83,7 +83,7 @@ export const polyfillLoader = new Promise(resolve => {
       },
     );
 
-    import('@webcomponents/custom-elements').then(() => {
+    import('document-register-element').then(() => {
       resolve();
     });
   }

--- a/packages/core/renderers/bolt-base.js
+++ b/packages/core/renderers/bolt-base.js
@@ -6,7 +6,7 @@ export function BoltBase(Base = HTMLElement) {
   return class extends Base {
     constructor(self) {
       super(self);
-      self._wasInitiallyRendered = false;
+      this._wasInitiallyRendered = false;
       return self;
     }
 

--- a/packages/core/renderers/bolt-base.js
+++ b/packages/core/renderers/bolt-base.js
@@ -4,25 +4,10 @@ import { findParentTag } from '../utils/find-parent-tag';
 
 export function BoltBase(Base = HTMLElement) {
   return class extends Base {
-    constructor(...args) {
-      super(...args);
-      this._wasInitiallyRendered = false;
-    }
-
-    connectedCallback() {
-      // NOTE: it's SUPER important that setupSlots is run during the component's connectedCallback lifecycle event
-      // Without this, browsers like IE 11 won't re-render as expected when props change!
-      if (!this.slots) {
-        this.setupSlots();
-      }
-
-      // Automatically force a component to render if no props exist BUT props are defined.
-      if (
-        Object.keys(this.props).length !== 0 &&
-        Object.keys(this._props).length === 0
-      ) {
-        this.updated();
-      }
+    constructor(self) {
+      super(self);
+      self._wasInitiallyRendered = false;
+      return self;
     }
 
     setupSlots() {


### PR DESCRIPTION
## Jira
BDS-840

## Summary
Bolt core Javascript updates related to more consistent cross-browser rendering when dealing with dynamically injected content rendering as expected.

## Details
Supersedes #992 (reverts previous update swapping out the custom element renderer); instead this PR makes two small updates to Bolt core based on local testing in IE 11:

1. Simplifies the `<replace-with-children>` element to not use any extra libraries or renderers to help speed up the initialization time + reduce the risk of the component re-rendering instead of automatically removing itself when booting up.

2. Adjusts the constructor method in bolt-core to return itself (needed when using the document-register-element polyfill) + remove the connectedCallback method which I suspect may be causing extra unnecessary component re-renders (and in local testing, no longer appears to be needed).

## How to test
Re-test injected examples on https://hotfix-bds-840-rendering-updates.boltdesignsystem.com/pattern-lab/?p=components-personalized-card-example--server-rendered-tests once the Travis build has completed.
