### PR TITLE
feat: add get-latest-deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ jobs:
     - stage: build-and-deploy
       name: 'Smoke Tests'
       before_script:
-        - ./scripts/get-latest-deploy.sh
         - phpenv config-rm xdebug.ini
         - composer global require hirak/prestissimo
         - yarn run setup:quick
@@ -60,7 +59,7 @@ jobs:
       after_script:
         - cd scripts && npm install
         - npm run deploy
-        - echo 'Latest deploy:' && ./get-latest-deploy.sh
+        - echo 'Latest deploy:' && ./get-latest-deploy.js
       cache:
         yarn: true
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ jobs:
       after_script:
         - cd scripts && npm install
         - npm run deploy
+        - echo 'Latest deploy:' && ./scripts/get-latest-deploy.sh
       cache:
         yarn: true
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
     - stage: build-and-deploy
       name: 'Smoke Tests'
       before_script:
+        - ./scripts/get-latest-deploy.sh
         - phpenv config-rm xdebug.ini
         - composer global require hirak/prestissimo
         - yarn run setup:quick

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       after_script:
         - cd scripts && npm install
         - npm run deploy
-        - echo 'Latest deploy:' && ./scripts/get-latest-deploy.sh
+        - echo 'Latest deploy:' && ./get-latest-deploy.sh
       cache:
         yarn: true
         directories:

--- a/scripts/get-latest-deploy.js
+++ b/scripts/get-latest-deploy.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// Outputs the latest now.sh deploy
+const { getLatestDeploy } = require('./utils');
+
+getLatestDeploy()
+  .then(url => {
+    process.stdout.write(url);
+  })
+  .catch(error => {
+    process.stderr.write(error);
+    process.exit(1);
+  });

--- a/scripts/get-latest-deploy.sh
+++ b/scripts/get-latest-deploy.sh
@@ -2,4 +2,4 @@
 # Outputs the latest now.sh deploy
 # Start in this directory even if ran elsewhere
 cd "$(dirname "$0")"
-node -e 'require("./utils").getLatestDeploy().then(x => process.stdout.write(x))'
+node -e 'require("./utils").getLatestDeploy().then(x => process.stdout.write(x)).catch(err => process.stdout.write(JSON.stringify(err)))'

--- a/scripts/get-latest-deploy.sh
+++ b/scripts/get-latest-deploy.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Outputs the latest now.sh deploy
-# Start in this directory even if ran elsewhere
-cd "$(dirname "$0")"
-node -e 'require("./utils").getLatestDeploy().then(x => process.stdout.write(x)).catch(err => process.stdout.write(JSON.stringify(err)))'

