### PR TITLE
Fix: Address Nav Overlap Issue w/ Dropdown Selector

### DIFF
--- a/apps/bolt-site/components/layout/layout.scss
+++ b/apps/bolt-site/components/layout/layout.scss
@@ -143,6 +143,7 @@ $bds-sidebar-width: 320px;
   @include bolt-mq(medium) {
     position: relative;
     transform: translate3d(0, 0, 0);
+    z-index: auto; // reset z-index to avoid overlap issues with nested components in the header (ex. version selector)
   
     @include bolt-mq(medium) {
       .c-bds-layout--has-sidebar & {


### PR DESCRIPTION
## Jira
N/A

## Summary
CSS fix to prevent the Bolt version selector from overlapping the off-canvas / side-nav on medium-ish screen sizes as reported by @joekarasek. 

## Details
Resets the z-index for the Bolt Docs site off-canvas nav back to `auto` on wider screens to prevent the different component's z-indexes from colliding.

## How to test
Confirm the version selector dropdown no longer is incorrectly overlapping the off-canvas nav on larger screen sizes (screenshot below of what we should expect to confirm this is working):

![image](https://user-images.githubusercontent.com/1617209/50305107-ef050a80-045f-11e9-9efa-4985aea8e57b.png)
