### PR TITLE
Fix: inline list alignment

### DIFF
--- a/packages/components/lists/bolt-list/src/_list-item.js
+++ b/packages/components/lists/bolt-list/src/_list-item.js
@@ -19,10 +19,12 @@ class BoltListItem extends withContext(withLitHtml()) {
   // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
   static get consumes() {
     return [
-      [
-        ListContext,
-        ['tag', 'spacing', 'inset', 'separator', 'display', 'align'],
-      ],
+      [ListContext, 'spacing'],
+      [ListContext, 'tag'],
+      [ListContext, 'inset'],
+      [ListContext, 'separator'],
+      [ListContext, 'display'],
+      [ListContext, 'align'],
     ];
   }
 

--- a/packages/components/lists/bolt-list/src/list.scss
+++ b/packages/components/lists/bolt-list/src/list.scss
@@ -22,6 +22,7 @@
 .c-bolt-list--display-inline {
   display: inline-flex;
   flex-flow: row wrap;
+  width: 100%; // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
 }
 
 .c-bolt-list--display-flex {


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-926

## Summary

Fixed an issue with the inline list's horizontal alignment in IE11, and props not rendering in real time when using the web component.

## Details

In IE11, the inline bolt-list was not filling the available space of a container, so the alignment was not able to display correctly. A simple CSS line to make the bolt-list parent full width fixes the issue.

Also @sghoweri fixed a bug with the JS context, instead of this:
```javascript
static get consumes() {
  return [
    [
      ListContext,
      ['tag', 'spacing', 'inset', 'separator', 'display', 'align'],
    ],
  ];
}
```

It's changed to this:
```javascript
static get consumes() {
  return [
    [ListContext, 'spacing'],
    [ListContext, 'tag'],
    [ListContext, 'inset'],
    [ListContext, 'separator'],
    [ListContext, 'display'],
    [ListContext, 'align'],
  ];
}
```
This allows the prop values (such as spacing) to trickle down from the parent to the children.

cc @remydenton @danielamorse @adam2661 

## How to test

1. Run the branch locally and check out the alignment demo page in IE11: http://localhost:3000/pattern-lab/patterns/02-components-list-40-list-align-variations/02-components-list-40-list-align-variations.html
2. Make sure the alignments are displaying correctly
3. Change some prop values on the web component using developer tool in the browser, make sure the changes take place in real time.