### PR TITLE
Fix Broken `replace-with-grandchildren` helper element on master

### DIFF
--- a/packages/core/elements/index.js
+++ b/packages/core/elements/index.js
@@ -5,20 +5,20 @@ polyfillLoader.then(res => {
     import(/* 
       webpackMode: 'eager', 
       webpackChunkName: 'replace-with-children' 
-    */ '@bolt/core/elements/replace-with-children');
+    */ './replace-with-children');
   }
 
   if (!window.customElements.get('replace-with-grandchildren')) {
     import(/*
       webpackMode: 'eager',
       webpackChunkName: 'replace-with-grandchildren'
-    */ '@bolt/core/elements/replace-with-grandchildren');
+    */ './replace-with-grandchildren');
   }
 
   if (!window.customElements.get('bolt-action')) {
     import(/*
       webpackMode: 'eager',
       webpackChunkName: 'bolt-action'
-    */ '@bolt/core/elements/bolt-action');
+    */ './bolt-action');
   }
 });

--- a/packages/core/elements/replace-with-grandchildren/index.js
+++ b/packages/core/elements/replace-with-grandchildren/index.js
@@ -1,37 +1,21 @@
 import { define } from '@bolt/core/utils';
-import { html } from '@bolt/core/renderers/renderer-lit-html';
-import { ReplaceWithChildren } from '@bolt/core/elements/replace-with-children';
+import { ReplaceWithChildren } from '../replace-with-children';
 
 @define
-class RemoveHtmlTag extends ReplaceWithChildren {
+class ReplaceWithGrandchildren extends ReplaceWithChildren {
   static is = 'replace-with-grandchildren';
 
-  constructor(self) {
-    self = super(self);
-    self.useShadow = false;
-    return self;
-  }
-
-  connecting() {
-    this.removeChildKeepGrandchildren();
-    super.connecting();
-  }
-
-  removeChildKeepGrandchildren() {
+  connectedCallback() {
     const childHtmlTag = this.children[0];
 
-    // // Originally was this.replaceWith(...this.childNodes) but IE11 doesn't like that
+    // Originally was this.replaceWith(...this.childNodes) but IE11 doesn't like that
     while (childHtmlTag.firstChild) {
       this.appendChild(childHtmlTag.firstChild);
     }
     this.removeChild(childHtmlTag);
-  }
 
-  render() {
-    return html`
-      ${this.slot('default')}
-    `;
+    super.connectedCallback();
   }
 }
 
-export { RemoveHtmlTag };
+export { ReplaceWithGrandchildren };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6830,12 +6830,11 @@ html-webpack-plugin@^3.2.0:
   version "4.0.0-beta"
   resolved "https://codeload.github.com/jantimon/html-webpack-plugin/tar.gz/7fb656a2dfdf129162f993a260f3291336b17ff1"
   dependencies:
-    "@types/tapable" "1.0.2"
-    html-minifier "^3.2.3"
+    html-minifier "^3.5.20"
     loader-utils "^1.1.0"
-    lodash "^4.17.10"
-    pretty-error "^2.0.2"
-    tapable "^1.0.0"
+    lodash "^4.17.11"
+    pretty-error "^2.1.1"
+    tapable "^1.1.0"
     util.promisify "1.0.0"
 
 htmlparser2@3.8.x, htmlparser2@~3.8.1:


### PR DESCRIPTION
## Jira
N/A

## Summary
Fixes the broken `<replace-with-grandchildren>` helper element on master -- related to component lifecycle event updates recently made to the `<replace-with-children>` element that are being extended.