### PR TITLE
fix: Remove all unwanted children blocks from twig templates

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/05-code-snippet.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/05-code-snippet.twig
@@ -1,42 +1,45 @@
 <p>
   Code snippet can be a block of code, and
   {% include "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": "inline",
-    "content": "display"
+    display: "inline",
+    content: "display"
   } only %}
   is set to
   {% include "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": "inline",
-    "content": "block"
+    display: "inline",
+    content: "block"
   } only %}
   by default.
 </p>
-{% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "scss"
-} only %}
-{% block children %}
+
+{% set blockSnippet %}
 display: block;
 margin: 0 0 1.65rem 0;
-{% endblock %}
+{% endset %}
+
+{% embed "@bolt-components-code-snippet/code-snippet.twig" with {
+  display: "block",
+  lang: "scss",
+  content: blockSnippet
+} only %}
 {% endembed %}
 
 <p>
   Well, code snippet can also be inline like this
   {% include "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": "inline",
-    "lang": "scss",
-    "content": "display:inline;"
+    display: "inline",
+    lang: "scss",
+    content: "display:inline;"
   } only %}
   when you set
   {% include "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": "inline",
-    "content": "display"
+    display: "inline",
+    content: "display"
   } only %}
   to be
   {% include "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": "inline",
-    "content": "inline"
+    display: "inline",
+    content: "inline"
   } only %}
   instead.
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/10-code-snippet-display-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/10-code-snippet-display-variation.twig
@@ -8,8 +8,8 @@
 {% for display in schema.properties.display.enum %}
   <h3>{{ display }}:</h3>
   {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": display,
-    "content": code
+    display: display,
+    content: code
   } only %}
   {% endembed %}
 {% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/15-code-snippet-language-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/15-code-snippet-language-variation.twig
@@ -22,48 +22,48 @@ import { polyfillLoader } from '@bolt/core';
 
 {% set twig %}{%- verbatim -%}
 {% include "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "html",
-  "content": "Some code snippet"
+  display: "block",
+  lang: "html",
+  content: "Some code snippet"
 } only %}
 {%- endverbatim -%}{% endset %}
 
 <h3>css:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "css",
-  "content": css
+  display: "block",
+  lang: "css",
+  content: css
 } only %}
 {% endembed %}
 
 <h3>scss:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "scss",
-  "content": scss
+  display: "block",
+  lang: "scss",
+  content: scss
 } only %}
 {% endembed %}
 
 <h3>html:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "html",
-  "content": html
+  display: "block",
+  lang: "html",
+  content: html
 } only %}
 {% endembed %}
 
 <h3>javascript:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "js",
-  "content": js
+  display: "block",
+  lang: "js",
+  content: js
 } only %}
 {% endembed %}
 
 <h3>twig:</h3>
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  "display": "block",
-  "lang": "twig",
-  "content": twig
+  display: "block",
+  lang: "twig",
+  content: twig
 } only %}
 {% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/20-code-snippet-syntax-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/20-code-snippet-syntax-variation.twig
@@ -8,9 +8,9 @@
 {% for syntax in schema.properties.syntax.enum %}
   <h3>{{ syntax }}:</h3>
   {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-    "display": "block",
-    "syntax": syntax,
-    "content": html
+    display: "block",
+    syntax: syntax,
+    content: html
   } only %}
   {% endembed %}
 {% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/icon/11-icon-branded-colors.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/icon/11-icon-branded-colors.twig
@@ -3,27 +3,24 @@
 
 <h2>via Web Component:</h2>
 
-{% set customElementExample %}
-  <bolt-icon
-    size="xlarge"
-    background="circle"
-    name="marketing-gray"
-    style="
+{% set customElementExample %}{%- verbatim -%}
+<bolt-icon
+  size="xlarge"
+  background="circle"
+  name="marketing-gray"
+  style="
     color: #a65388;
     --bolt-theme-icon-background: #a65388;
     --bolt-theme-icon: #FFF;
     --bolt-theme-icon-background-opacity: 1;
   "></bolt-icon>
-{% endset %}
+{%- endverbatim -%}{% endset %}
 
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  lang: "html"
+  lang: "html",
+  content: customElementExample
 } %}
-  {% block children %}
-    {{ customElementExample|raw }}
-  {% endblock %}
 {% endembed %}
-
 
 <bolt-icon
   size="xlarge"
@@ -74,33 +71,27 @@
 
 <h2>via Twig Include:</h2>
 
-{% set twigIncludeExample %}
-  {% verbatim %}
-    {% include "@bolt-components-icon/icon.twig" with {
-    name: "customer-service",
-    background: "circle",
-    size: "xlarge",
-    attributes: {
-      style: [
-        "color: #e64b18;",
-        "--bolt-theme-icon-background: #e64b18;",
-        "--bolt-theme-icon: #FFF;",
-        "--bolt-theme-icon-background-opacity: 1;"
-      ]
-    }
-    } only %}
-  {% endverbatim %}
-{% endset %}
+{% set twigIncludeExample %}{%- verbatim -%}
+{% include "@bolt-components-icon/icon.twig" with {
+  name: "customer-service",
+  background: "circle",
+  size: "xlarge",
+  attributes: {
+    style: [
+      "color: #e64b18;",
+      "--bolt-theme-icon-background: #e64b18;",
+      "--bolt-theme-icon: #FFF;",
+      "--bolt-theme-icon-background-opacity: 1;"
+    ]
+  }
+} only %}
+{%- endverbatim -%}{% endset %}
 
 {% embed "@bolt-components-code-snippet/code-snippet.twig" with {
-  lang: "twig"
+  lang: "twig",
+  content: twigIncludeExample
 } %}
-{% block children %}
-  {{ twigIncludeExample|raw }}
-{% endblock %}
 {% endembed %}
-
-
 
 {% include "@bolt-components-icon/icon.twig" with {
   name: "marketing-gray",
@@ -115,8 +106,6 @@
     ]
   }
 } only %}
-
-
 
 {% include "@bolt-components-icon/icon.twig" with {
   name: "customer-service",

--- a/packages/components/bolt-code-snippet/src/code-snippet.twig
+++ b/packages/components/bolt-code-snippet/src/code-snippet.twig
@@ -24,7 +24,7 @@
 ] %}
 
 {% set codeContent %}
-  <code class="{{ "#{baseClass}__code #{baseClass}__code--#{display}" }} nohighlight" is="shadow-root">{% block children %}{{ content }}{% endblock %}</code>
+  <code class="{{ "#{baseClass}__code #{baseClass}__code--#{display}" }} nohighlight" is="shadow-root">{{ content }}</code>
 {% endset %}
 
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-832

## Summary

Remove children blocks from twig files.

## How to test

Run this code locally. Search for {% block children %} if you find nothing that's ok :). You can find some in `node_modules` directory in `test` files but those files we ignore.