### PR TITLE
Speed Up Component Explorer Rendering Times

### DIFF
--- a/docs-site/src/components/schema-form/component-explorer.js
+++ b/docs-site/src/components/schema-form/component-explorer.js
@@ -92,6 +92,7 @@ export default class ComponentExplorer extends withContext(withLitHtml()) {
       const res = await fetch(
         `/api/render?${qs.stringify({
           template: this.props.template,
+          keepAlive: true,
         })}`,
         {
           method: 'POST',

--- a/docs-site/src/components/schema-form/component-explorer.js
+++ b/docs-site/src/components/schema-form/component-explorer.js
@@ -92,7 +92,6 @@ export default class ComponentExplorer extends withContext(withLitHtml()) {
       const res = await fetch(
         `/api/render?${qs.stringify({
           template: this.props.template,
-          keepAlive: true,
         })}`,
         {
           method: 'POST',

--- a/packages/build-tools/api/index.js
+++ b/packages/build-tools/api/index.js
@@ -47,7 +47,7 @@ async function handleRequest(req, res, next) {
           log.error('The template paramater is missing!');
         }
         const body = await getBody(req);
-        const { ok, html, message } = await render(query.template, body);
+        const { ok, html, message } = await render(query.template, body, true);
 
         if (!ok) {
           log.error(message);

--- a/packages/twig-renderer/twig-renderer.js
+++ b/packages/twig-renderer/twig-renderer.js
@@ -33,7 +33,7 @@ async function init() {
     alterTwigEnv: config.alterTwigEnv,
     hasExtraInfoInResponses: false, // Will add `info` onto results with a lot of info about Twig Env
     maxConcurrency: 50,
-    keepAlive: config.prod ? true : false, // setting this to true will cause subsequent template / page recompiles to not regenerate when the source files have changed
+    keepAlive: false, // setting this to true will cause subsequent template / page recompiles to not regenerate when the source files have changed
   });
   state = STATES.READY;
 }

--- a/packages/twig-renderer/twig-renderer.js
+++ b/packages/twig-renderer/twig-renderer.js
@@ -14,7 +14,11 @@ const STATES = {
 };
 let state = STATES.NOT_STARTED;
 
-async function init() {
+/**
+ * Initialize Twig Renderer instance
+ * @param {Boolean} keepAlive - Optionally tell the Twig renderer service to keep alive to help speed up requests
+ */
+async function init(keepAlive = false) {
   state = STATES.STARTING;
   const config = await getConfig();
   const relativeFrom = path.dirname(config.configFileUsed);
@@ -33,17 +37,17 @@ async function init() {
     alterTwigEnv: config.alterTwigEnv,
     hasExtraInfoInResponses: false, // Will add `info` onto results with a lot of info about Twig Env
     maxConcurrency: 50,
-    keepAlive: false, // setting this to true will cause subsequent template / page recompiles to not regenerate when the source files have changed
+    keepAlive, // only set this to be true when doing in-browser requests to avoid issues with this process not exiting when complete
   });
   state = STATES.READY;
 }
 
-async function prep() {
+async function prep(keepAlive) {
   switch (state) {
     case STATES.READY:
       return;
     case STATES.NOT_STARTED:
-      return await init();
+      return await init(keepAlive);
     case STATES.STARTING:
       while (state === STATES.STARTING) {
         await sleep(20); // eslint-disable-line no-await-in-loop
@@ -55,10 +59,11 @@ async function prep() {
  * Render Twig Template
  * @param {string} template - Template name (i.e. `@bolt/button.twig`)
  * @param {Object} data - Optional data to pass to template
+ * @param {Boolean} keepAlive - Optionally tell the Twig renderer service to keep alive to help speed up requests
  * @return {Promise<{{ ok: boolean, html: string, message: string}}>} - Results of render
  */
-async function render(template, data = {}) {
-  await prep();
+async function render(template, data = {}, keepAlive = false) {
+  await prep(keepAlive);
   const results = await twigRenderer.render(template, data);
   return results;
 }
@@ -67,10 +72,11 @@ async function render(template, data = {}) {
  * Render Twig String
  * @param {string} templateString - String that is a Twig template (i.e. `<p>{{ text }}</p>`)
  * @param {Object} data - Optional data to pass to template
+ * @param {Boolean} keepAlive - Optionally tell the Twig renderer service to keep alive to help speed up requests
  * @return {Promise<{{ ok: boolean, html: string, message: string}}>} - Results of render
  */
-async function renderString(templateString, data = {}) {
-  await prep();
+async function renderString(templateString, data = {}, keepAlive = false) {
+  await prep(keepAlive);
   const results = await twigRenderer.renderString(templateString, data);
   // console.log({ results });
   return results;

--- a/packages/twig-renderer/twig-renderer.js
+++ b/packages/twig-renderer/twig-renderer.js
@@ -32,8 +32,8 @@ async function init() {
     debug: true,
     alterTwigEnv: config.alterTwigEnv,
     hasExtraInfoInResponses: false, // Will add `info` onto results with a lot of info about Twig Env
-    maxConcurrency: 10,
-    keepAlive: false, // setting this to true will cause subsequent template / page recompiles to not regenerate when the source files have changed
+    maxConcurrency: 50,
+    keepAlive: config.prod ? true : false, // setting this to true will cause subsequent template / page recompiles to not regenerate when the source files have changed
   });
   state = STATES.READY;
 }
@@ -46,7 +46,7 @@ async function prep() {
       return await init();
     case STATES.STARTING:
       while (state === STATES.STARTING) {
-        await sleep(100); // eslint-disable-line no-await-in-loop
+        await sleep(20); // eslint-disable-line no-await-in-loop
       }
   }
 }


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-913?filter=-1

## Summary
Speed up response times for the new in-browser component explorer. [Testing Steps](https://github.com/bolt-design-system/bolt/pull/1034#user-content-testing-steps)

## Description
Speeds up the response times for the in-browser component explorer by allowing the Twig renderer to conditionally allow certain requests to keep the service alive under the hood (ie. in-browser API requests) while having other services (like the static site generator or Jest snapshot tests) automatically opt out of `keepAlive` to help prevent runaway tasks that don't exit when expected. 

Re-rendering times (when you change content in the component explorer form) are especially faster when compared to the latest that's up on master!

<h2 id="testing-steps">Testing Steps</h2>

### 1. Do these updates work and make sense?
- [ ] Verify that the JSDoc updates that explain the new optional API config option here make sense
- [ ] Compare speed / response times with the [previous version](https://master.boltdesignsystem.com/pattern-lab/?p=components-button-docs) of our component explorer with these [new updates](https://feature-speed-up-twig-renderer.boltdesignsystem.com/pattern-lab/?p=components-button-docs) to confirm these updates help improve how long it takes to render / re-render the component.

### 2. Do these updates break the build or any existing functionality?
- [ ] Jest tests run and complete as expected
- [ ] Static site generator compiles the boltdesignsystem.com site as expected
- [ ] The in-browser component explorer for the [Button](https://feature-speed-up-twig-renderer.boltdesignsystem.com/pattern-lab/?p=components-button-docs) and [Navbar](https://feature-speed-up-twig-renderer.boltdesignsystem.com/pattern-lab/?p=components-navbar-docs) components renders and re-renders (after updating some content) as expected
- [ ] Travis CI builds + deploys to now.sh as expected