### PR TITLE
Fix: slotted bolt-button full width option

### DIFF
--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -116,15 +116,31 @@ bolt-button {
 
 
 
-/** Button Width Variations **/
+// full width variations
 bolt-button[width='full'],
 .c-bolt-button--full {
   width: 100%;
 }
 
+// :host selector for correctly styling the <bolt-button> element inside other components
+// writing this out in a separate selector due to unsupporting browsers throwing out the :host selector
+:host([width='full']) {
+  width: 100%;
+}
+
+
+// full@small width variations
 bolt-button[width='full@small'],
 .c-bolt-button--full\@small {
-  @media screen and (max-width: map-get($bolt-breakpoints, small)) {
+  @include bolt-mq($from: small) {
+    width: 100%;
+  }
+}
+
+// :host selector for correctly styling the <bolt-button> element inside other components
+// writing this out in a separate selector due to unsupporting browsers throwing out the :host selector
+:host([width='full@small']) {
+  @include bolt-mq($from: small) {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-846

## Summary

Fixes a bug when a `<bolt-button width="full">` does not appear to be full width when used inside a slot.

## Details

Additional CSS is needed for this to work, namely to use `:host` to repeat the styles.

## How to test

Try to put bolt-button inside the slot of another component and define the width as full.

```
<bolt-card>
  <bolt-card-actions>
    <bolt-card-action>
      <bolt-button width="full">
        Button text
      </bolt-button>
    </bolt-card-action>
  </bolt-card-actions>
</bolt-card>
```