--- a/scripts/get-latest-deploy.sh
+++ b/scripts/get-latest-deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Outputs the latest now.sh deploy
+# Start in this directory even if ran elsewhere
+cd "$(dirname "$0")"
+node -e 'require("./utils").getLatestDeploy().then(x => process.stdout.write(x))'

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -84,7 +84,7 @@ function get({ path, query, hostname, TOKEN }) {
  * @link https://zeit.co/docs/api/v1/#endpoints/deployments/list-all-the-deployments
  * @return {Promise<string>} - URL of latest deploymennt
  */
-async function getLatestDeploy() {
+function getLatestDeploy() {
   if (!process.env.NOW_TOKEN) {
     process.stderr.write('NOW_TOKEN env var required and is missing');
     process.exit(1);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -98,6 +98,7 @@ async function getLatestDeploy() {
         teamId: 'team_etXPus2wqbe3W15GcdHsbAs8', // boltdesignsystem
       },
     }).then(results => {
+      console.log({ results });
       if (results.error) {
         process.stderr.write(`Error getting latest now.sh deploy: ${results.error.message}`);
         process.exit(1);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,113 @@
+const http = require('https');
+const qs = require('querystring');
+
+/**
+ * @param {Object} opt
+ * @param {string} opt.path
+ * @param {Object} opt.requestBody
+ * @param {string} opt.hostname
+ * @param {string} opt.TOKEN
+ * @param {Object} [opt.query]
+ * @return {Promise<any>}
+ */
+function post({ path, requestBody, query }) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      method: 'POST',
+      hostname,
+      path: query ? `${path}?${qs.stringify(query)}` : path,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `token ${TOKEN}`,
+      },
+    };
+
+    const req = http.request(options, res => {
+      const chunks = [];
+
+      res.on('data', chunk => {
+        chunks.push(chunk);
+      });
+
+      res.on('end', () => {
+        const responseBody = Buffer.concat(chunks);
+        resolve(JSON.parse(responseBody.toString()));
+      });
+    });
+
+    // console.log({ requestBody });
+    req.write(JSON.stringify(requestBody));
+    req.end();
+  });
+}
+
+
+/**
+ * @param {Object} opt
+ * @param {string} opt.path
+ * @param {string} opt.hostname
+ * @param {string} opt.TOKEN
+ * @param {Object} [opt.query]
+ * @return {Promise<any>}
+ */
+function get({ path, query, hostname, TOKEN }) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      method: '',
+      hostname,
+      path: query ? `${path}?${qs.stringify(query)}` : path,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `token ${TOKEN}`,
+      },
+    };
+
+    const req = http.request(options, res => {
+      const chunks = [];
+
+      res.on('data', chunk => {
+        chunks.push(chunk);
+      });
+
+      res.on('end', () => {
+        const responseBody = Buffer.concat(chunks);
+        resolve(JSON.parse(responseBody.toString()));
+      });
+    });
+
+    req.end();
+  });
+}
+
+/**
+ * @link https://zeit.co/docs/api/v1/#endpoints/deployments/list-all-the-deployments
+ * @return {Promise<string>} - URL of latest deploymennt
+ */
+async function getLatestDeploy() {
+  return new Promise((resolve, reject) => {
+    get({
+      path: '/v2/now/deployments',
+      hostname: 'api.zeit.co',
+      token: process.env.NOW_TOKEN,
+      query: {
+        teamId: 'team_etXPus2wqbe3W15GcdHsbAs8', // boltdesignsystem
+      },
+    }).then(({ deployments }) => {
+      // If a deployment hasn't finished uploading (is incomplete), the url property will have a value of null.
+      const result = deployments.find(d => d.url);
+      if (result) {
+        resolve(result.url);
+      } else {
+        reject();
+      }
+    }).catch(error => {
+      reject(error);
+    });
+  });
+}
+
+module.exports = {
+  getLatestDeploy,
+};

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -98,11 +98,11 @@ async function getLatestDeploy() {
         teamId: 'team_etXPus2wqbe3W15GcdHsbAs8', // boltdesignsystem
       },
     }).then(results => {
-      console.log({ results });
       if (results.error) {
         process.stderr.write(`Error getting latest now.sh deploy: ${results.error.message}`);
         process.exit(1);
       }
+      console.log(results.deployments[0]);
       // If a deployment hasn't finished uploading (is incomplete), the url property will have a value of null.
       const result = results.deployments.find(d => d.url);
       if (result) {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -102,13 +102,12 @@ async function getLatestDeploy() {
         process.stderr.write(`Error getting latest now.sh deploy: ${results.error.message}`);
         process.exit(1);
       }
-      console.log(results.deployments[0]);
       // If a deployment hasn't finished uploading (is incomplete), the url property will have a value of null.
       const result = results.deployments.find(d => d.url);
       if (result) {
         resolve(result.url);
       } else {
-        reject();
+        reject(new Error('No deployments found'));
       }
     }).catch(error => {
       reject(error);


### PR DESCRIPTION
## Summary

Can get the latest now.sh deploy url via Node or Bash script in a way that uses zero dependencies.

## Details

Usage:

```
./scripts/get-latest-deploy.sh
NOW_URL=`./scripts/get-latest-deploy.sh` some-other-script-to-run.sh
```

OR

```js
const { getLatestDeploy } = require('./scripts/utils');
getLatestDeploy().then(x => console.log(x));
```

Additionally, the `./scripts/utils.js` file contains vanilla node.js functions for HTTP GET and POST that other utilities could use easily. Also, the `./scripts/get-latest-deploy.sh` shows off a short and clean way that bash can use node utils.

## How to test

I've added it at the bottom of `.travis.yml`, so we'll see the output there.