### PR TITLE
Add the ability to hide or show a prop in the schema table on the Pattern Lab site

### DIFF
--- a/apps/pattern-lab/src/_includes/utils/schema-docs.twig
+++ b/apps/pattern-lab/src/_includes/utils/schema-docs.twig
@@ -105,7 +105,7 @@
       </thead>
 
       <tbody>
-        {% for key, prop in schema.properties %}
+        {% for key, prop in schema.properties if not schema.properties[key].hidden %}
           <tr class="c-bolt-docs-table__row">
             <td class="c-bolt-docs-table__col c-bolt-docs-table__col--key">{{ key }}{% if key in requiredProps %}<span class="required-key" title="Required">*</span>{% endif %}</td>
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-847

## Summary

Adds the ability to hide or show certain props in the Pattern Lab schema table.

## Details

Each prop in the schema table should have the ability to hide or show, in case a developer does not want to expose an internal prop from being consumed by a design system user. Hence the option to hide or show it in the schema table on the Pattern Lab site.

## How to test

Try to add `hidden: true` to any prop in a component's schema, make sure it doesn't show up in Pattern Lab anymore.
