### PR TITLE
Hotfix: Band / Height Issue In IE 11 & Firefox

### DIFF
--- a/docs-site/src/components/site-layout/site-layout.scss
+++ b/docs-site/src/components/site-layout/site-layout.scss
@@ -3,15 +3,10 @@
 @import '@bolt/core';
 $bds-sidebar-width: 320px;
 
-html {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
 .c-bds-layout {
   grid-template-columns: auto 1fr auto;
   display: grid;
+  min-height: 100vh;
 
   &--parent:not(.c-bds-layout--has-sidebar) {
     display: flex;

--- a/docs-site/src/templates/_site-head.twig
+++ b/docs-site/src/templates/_site-head.twig
@@ -26,7 +26,7 @@
 {% set cacheBuster = bolt.data.config.prod ? "?v=" ~ bolt.data.fullManifest.version : "" %}
 
 {% set htmlClasses = [
-  '',
+  currentUrl == 'index.html' ? 'u-bolt-min-height-screen u-bolt-flex' : ''
 ] %}
 
 <!DOCTYPE html>

--- a/nightwatch.js
+++ b/nightwatch.js
@@ -126,6 +126,7 @@ function handleNightwatchResults(client, callback) {
 
 module.exports = {
   globals: {
+    asyncHookTimeout: 30000, // increasing timeout to prevent errors in Sauce Labs
     testingUrl,
     results: [],
     testCount: 0,


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1016

## Summary
Hotfix to address a `display: flex` + `min-height` related layout issue in IE 11 and Firefox that was causing certain bands to display incorrectly on the Bolt docs site -- reported by @mikemai2awesome 

## How to test
Confirm fix working in IE 11 and Firefox by checking the band demos in PL on the docs site.
