### PR TITLE
Fix: link text and icon spacing

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/link/20-link-valign-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/link/20-link-valign-variations.twig
@@ -12,7 +12,7 @@
       display: "flex",
       valign: valign,
       icon: {
-        name: "arrow-left",
+        name: "chevron-left",
         position: "before"
       },
     } only %}

--- a/packages/components/bolt-link/src/link.scss
+++ b/packages/components/bolt-link/src/link.scss
@@ -10,6 +10,7 @@
 
 // Component variables
 $bolt-link-transition: $bolt-transition;
+$bolt-link-spacing: 'xxsmall';
 
 // Component styles
 .c-bolt-link {
@@ -18,9 +19,8 @@ $bolt-link-transition: $bolt-transition;
   display: inline;
   appearance: none; // [1]
   opacity: bolt-opacity(100);
-  margin-left: bolt-spacing(xxsmall) * -1;
+  margin-left: bolt-spacing(#{$bolt-link-spacing}) * -1;
   color: bolt-theme(link);
-  line-height: 1.45;
   text-decoration: underline;
   cursor: pointer;
   border: none; // [1]
@@ -57,7 +57,7 @@ $bolt-link-transition: $bolt-transition;
 
 .c-bolt-link__icon,
 .c-bolt-link__text {
-  @include bolt-padding-left(xsmall);
+  @include bolt-padding-left(#{$bolt-link-spacing});
 }
 
 .c-bolt-link__text {


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixes a regression with the link text and icon spacing.

## Details

Reverts back the CSS to make the link text and icon spacing stay the same as last release.

## How to test

Run the branch locally and compare the link demo page between local and 2.2 on the bolt website. Make sure the spacing did not change.
