### PR TITLE
Hotfix: Update Bolt Core Polyfill Loader Test

### DIFF
--- a/packages/core/polyfills/index.js
+++ b/packages/core/polyfills/index.js
@@ -34,7 +34,9 @@ if (!window.customElements || window.customElements.forcePolyfill) {
 
 // NOTE: any browser that does not have template or ES6 features
 // must load the full suite (called `lite` for legacy reasons) of polyfills.
-if (
+if {
+  // https://stackoverflow.com/a/21825207 - IE 11 check
+  (!!window.MSInputMethodContext && !!document.documentMode) ||
   !('content' in document.createElement('template')) ||
   !window.Promise ||
   !Array.from ||

--- a/packages/core/polyfills/index.js
+++ b/packages/core/polyfills/index.js
@@ -34,7 +34,7 @@ if (!window.customElements || window.customElements.forcePolyfill) {
 
 // NOTE: any browser that does not have template or ES6 features
 // must load the full suite (called `lite` for legacy reasons) of polyfills.
-if {
+if (
   // https://stackoverflow.com/a/21825207 - IE 11 check
   (!!window.MSInputMethodContext && !!document.documentMode) ||
   !('content' in document.createElement('template')) ||


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-861

## Summary
Updates the Bolt Core polyfill loader test to more specifically check for IE 11 (to opt out of loading the Shady DOM polyfill) — intended to address a noticeable performance hit with Bolt v2.2.0.

## How to test
- Confirm overall JS functionality continues to work as expected
- Confirm update fixes perf hit in IE 11 — recommend checking out 
https://fix-update-polyfill-loader-ie11-check.boltdesignsystem.com/pattern-lab/patterns/04-pages-15-d8-product-pages--product-t3-extra-videos/04-pages-15-d8-product-pages--product-t3-extra-videos.html especially 

CC @margoromo @remydenton @semiuniversal @krlucas @charginghawk  