### PR TITLE
Bolt Card Link and Action updates

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card/30-card-link-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card/30-card-link-variations.twig
@@ -23,6 +23,7 @@
     {% include "@bolt-components-card/card.twig" with {
       link: {
         url: "http://pega.com",
+        text: "Go to pega.com"
       },
       media: {
         image: {

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card/45-card-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card/45-card-with-web-component.twig
@@ -63,7 +63,7 @@
 {% endset %}
 
 {% set simple_link_demo %}
-<bolt-card url="https://google.com">
+<bolt-card url="https://google.com" url-text="Go to google.com">
   {% include card_demo.image() %}
   {% include card_demo.body_clickable() %}
 </bolt-card>
@@ -71,7 +71,7 @@
 
 {% set advanced_link_demo %}
 <bolt-card>
-  <bolt-card-link url="https://google.com" target="_blank" custom-attribute="foo" html-attribute="bar"></bolt-card-link>
+  <bolt-card-link custom-attribute="foo" html-attribute="bar"><a href="http://google.com" target="_blank">Go to google.com</a></bolt-card-link>
   {% include card_demo.image() %}
   {% include card_demo.body_clickable() %}
 </bolt-card>
@@ -107,7 +107,7 @@
     Simple Link Usage
   </bolt-text>
   <bolt-text>
-    The simplest way to make the whole card clickable is by passing a link address to the <bolt-code-snippet display="inline" lang="html">url</bolt-code-snippet> prop on the main <bolt-code-snippet display="inline" lang="html">&lt;bolt-card&gt;</bolt-code-snippet> component itself.
+    The simplest way to make the whole card clickable is by passing a link address to the <bolt-code-snippet display="inline" lang="html">url</bolt-code-snippet> prop on the main <bolt-code-snippet display="inline" lang="html">&lt;bolt-card&gt;</bolt-code-snippet> component itself. Also include the <bolt-code-snippet display="inline" lang="html">url-text</bolt-code-snippet> prop for accessibility.
   </bolt-text>
   <div class="t-bolt-light u-bolt-margin-bottom-small u-bolt-padding-medium">
     {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--center" %}
@@ -124,7 +124,7 @@
     Advanced Link Usage
   </bolt-text>
   <bolt-text>
-    Insert a <bolt-code-snippet display="inline" lang="html">&lt;bolt-card-link&gt;</bolt-code-snippet> inside <bolt-code-snippet display="inline" lang="html">&lt;bolt-card&gt;</bolt-code-snippet>, and you can pass more than just <bolt-code-snippet display="inline" lang="html">url</bolt-code-snippet>. <bolt-code-snippet display="inline" lang="html">&lt;bolt-card-link&gt;</bolt-code-snippet> acts exactly like <bolt-code-snippet display="inline" lang="html">&lt;bolt-link&gt;</bolt-code-snippet>, it accepts all the props from <bolt-code-snippet display="inline" lang="html">&lt;bolt-link&gt;</bolt-code-snippet> and any other attributes that are allowed in <bolt-code-snippet display="inline" lang="html">&lt;bolt-link&gt;</bolt-code-snippet>.
+    Insert a <bolt-code-snippet display="inline" lang="html">&lt;bolt-card-link&gt;</bolt-code-snippet> inside <bolt-code-snippet display="inline" lang="html">&lt;bolt-card&gt;</bolt-code-snippet> and you can pass more than just <bolt-code-snippet display="inline" lang="html">url</bolt-code-snippet>. <bolt-code-snippet display="inline" lang="html">&lt;bolt-card-link&gt;</bolt-code-snippet> is similar to <bolt-code-snippet display="inline" lang="html">&lt;bolt-link&gt;</bolt-code-snippet>. You can add custom attributes to <bolt-code-snippet display="inline" lang="html">&lt;bolt-card-link&gt;</bolt-code-snippet> and insert a semantic <bolt-code-snippet display="inline" lang="html">&lt;a&gt;</bolt-code-snippet> or <bolt-code-snippet display="inline" lang="html">&lt;button&gt;</bolt-code-snippet> element inside.
   </bolt-text>
   <div class="t-bolt-light u-bolt-margin-bottom-small u-bolt-padding-medium">
     {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--center" %}

--- a/packages/components/bolt-button/src/button.standalone.js
+++ b/packages/components/bolt-button/src/button.standalone.js
@@ -114,6 +114,14 @@ class BoltButton extends BoltAction {
 
     if (this.rootElement) {
       buttonElement = this.rootElement.firstChild.cloneNode(true);
+      if (buttonElement.tagName === 'A') {
+        if (buttonElement.getAttribute('href') === null && hasUrl) {
+          buttonElement.setAttribute('href', this.props.url);
+        }
+        if (buttonElement.getAttribute('target') === null && urlTarget) {
+          buttonElement.setAttribute('target', urlTarget);
+        }
+      }
       buttonElement.className += ' ' + classes;
       render(innerSlots, buttonElement);
     } else if (hasUrl) {

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -53,6 +53,9 @@
   {% if url %}
     {% set innerAttributes = innerAttributes.setAttribute("href", url) %}
   {% endif %}
+  {% if target or attributes['target'] %}
+    {% set innerAttributes = innerAttributes.setAttribute("target", target|default(attributes['target'])) %}
+  {% endif %}
 {% elseif tag == "reset" %}
   {% set tag = "button" %}
   {% set innerAttributes = innerAttributes.setAttribute("type", "reset") %}

--- a/packages/components/bolt-card/__tests__/__snapshots__/card.js.snap
+++ b/packages/components/bolt-card/__tests__/__snapshots__/card.js.snap
@@ -1,44 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`card basic card 1`] = `
-"<bolt-card
-   tag=\\"article\\"    theme=\\"none\\"    height=\\"full\\"     
+
+<bolt-card tag="article"
+           theme="none"
+           height="full"
 >
-    
-    
-  <replace-with-children  class=\\"c-bolt-card\\">
-    
-                                      
+  <replace-with-children class="c-bolt-card">
+    <bolt-card-body>
+      <replace-with-children class="c-bolt-card__body">
+        <p class="c-bolt-text c-bolt-text--regular c-bolt-text--normal c-bolt-text--medium">
+          This is a paragraph.
+        </p>
+      </replace-with-children>
+    </bolt-card-body>
+  </replace-with-children>
+</bolt-card>
 
-<bolt-card-body>
-  <replace-with-children class=\\"c-bolt-card__body\\">
-                      
-                            
-
-
-  
-
- 
-  
-
-
-
-
-  
-
-  
-
-
-
-
-
-<p  class=\\"c-bolt-text c-bolt-text--regular c-bolt-text--normal c-bolt-text--medium\\">
-  
-      This is a paragraph.
-  
-  </p>
-            </replace-with-children>
-</bolt-card-body>
-                            </replace-with-children>
-</bolt-card>"
 `;

--- a/packages/components/bolt-card/card.schema.yml
+++ b/packages/components/bolt-card/card.schema.yml
@@ -36,6 +36,9 @@ properties:
       url:
         type: string
         description: Address for the link.
+      text:
+        type: string
+        description: Visually hidden text for link, included for accessibility.
       attributes:
         type: object
         description: A Drupal-style attributes object with extra attributes to append to this component.

--- a/packages/components/bolt-card/src/_card-link.js
+++ b/packages/components/bolt-card/src/_card-link.js
@@ -1,9 +1,10 @@
 import { BoltAction } from '@bolt/core/elements/bolt-action';
 import { props, define } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { html } from '@bolt/core/renderers/renderer-lit-html';
+import { html, render } from '@bolt/core/renderers/renderer-lit-html';
 import { convertInitialTags } from '@bolt/core/decorators';
 
+import visuallyhiddenUtils from '@bolt/global/styles/07-utilities/_utilities-visuallyhidden.scss';
 import styles from './_card-link.scss';
 
 let cx = classNames.bind(styles);
@@ -25,6 +26,14 @@ class BoltCardLink extends BoltAction {
 
     let renderedLink;
 
+    const slotMarkup = () => {
+      return html`
+        <span class="${cx('u-bolt-visuallyhidden')}"
+          >${this.slot('default')}</span
+        >
+      `;
+    };
+
     if (this.rootElement) {
       renderedLink = this.rootElement.firstChild.cloneNode(true);
       if (renderedLink.tagName === 'A') {
@@ -36,24 +45,23 @@ class BoltCardLink extends BoltAction {
         }
       }
       renderedLink.className += ' ' + classes;
+      render(slotMarkup(), renderedLink);
     } else {
       if (hasUrl) {
         renderedLink = html`
-          <a
-            href="${this.props.url}"
-            class="${classes}"
-            target="${urlTarget}"
-          ></a>
+          <a href="${this.props.url}" class="${classes}" target="${urlTarget}"
+            >${slotMarkup()}</a
+          >
         `;
       } else {
         renderedLink = html`
-          <button class="${classes}" type="button"></button>
+          <button class="${classes}" type="button">${slotMarkup()}</button>
         `;
       }
     }
 
     return html`
-      ${this.addStyles([styles])} ${renderedLink}
+      ${this.addStyles([styles, visuallyhiddenUtils])} ${renderedLink}
     `;
   }
 }

--- a/packages/components/bolt-card/src/_card-link.js
+++ b/packages/components/bolt-card/src/_card-link.js
@@ -1,34 +1,59 @@
-import { BoltLink } from '@bolt/components-link/src/link.js';
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { BoltAction } from '@bolt/core/elements/bolt-action';
+import { props, define } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { html } from '@bolt/core/renderers/renderer-lit-html';
+import { convertInitialTags } from '@bolt/core/decorators';
 
-import schema from '../card.schema.yml';
 import styles from './_card-link.scss';
 
 let cx = classNames.bind(styles);
 
 @define
-class BoltCardLink extends BoltLink {
+@convertInitialTags('a') // The first matching tag will have its attributes converted to component props
+class BoltCardLink extends BoltAction {
   static is = 'bolt-card-link';
 
   constructor() {
     super();
-    this.styles = styles;
-    this.baseClass = 'c-bolt-card__link';
   }
 
   render() {
     const classes = cx('c-bolt-card__link');
 
-    return html`
-      ${this.addStyles([styles])}
-      ${
-        this.rootElement
-          ? this.customLinkTemplate(this.props.url, classes, this.props.target)
-          : this.linkTemplate(this.props.url, classes, this.props.target)
+    const hasUrl = this.props.url.length > 0 && this.props.url !== 'null';
+    const urlTarget = this.props.target && hasUrl ? this.props.target : '_self';
+
+    let renderedLink;
+
+    if (this.rootElement) {
+      renderedLink = this.rootElement.firstChild.cloneNode(true);
+      if (renderedLink.tagName === 'A') {
+        if (renderedLink.getAttribute('href') === null && hasUrl) {
+          renderedLink.setAttribute('href', this.props.url);
+        }
+        if (renderedLink.getAttribute('target') === null && urlTarget) {
+          renderedLink.setAttribute('target', urlTarget);
+        }
       }
-      ${this.slot('default')}
+      renderedLink.className += ' ' + classes;
+    } else {
+      if (hasUrl) {
+        renderedLink = html`
+          <a
+            href="${this.props.url}"
+            class="${classes}"
+            target="${urlTarget}"
+          ></a>
+        `;
+      } else {
+        renderedLink = html`
+          <button class="${classes}" type="button"></button>
+        `;
+      }
+    }
+
+    return html`
+      ${this.addStyles([styles])} ${renderedLink}
     `;
   }
 }

--- a/packages/components/bolt-card/src/_card-link.scss
+++ b/packages/components/bolt-card/src/_card-link.scss
@@ -5,8 +5,9 @@
 @import '@bolt/core';
 @import './_card-settings-and-tools.scss';
 
+// https://www.w3.org/TR/CSS21/visudet.html#abs-replaced-width
+
 .c-bolt-card__link {
-  content: '';
   display: block;
   position: absolute;
   top: 0;
@@ -15,4 +16,15 @@
   left: 0;
   z-index: $bolt-card-link-z-index; // a small z-index is required here so the <bolt-card-link> covers most types of content used inside the card component, except for a few exceptions
   cursor: pointer;
+}
+
+button.c-bolt-card__link {
+  width: 100%; // [1]
+  height: 100%; // [1]
+  padding: 0;
+  border: none;
+  background: none;
+  &:focus {
+    outline: none;
+  }
 }

--- a/packages/components/bolt-card/src/card.js
+++ b/packages/components/bolt-card/src/card.js
@@ -38,6 +38,7 @@ class BoltCard extends withContext(withLitHtml()) {
     height: props.string, // full | auto
     raised: props.boolean,
     url: props.string,
+    urlText: props.string,
   };
 
   constructor(self) {
@@ -91,7 +92,8 @@ class BoltCard extends withContext(withLitHtml()) {
             <bolt-card-link
               url="${this.props.url}"
               ?target="${this.props.target}"
-            ></bolt-card-link>
+              >${this.props.urlText}</bolt-card-link
+            >
           `
         : '';
 

--- a/packages/components/bolt-card/src/card.twig
+++ b/packages/components/bolt-card/src/card.twig
@@ -21,6 +21,7 @@
 
 {% if link %}
   {% set link_url = link.url %}
+  {% set link_target = link.target %}
   {% set link_attributes = create_attribute(link.attributes) %}
 {% endif %}
 
@@ -45,11 +46,15 @@
   <replace-with-children {{ inner_attributes.addClass(classes) }}>
     {% if link %}
       <bolt-card-link
-        class="{{ "#{base_class}__link" }}"
         {{ link_attributes }}
       >
-        <a href="{{ link_url }}">
-        </a>
+        {% if link_url %}
+          <a
+            href="{{ link_url }}"
+            class="{{ "#{base_class}__link" }}"
+            {% if link_target %} target="{{ link_target }}"{% endif %}
+          ></a>
+        {% endif %}
       </bolt-card-link>
     {% endif %}
 

--- a/packages/components/bolt-card/src/card.twig
+++ b/packages/components/bolt-card/src/card.twig
@@ -21,10 +21,10 @@
 
 {% if link %}
   {% set link_url = link.url %}
+  {% set link_text = link.text %}
   {% set link_target = link.target %}
   {% set link_attributes = create_attribute(link.attributes) %}
 {% endif %}
-
 
 {# card component's custom element wrapper #}
 <bolt-card
@@ -53,7 +53,11 @@
             href="{{ link_url }}"
             class="{{ "#{base_class}__link" }}"
             {% if link_target %} target="{{ link_target }}"{% endif %}
-          ></a>
+          >
+            {% if link_text %}
+              <replace-with-children class="u-bolt-visuallyhidden">{{ link_text }}</replace-with-children>
+            {% endif %}
+          </a>
         {% endif %}
       </bolt-card-link>
     {% endif %}

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -50,8 +50,7 @@ class BoltLink extends BoltAction {
     const hasUrl = this.props.url.length > 0 && this.props.url !== 'null';
 
     // Assign default target attribute value if one isn't specified
-    const anchorTarget =
-      this.props.target && hasUrl ? this.props.target : '_self';
+    const urlTarget = this.props.target && hasUrl ? this.props.target : '_self';
 
     // The linkElement to render, based on the initial HTML passed alone.
     let renderedLink;
@@ -94,12 +93,15 @@ class BoltLink extends BoltAction {
       if (renderedLink.getAttribute('href') === null && hasUrl) {
         renderedLink.setAttribute('href', this.props.url);
       }
+      if (renderedLink.getAttribute('target') === null && urlTarget) {
+        renderedLink.setAttribute('target', urlTarget);
+      }
       renderedLink.className += ' ' + classes;
       render(innerSlots, renderedLink);
     } else {
       // [1]
       // prettier-ignore
-      renderedLink = html`<a href="${this.props.url}" class="${classes}" target="${anchorTarget}"
+      renderedLink = html`<a href="${this.props.url}" class="${classes}" target="${urlTarget}"
           >${innerSlots}</a
         >`;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,6 +1416,11 @@
   version "1.5.1"
   resolved "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz#48fd98c1561fe718b61733daed46ff115b496e18"
 
+"@types/tapable@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
+  integrity sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==
+
 "@verdaccio/file-locking@0.0.7", "@verdaccio/file-locking@^0.0.7":
   version "0.0.7"
   resolved "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-0.0.7.tgz#5fd1b2bd391e54fa32d079002b5f7ba90844e344"
@@ -6740,7 +6745,7 @@ html-loader@^0.5.5:
     loader-utils "^1.1.0"
     object-assign "^4.1.1"
 
-html-minifier@^3.3.1, html-minifier@^3.5.20, html-minifier@^3.5.8:
+html-minifier@^3.2.3, html-minifier@^3.3.1, html-minifier@^3.5.8:
   version "3.5.21"
   resolved "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c"
   dependencies:
@@ -6768,12 +6773,11 @@ html-tags@^2.0.0:
   version "4.0.0-beta"
   resolved "https://codeload.github.com/jantimon/html-webpack-plugin/tar.gz/7fb656a2dfdf129162f993a260f3291336b17ff1"
   dependencies:
-    "@types/tapable" "1.0.2"
-    html-minifier "^3.2.3"
+    html-minifier "^3.5.20"
     loader-utils "^1.1.0"
-    lodash "^4.17.10"
-    pretty-error "^2.0.2"
-    tapable "^1.0.0"
+    lodash "^4.17.11"
+    pretty-error "^2.1.1"
+    tapable "^1.1.0"
     util.promisify "1.0.0"
 
 htmlparser2@3.9.1:
@@ -11384,9 +11388,10 @@ prettier@^1.14.2, prettier@^1.7.4:
   version "1.15.3"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
 
-pretty-error@^2.1.1:
+pretty-error@^2.0.2:
   version "2.1.1"
-  resolved "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
+  integrity sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"


### PR DESCRIPTION
## Jira

 - http://vjira2:8080/browse/BDS-911
 - http://vjira2:8080/browse/BDS-912

## Summary
1. Update `BoltCardLink` to extend `BoltAction` class instead of `BoltLink`.
2. Update `BoltButton` component to set `target` attribute on initial semantic anchor element.

## Details
1. `BoltCardLink` was extending `BoltLink` which meant it always output an anchor element and required an `href`. Now, it outputs an anchor *or* a button depending upon the presence of the `url` attribute.
2. `BoltButton` was not setting the `target` attribute on the semantic anchor tag inside the component. Now, if there is a semantic anchor without a `target` attribute, and `target` prop is set on the component, that attribute will be set on the anchor. This bug was discovered while QA'ing `BoltCardAction`, so fixing it now.

## How to test
### Card with Link
- Go to [Card with link variations page](https://feature-card-link-action-updates.boltdesignsystem.com/pattern-lab/patterns/02-components-card-30-card-link-variations/02-components-card-30-card-link-variations.html)
- Right card: Verify that the whole card is clickable. Clicking on the bottom button will go to one URL, clicking anywhere else goes to a different URL.

### Card with Video
- Go to [Card with video page](https://feature-card-link-action-updates.boltdesignsystem.com/pattern-lab/patterns/02-components-card-35-card-with-video/02-components-card-35-card-with-video.html)
- Left card: Verify that clicking the button starts/stops the video.
- Right card: Verify that clicking the button or clicking anywhere else on the card starts/stops the video.

### Card with Button
- Go to [Card button variations](https://feature-card-link-action-updates.boltdesignsystem.com/pattern-lab/patterns/02-components-card-10-card-button-variations/02-components-card-10-card-button-variations.html)
- Left card: Verify that clicking the button opens a link in same window.
- Right card: Verify that clicking the button opens a link in new window.

### Card with Web Components
- Go to [Card with web components](https://feature-card-link-action-updates.boltdesignsystem.com/pattern-lab/patterns/02-components-card-45-card-with-web-component/02-components-card-45-card-with-web-component.html)
- Web Component Usage: Verify "Internal link" opens in same window, "External link" opens in new window.
- Simple Link Usage: Verify the whole card is clickable.
- Advanced Link Usage: Verify the whole card is clickable.
- Nested Links: Verify clicking on video starts/stops video, "Internal link" opens in same window, "External link" opens in new window, clicking anywhere else opens a link in same window.

### Button
- Go to [Button page](https://feature-card-link-action-updates.boltdesignsystem.com/pattern-lab/patterns/02-components-button/index.html)
- Test for visual and functional regressions

### Link
- Go to [Link page](https://feature-card-link-action-updates.boltdesignsystem.com/pattern-lab/patterns/02-components-link/index.html)
- Test for visual and functional regressions