### PR TITLE
Fix: video cue point button border radius

### DIFF
--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -51,8 +51,10 @@ class BoltButton extends BoltAction {
       [`c-bolt-button--${this.props.width}`]: this.props.width,
       [`c-bolt-button--${this.props.transform}`]: this.props.transform,
       'c-bolt-button--border-radius-regular': !this.props.borderRadius, // Default border radius
-      'c-bolt-button--border-radius-full': this.props.rounded && !this.props.borderRadius, // DEPRECATED.  Use the border-radius property instead of rounded.
-      [`c-bolt-button--border-radius-${this.props.borderRadius}`]: this.props.borderRadius,
+      'c-bolt-button--border-radius-full':
+        this.props.rounded && !this.props.borderRadius, // DEPRECATED.  Use the border-radius property instead of rounded.
+      [`c-bolt-button--border-radius-${this.props.borderRadius}`]: this.props
+        .borderRadius,
     });
 
     // Decide on if the rendered button tag should be a <button> or <a> tag, based on if a URL exists OR if a link was passed in from the getgo

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -42,18 +42,17 @@ class BoltButton extends BoltAction {
     const classes = cx('c-bolt-button', {
       'c-bolt-button--disabled': this.props.disabled,
       'c-bolt-button--icon-only': this.props.iconOnly,
-      'c-bolt-button--center': !this.props.align, // defautl align prop
+      'c-bolt-button--center': !this.props.align, // Default align
       [`c-bolt-button--${this.props.align}`]: this.props.align,
-      'c-bolt-button--primary': !this.props.color, // default color prop
+      'c-bolt-button--primary': !this.props.color, // Default color
       [`c-bolt-button--${this.props.color}`]: this.props.color,
       'c-bolt-button--medium': !this.props.size,
       [`c-bolt-button--${this.props.size}`]: this.props.size,
       [`c-bolt-button--${this.props.width}`]: this.props.width,
       [`c-bolt-button--${this.props.transform}`]: this.props.transform,
-      [`c-bolt-button--border-radius-full`]:
-        this.props.rounded && !this.props.borderRadius, // DEPRECATED.  Use the border-radius property instead of rounded.
-      [`c-bolt-button--border-radius-${this.props.borderRadius}`]: this.props
-        .borderRadius,
+      'c-bolt-button--border-radius-regular': !this.props.borderRadius, // Default border radius
+      'c-bolt-button--border-radius-full': this.props.rounded && !this.props.borderRadius, // DEPRECATED.  Use the border-radius property instead of rounded.
+      [`c-bolt-button--border-radius-${this.props.borderRadius}`]: this.props.borderRadius,
     });
 
     // Decide on if the rendered button tag should be a <button> or <a> tag, based on if a URL exists OR if a link was passed in from the getgo

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -621,6 +621,7 @@ class BoltVideo extends withPreact() {
     }
 
     const classes = css(
+      `t-bolt-xdark`,
       `c-${bolt.namespace}-video`,
       this.props.controls === false
         ? `c-${bolt.namespace}-video--hide-controls`


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-886

## Summary

Fixed an issue where the cue point button is not using the correct theme and border-radius.

## Details

When using the bolt-button web component (which the video cue point demo is using), the default border-radius should be regular. I updated the button.js to fix that, and the theme class in video to make it a yellow button.

## How to test

Run the branch locally and check the web component button demo page, and the cue point video demo page.

1. Button demo should have border-radius set to regular
2. Cue point demo should have the yellow button and regular border-radius
