### PR TITLE
Remove space around inline links

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/link/20-custom-element-links.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/link/20-custom-element-links.twig
@@ -12,49 +12,27 @@
 
     {# no props, no attributes on the anchor #}
     <p>
-      <bolt-link>
-        <a>
-          Link text
-        </a>
-      </bolt-link>
+      <bolt-link><a>Link text</a></bolt-link>
     </p>
 
     {# no props, url and class attributes on the anchor #}
     <p>
-      <bolt-link>
-        <a href="#!" class="c-bolt-link">
-          Link text
-        </a>
-      </bolt-link>
+      <bolt-link><a href="#!" class="c-bolt-link">Link text</a></bolt-link>
     </p>
 
     {# url prop, no attributes on the anchor #}
     <p>
-      <bolt-link url="#!">
-        <a>
-          Link text
-        </a>
-      </bolt-link>
+      <bolt-link url="#!"><a>Link text</a></bolt-link>
     </p>
 
     {# with icon in "before" slot #}
     <p>
-      <bolt-link>
-        <a href="#!" class="c-bolt-link">
-          <bolt-icon slot="before" name="info-open"></bolt-icon>
-          Link text with icon
-        </a>
-      </bolt-link>
+      <bolt-link><a href="#!" class="c-bolt-link"><bolt-icon slot="before" name="info-open"></bolt-icon>Link text with icon</a></bolt-link>
     </p>
 
     {# with icon in "before" slot #}
     <p>
-      <bolt-link>
-        <a href="#!" class="c-bolt-link">
-          Link text with icon
-          <bolt-icon slot="after" name="info-open"></bolt-icon>
-        </a>
-      </bolt-link>
+      <bolt-link><a href="#!" class="c-bolt-link">Link text with icon<bolt-icon slot="after" name="info-open"></bolt-icon></a></bolt-link>
     </p>
 
   {% endcell %}
@@ -65,32 +43,22 @@
 
     {# no props #}
     <p>
-      <bolt-link>
-        Link text
-      </bolt-link>
+      <bolt-link>Link text</bolt-link>
     </p>
 
     {# url prop #}
     <p>
-      <bolt-link url="#!">
-        Link Text
-      </bolt-link>
+      <bolt-link url="#!">Link Text</bolt-link>
     </p>
 
     {# with icon in "before" slot #}
     <p>
-      <bolt-link url="#!">
-        <bolt-icon slot="before" name="info-open"></bolt-icon>
-        Link text with icon
-      </bolt-link>
+      <bolt-link url="#!"><bolt-icon slot="before" name="info-open"></bolt-icon>Link text with icon</bolt-link>
     </p>
 
     {# with icon in "before" slot #}
     <p>
-      <bolt-link url="#!">
-        Link text with icon
-        <bolt-icon slot="after" name="info-open"></bolt-icon>
-      </bolt-link>
+      <bolt-link url="#!">Link text with icon<bolt-icon slot="after" name="info-open"></bolt-icon></bolt-link>
     </p>
 
   {% endcell %}
@@ -100,26 +68,7 @@
     <h2>Custom elements in a paragraph</h2>
 
     <p>
-      Sunt laborum ad in consectetur consectetur duis in Lorem ut
-      <bolt-link url="#!">
-        <a href="#!" class="c-bolt-link">
-          This is a text link
-        </a>
-      </bolt-link>
-      . Magna non voluptate deserunt fugiat esse esse cillum.
-      <bolt-link url="#!">
-        <a href="#!" class="c-bolt-link">
-          <bolt-icon slot="before" name="info-open"></bolt-icon>
-          This is a text link
-        </a>
-      </bolt-link>
-      velit commodo cillum sint enim reprehenderit sunt labore commodo dolor.
-      <bolt-link url="#!">
-        <a href="#!" class="c-bolt-link">
-          This is a text link
-          <bolt-icon slot="after" name="info-open"></bolt-icon>
-        </a>
-      </bolt-link>
+      Sunt laborum ad in consectetur consectetur duis in Lorem ut <bolt-link url="#!"><a href="#!" class="c-bolt-link">This is a text link</a></bolt-link>. Magna non voluptate deserunt fugiat esse esse cillum. <bolt-link url="#!"><a href="#!" class="c-bolt-link"><bolt-icon slot="before" name="info-open"></bolt-icon>This is a text link</a></bolt-link> velit commodo cillum sint enim reprehenderit sunt labore commodo dolor. <bolt-link url="#!"><a href="#!" class="c-bolt-link">This is a text link<bolt-icon slot="after" name="info-open"></bolt-icon></a></bolt-link>
     </p>
 
   {% endcell %}
@@ -127,18 +76,9 @@
 
 {% set link %}
   <h2 class="c-bolt-headline c-bolt-headline--bold c-bolt-headline--xlarge c-bolt-headline--link">
-    <bolt-link url="#!" is-headline="true">
-      <a href="#!" class="c-bolt-link">
-        This is a text link
-        <bolt-icon slot="after" name="chevron-right"></bolt-icon>
-      </a>
-    </bolt-link>
+    <bolt-link url="#!" is-headline="true"><a href="#!" class="c-bolt-link">This is a text link<bolt-icon slot="after" name="chevron-right"></bolt-icon></a></bolt-link>
   </h2>
-  <bolt-link url="#!">
-    <a href="#!" class="c-bolt-link">
-      This is a text link
-    </a>
-  </bolt-link>
+  <bolt-link url="#!"><a href="#!" class="c-bolt-link">This is a text link</a></bolt-link>
 {% endset %}
 
 {% include "@bolt-components-band/band.twig" with {

--- a/packages/components/bolt-link/src/_link-macros.twig
+++ b/packages/components/bolt-link/src/_link-macros.twig
@@ -8,7 +8,5 @@
       }) %}
       {% include "@bolt-components-icon/icon.twig" with icon only %}
     </replace-with-children>
-  {% else %}
-    <replace-with-children class="c-bolt-link__icon is-empty"></replace-with-children>
   {% endif %}
 {% endmacro %}

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -132,7 +132,9 @@ class BoltLink extends withLitHtml() {
   }
 
   render() {
-    // validate the original prop data passed along -- returns back the validated data w/ added default values
+    // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
+
+    // Validate the original prop data passed along -- returns back the validated data w/ added default values
     const { url, target, isHeadline } = this.validateProps(this.props);
 
     const classes = cx('c-bolt-link', {
@@ -155,29 +157,25 @@ class BoltLink extends withLitHtml() {
         case 'after':
           const iconClasses = cx('c-bolt-link__icon');
 
+          // [1]
+          // prettier-ignore
           return name in this.slots
-            ? html`
-                <span class="${iconClasses}">${this.slot(name)}</span>
-              `
-            : html`
-                <slot name="${name}" />
-              `;
+            ? html`<span class="${iconClasses}">${this.slot(name)}</span>`
+            : html`<slot name="${name}" />`;
         default:
           const itemClasses = cx('c-bolt-link__text', {
             'is-empty': name in this.slots === false,
           });
 
-          return html`
-            <span class="${itemClasses}"
+          // [1]
+          // prettier-ignore
+          return html`<span class="${itemClasses}"
               >${
                 name in this.slots
                   ? this.slot('default')
-                  : html`
-                      <slot />
-                    `
+                  : html`<slot />`
               }</span
-            >
-          `;
+            >`;
       }
     };
 
@@ -195,16 +193,16 @@ class BoltLink extends withLitHtml() {
       renderedLink.className += ' ' + classes;
       render(innerSlots, renderedLink);
     } else {
-      renderedLink = html`
-        <a href="${this.props.url}" class="${classes}" target="${anchorTarget}"
+      // [1]
+      // prettier-ignore
+      renderedLink = html`<a href="${this.props.url}" class="${classes}" target="${anchorTarget}"
           >${innerSlots}</a
-        >
-      `;
+        >`;
     }
 
-    return html`
-      ${this.addStyles([styles])} ${renderedLink}
-    `;
+    // [1]
+    // prettier-ignore
+    return html`${this.addStyles([styles])} ${renderedLink}`;
   }
 }
 

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -162,7 +162,9 @@ class BoltLink extends withLitHtml() {
               >${
                 name in this.slots
                   ? this.slot(name)
-                  : html`<slot name="${name}" />`
+                  : html`
+                      <slot name="${name}" />
+                    `
               }</span
             >
           `;
@@ -174,7 +176,11 @@ class BoltLink extends withLitHtml() {
           return html`
             <span class="${itemClasses}"
               >${
-                name in this.slots ? this.slot('default') : html`<slot/>`
+                name in this.slots
+                  ? this.slot('default')
+                  : html`
+                      <slot />
+                    `
               }</span
             >
           `;

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -153,21 +153,15 @@ class BoltLink extends withLitHtml() {
       switch (name) {
         case 'before':
         case 'after':
-          const iconClasses = cx('c-bolt-link__icon', {
-            'is-empty': name in this.slots === false,
-          });
+          const iconClasses = cx('c-bolt-link__icon');
 
-          return html`
-            <span class="${iconClasses}"
-              >${
-                name in this.slots
-                  ? this.slot(name)
-                  : html`
-                      <slot name="${name}" />
-                    `
-              }</span
-            >
-          `;
+          return name in this.slots
+            ? html`
+                <span class="${iconClasses}">${this.slot(name)}</span>
+              `
+            : html`
+                <slot name="${name}" />
+              `;
         default:
           const itemClasses = cx('c-bolt-link__text', {
             'is-empty': name in this.slots === false,

--- a/packages/components/bolt-link/src/link.scss
+++ b/packages/components/bolt-link/src/link.scss
@@ -19,8 +19,8 @@ bolt-link {
 
 // Component styles
 .c-bolt-link {
-  @include bolt-padding(0);  // [1]
-  @include bolt-font-family(body);  // [1]
+  @include bolt-padding(0); // [1]
+  @include bolt-font-family(body); // [1]
 
   display: block;
   display: flex; // Container is set to "inline-flex" so this can just be "flex"
@@ -29,10 +29,9 @@ bolt-link {
   color: bolt-theme(link);
   text-decoration: underline;
   cursor: pointer;
-  border: none;  // [1]
-  background: none;  // [1]
+  border: none; // [1]
+  background: none; // [1]
   transition: all $bolt-link-transition;
-
 
   &:hover {
     opacity: $bolt-global-link-hover-opacity;
@@ -44,8 +43,6 @@ bolt-link {
   }
 }
 
-
-
 // Changes the underline styles when a link is also a headline, chevrons are added to headline links by default.
 .c-bolt-link--headline {
   color: bolt-theme(headline-link);
@@ -56,7 +53,6 @@ bolt-link {
   }
 }
 
-
 // Text and icon spacing
 .c-bolt-link__text + .c-bolt-link__icon:not(.is-empty) {
   @include bolt-margin-left(xxsmall);
@@ -65,7 +61,6 @@ bolt-link {
 .c-bolt-link__icon:not(.is-empty) + .c-bolt-link__text {
   @include bolt-margin-left(xxsmall);
 }
-
 
 // Icon styles
 .c-bolt-link__icon {

--- a/packages/components/bolt-link/src/link.twig
+++ b/packages/components/bolt-link/src/link.twig
@@ -62,7 +62,7 @@ Sort classes passed in via attributes into two groups:
 {% set filteredAttributes = attributes | without('url') | without('href') | without('target') | without('class') %}
 
 {# link component's custom element wrapper #}
-<bolt-link
+{% spaceless %}<bolt-link
   {{ filteredAttributes }}
   {% if url %} url="{{ url }}" {% endif %}
   {% if target %} target="{{ target }}" {% endif %}
@@ -83,8 +83,8 @@ Sort classes passed in via attributes into two groups:
   >
     {{ macros.slotted_icon(icon, icon_position, 'before') }}
     <replace-with-children class="{{ "#{base_class}__text" }}">
-      {{ text | default(label) | default("Learn More") }}
+      {{- text | default(label) | default("Learn More") -}}
     </replace-with-children>
     {{ macros.slotted_icon(icon, icon_position, 'after') }}
   </a>
-</bolt-link>
+</bolt-link>{% endspaceless %}

--- a/packages/core/renderers/renderer-lit-html.js
+++ b/packages/core/renderers/renderer-lit-html.js
@@ -37,25 +37,19 @@ export function withLitHtml(Base = HTMLElement) {
         this.slots[name] = [];
       }
 
+      // prettier-ignore
+      // Remove line breaks before and after lit-html template tags, causes unwanted space on inline elements
       if (this.useShadow && hasNativeShadowDomSupport) {
         if (name === 'default') {
-          return html`
-            <slot />
-          `;
+          return html`<slot />`;
         } else {
-          return html`
-            <slot name="${name}" />
-          `;
+          return html`<slot name="${name}" />`;
         }
       } else {
         if (name === 'default') {
-          return html`
-            ${this.slots.default}
-          `;
+          return html`${this.slots.default}`;
         } else if (this.slots[name] && this.slots[name] !== []) {
-          return html`
-            ${this.slots[name]}
-          `;
+          return html`${this.slots[name]}`;
         } else {
           return ''; // No slots assigned so don't return any markup.
           console.log(`The ${name} slot doesn't appear to exist...`);


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-865

## Summary

There is unwanted space around bolt-links that is revealed once links are set to display `inline`.

## Details

Whitespace lies in and around the link and between the link's slot tags. Upon debugging, I found that this space could only be closed by removing the line breaks added by Prettier when formatting lit-html template markup.

For example, this code:
```
    >${innerSlots}</a
  >
`;
```
Must be changed to:
```
  >${innerSlots}</a
>`;
```
Otherwise, the line break before the closing tick will add a space after the inner anchor. Same issue applies to `slot` tags. All spaces around tags needed to be closed, **including some on the bolt-base class**.

Also, if a link is to be displayed `inline`, the markup itself must be in a single line, i.e.
```
<bolt-link url="#!">Link text with icon<bolt-icon slot="after" name="info-open"></bolt-icon></bolt-link>
```
Not...
```
<bolt-link url="#!">
  Link text with icon
  <bolt-icon slot="after" name="info-open"></bolt-icon>
</bolt-link>
```
This is not necessary if it's `block`, `flex`, etc.

## How to test
The work required to make links inline by default is not done yet (@mikemai2awesome will work on this), so you'll have to pull down this branch locally, edit `bolt-link/src.link.scss` and change `block` and `inline-block` rules to `inline`.