### PR TITLE
chore: revert renaming the components section on the docs site

### DIFF
--- a/docs-site/src/templates/_page-header.twig
+++ b/docs-site/src/templates/_page-header.twig
@@ -12,7 +12,7 @@
     },
     links: [
       {
-        text: "Patterns",
+        text: "Components",
         url: "/pattern-lab/index.html"
       },
       {


### PR DESCRIPTION
## Jira
N/A

Revert renaming the top-level nav link on the docs site for the time being.

CC @mikemai2awesome @margoromo 
