### PR TITLE
Publishing / Deployment-related DevOps Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ jobs:
     - stage: Prep
       name: 'Build + Deploy'
       script:
+        # Clear incache file on normal Travis builds
+        - find . -name '.incache' -exec rm -rf {} +
         - yarn run setup
         - ./scripts/check-run-in-progress.js 'Deploy - now.sh'
         - yarn run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         - echo "The Now URL is $NOW_URL"
         - time curl -sSf "$NOW_URL" > /dev/null # warming up site
         - yarn run test:e2e:full
-        - sleep 10
+        - sleep 10000
         - ./scripts/report-nightwatch-results.js
       after_success:
         - ./scripts/deploy-branch-alias.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ jobs:
         - yarn run test:e2e:full
         - sleep 10
         - ./scripts/report-nightwatch-results.js
+      after_success:
+        - ./scripts/deploy-branch-alias.js
+        - ./scripts/deploy-tagged-release.js
 
     - stage: Test Live Site
       name: 'Ensure site is live'

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         - echo "The Now URL is $NOW_URL"
         - time curl -sSf "$NOW_URL" > /dev/null # warming up site
         - yarn run test:e2e:full
-        - sleep 10000
+        - sleep 60
         - ./scripts/report-nightwatch-results.js
       after_success:
         - ./scripts/deploy-branch-alias.js

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Pegasystems
+Copyright (c) 2019 Pegasystems
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,12 @@
         "next/*",
         "release/*"
       ],
+      "conventionalCommits": true,
+      "gitReset": true,
       "includeMergedTags": true,
+      "noCommitHooks": true,
+      "verifyAccess": true
+    },
     "changed": {
       "includeMergedTags": true
     }

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,10 @@
       "allowBranch": [
         "next/*",
         "release/*"
-      ]
+      ],
+      "includeMergedTags": true,
+    "changed": {
+      "includeMergedTags": true
     }
   },
   "npmClient": "yarn",

--- a/scripts/deploy-branch-alias.js
+++ b/scripts/deploy-branch-alias.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { getLatestDeploy } = require('./utils');
+const { aliasNowUrl } = require('./utils/handle-now-aliases');
+const { branchName } = require('./utils/branch-name');
+
+getLatestDeploy()
+  .then(url => {
+    aliasNowUrl(url, branchName);
+  })
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/deploy-tagged-release.js
+++ b/scripts/deploy-tagged-release.js
@@ -4,6 +4,7 @@ const gitSemverTags = require('git-semver-tags');
 const promisifyGitTags = promisify(gitSemverTags);
 const { getLatestDeploy } = require('./utils');
 const { aliasNowUrl } = require('./utils/handle-now-aliases');
+const { TRAVIS_TAG } = require('./utils/travis-vars');
 
 getLatestDeploy()
   .then(async url => {

--- a/scripts/deploy-tagged-release.js
+++ b/scripts/deploy-tagged-release.js
@@ -20,10 +20,7 @@ getLatestDeploy()
       aliasNowUrl(url, '');
       aliasNowUrl(url, 'www');
     } else {
-      console.error(
-        `Error aliasing: Travis Tag of ${TRAVIS_TAG} doesn't match the latest tag of ${latestTag}`,
-      );
-      process.exit(1);
+      // skip alias to main site
     }
   })
   .catch(error => {

--- a/scripts/deploy-tagged-release.js
+++ b/scripts/deploy-tagged-release.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const { promisify } = require('util');
+const gitSemverTags = require('git-semver-tags');
+const promisifyGitTags = promisify(gitSemverTags);
+const { getLatestDeploy } = require('./utils');
+const { aliasNowUrl } = require('./utils/handle-now-aliases');
+
+getLatestDeploy()
+  .then(async url => {
+    const tags = await promisifyGitTags();
+    const latestTag = tags[0];
+
+    if (TRAVIS_TAG) {
+      // console.log(`Latest Bolt Release Git Tag: ${latestTag}`);
+      aliasNowUrl(url, latestTag);
+    }
+
+    if (TRAVIS_TAG && TRAVIS_TAG === latestTag && !latestTag.includes('rc')) {
+      aliasNowUrl(url, '');
+      aliasNowUrl(url, 'www');
+    } else {
+      console.error(
+        `Error aliasing: Travis Tag of ${TRAVIS_TAG} doesn't match the latest tag of ${latestTag}`,
+      );
+      process.exit(1);
+    }
+  })
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -38,7 +38,7 @@ async function init() {
     });
 
     await setCheckRun({
-      name: 'Deploy - now.sh',
+      name: 'Deploy - now.sh (basic)',
       status: 'in_progress',
     });
     outputBanner('Starting deploy...');
@@ -69,7 +69,7 @@ async function init() {
 
       await setCheckRun({
         status: 'completed',
-        name: 'Deploy - now.sh',
+        name: 'Deploy - now.sh (basic)',
         conclusion: 'failure',
         output: {
           title: 'Now.sh Deploy failure',

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,160 +1,31 @@
 #!/usr/bin/env node
-const { resolve } = require('path');
-
-const { spawnSync } = require('child_process');
-const { promisify } = require('util');
 const shell = require('shelljs');
-const gitSemverTags = require('git-semver-tags');
 const { outputBanner } = require('ci-utils');
-const { setCheckRun } = require('./check-run');
 const { gitSha } = require('./utils');
-const promisifyGitTags = promisify(gitSemverTags);
+let setCheckRun = '';
 
-let {
-  NOW_TOKEN,
-  GITHUB_TOKEN,
-  // if in Travis, then it's `"true"`
+const {
   TRAVIS,
-  // for push builds, or builds not triggered by a pull request, this is the name of the branch.
-  // for builds triggered by a pull request this is the name of the branch targeted by the pull request.
-  // for builds triggered by a tag, this is the same as the name of the tag(TRAVIS_TAG).
-  TRAVIS_BRANCH,
-  // if the current job is a pull request, the name of the branch from which the PR originated
-  // if the current job is a push build, this variable is empty("").
-  TRAVIS_PULL_REQUEST_BRANCH,
-  // The pull request number if the current job is a pull request, “false” if it’s not a pull request.
   TRAVIS_PULL_REQUEST,
-  // The slug (in form: owner_name/repo_name) of the repository currently being built.
+  TRAVIS_BRANCH,
+  TRAVIS_PULL_REQUEST_BRANCH,
   TRAVIS_REPO_SLUG,
-  // If the current build is for a git tag, this variable is set to the tag’s name
   TRAVIS_TAG,
   TRAVIS_BUILD_WEB_URL,
-} = process.env;
+} = require('./utils/travis-vars');
+
+if (TRAVIS !== undefined) {
+  setCheckRun = require('./check-run');
+}
+
+let { NOW_TOKEN, GITHUB_TOKEN } = process.env;
 
 const baseNowArgs = ['--platform-version=1', '--team=boltdesignsystem'];
 
 if (NOW_TOKEN) baseNowArgs.push(`--token=${NOW_TOKEN}`);
 
-let branchName = 'detached-HEAD';
-try {
-  branchName = spawnSync('git', ['symbolic-ref', 'HEAD'], {
-    encoding: 'utf8',
-  })
-    .stdout.replace('refs/heads/', '')
-    .replace(/\//g, '-')
-    .trim();
-} catch (error) {
-  process.exit(1);
-}
-
-async function handleNowDeploy(deployOutput) {
-  console.log(deployOutput);
-  const deployedUrl = deployOutput.trim();
-  const deployedId = deployedUrl
-    .replace('https://', '')
-    .replace('boltdesignsystem-', '')
-    .replace('.now.sh', '');
-
-  console.log('Aliasing to branch/tag name...');
-  // Making sure branch name is ok to be in URL
-  const branchUrlPart = branchName
-    .replace(/\//g, '-') // `/` => `-`
-    .replace('--', '-') // `--` => `-` now.sh subdomains can't have `--` for some reason
-    .replace(/\./g, '-'); // `.` => `-`
-  const aliasedUrlSubdomain = `${encodeURIComponent(
-    branchUrlPart,
-  )}.boltdesignsystem`;
-
-  const aliasedUrl = `https://${aliasedUrlSubdomain}.com`;
-  const aliasOutput = spawnSync(
-    'now',
-    ['alias', deployedUrl, aliasedUrl, ...baseNowArgs],
-    { encoding: 'utf8' },
-  );
-  if (aliasOutput.status !== 0) {
-    console.error('Error aliasing:');
-    console.log(aliasOutput.stdout, aliasOutput.stderr);
-
-    if (setCheckRun) {
-      await setCheckRun({
-        status: 'completed',
-        name: 'Deploy - now.sh',
-        conclusion: 'failure',
-        output: {
-          title: 'Now.sh Deploy failure',
-          summary: `
-${aliasOutput.stdout}
-${aliasOutput.stderr}
-          `.trim(),
-        },
-      });
-    }
-    process.exit(1);
-  }
-  console.log(aliasOutput.stdout, aliasOutput.stderr);
-
-  if (setCheckRun) {
-    await setCheckRun({
-      status: 'completed',
-      name: 'Deploy - now.sh',
-      conclusion: 'success',
-      output: {
-        title: 'Now.sh Deploy',
-        summary: `
-  - ${deployedUrl}
-  - ${aliasedUrl}
-        `.trim(),
-      },
-    });
-  }
-
-  // if this is a tagged full release, then it should become the main site. we aliased above so we have a tagged version out as well i.e. `v1-2-3-boltdesignsystem.com`
-  if (TRAVIS_TAG && TRAVIS_TAG === latestTag && !latestTag.includes('rc')) {
-    console.log('Is tag build, aliasing to main site.');
-    const aliasOutput2 = spawnSync(
-      'now',
-      ['alias', deployedUrl, 'boltdesignsystem.com', ...baseNowArgs],
-      { encoding: 'utf8' },
-    );
-    if (aliasOutput2.status !== 0) {
-      // @todo setCheckRun
-      console.error('Error aliasing:');
-      console.log(aliasOutput2.stdout, aliasOutput2.stderr);
-      process.exit(1);
-    }
-    // @todo setCheckRun
-    console.log(aliasOutput2.stdout, aliasOutput2.stderr);
-
-    console.log('aliasing www.boltdesignsystem.com to main site too.');
-    const aliasOutput3 = spawnSync(
-      'now',
-      ['alias', deployedUrl, 'www.boltdesignsystem.com', ...baseNowArgs],
-      { encoding: 'utf8' },
-    );
-    if (aliasOutput3.status !== 0) {
-      // @todo setCheckRun
-      console.error('Error aliasing:');
-      console.log(aliasOutput3.stdout, aliasOutput3.stderr);
-      process.exit(1);
-    }
-    // @todo setCheckRun
-    console.log(aliasOutput3.stdout, aliasOutput3.stderr);
-  } else if (TRAVIS_TAG && TRAVIS_TAG !== latestTag) {
-    // @todo setCheckRun
-    console.error(
-      `Error aliasing: Travis Tag of ${TRAVIS_TAG} doesn't match the latest tag of ${latestTag}`,
-    );
-    process.exit(1);
-  } else {
-    console.log("Skipping now.sh tag alias since this isn't a tagged version.");
-  }
-}
-
 async function init() {
   try {
-    const tags = await promisifyGitTags();
-    const latestTag = tags[0];
-
     // also made in `.travis.yml` during docker tag
     // const gitSha = getGitSha(true);
     // const gitShaLong = getGitSha();
@@ -170,17 +41,7 @@ async function init() {
       gitSha,
     });
 
-    if (TRAVIS === 'true') {
-      if (TRAVIS_PULL_REQUEST === 'false') {
-        branchName = TRAVIS_BRANCH;
-      } else {
-        branchName = TRAVIS_PULL_REQUEST_BRANCH;
-      }
-    }
-
-    console.log(`Branch Name: ${branchName}`);
-
-    if (GITHUB_TOKEN) {
+    if (setCheckRun) {
       await setCheckRun({
         name: 'Deploy - now.sh',
         status: 'in_progress',
@@ -189,14 +50,32 @@ async function init() {
     }
 
     try {
-      const child = shell.exec(`now deploy --meta gitSha="${gitSha}" --env GIT_SHA=${gitSha} --build-env GIT_SHA=${gitSha} --platform-version=1 --team=boltdesignsystem --token=${NOW_TOKEN}`).stdout;
+      const deployedUrl = shell.exec(
+        `now deploy --meta gitSha="${gitSha}" --env GIT_SHA=${gitSha} --build-env GIT_SHA=${gitSha} --platform-version=1 --team=boltdesignsystem --token=${NOW_TOKEN}`,
+      ).stdout;
 
-      await handleNowDeploy(child);
+      let deployedUrlPretty = deployedUrl.trim();
+
+      if (setCheckRun) {
+        await setCheckRun({
+          status: 'completed',
+          name: 'Deploy - now.sh (basic)',
+          conclusion: 'success',
+          output: {
+            title: 'Now.sh Basic Deploy',
+            summary: `
+      - ${deployedUrlPretty}
+            `.trim(),
+          },
+        });
+      }
+
+      // await handleNowDeploy(child);
     } catch (error) {
       console.error('Error deploying:');
       console.log(error.stdout, error.stderr);
 
-      if (GITHUB_TOKEN) {
+      if (setCheckRun) {
         await setCheckRun({
           status: 'completed',
           name: 'Deploy - now.sh',

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -2,7 +2,7 @@
 const shell = require('shelljs');
 const { outputBanner } = require('ci-utils');
 const { gitSha } = require('./utils');
-const setCheckRun = require('./check-run');
+const { setCheckRun } = require('./check-run');
 
 const {
   TRAVIS,
@@ -37,13 +37,11 @@ async function init() {
       gitSha,
     });
 
-    if (setCheckRun) {
-      await setCheckRun({
-        name: 'Deploy - now.sh',
-        status: 'in_progress',
-      });
-      outputBanner('Starting deploy...');
-    }
+    await setCheckRun({
+      name: 'Deploy - now.sh',
+      status: 'in_progress',
+    });
+    outputBanner('Starting deploy...');
 
     try {
       const deployedUrl = shell.exec(
@@ -52,39 +50,35 @@ async function init() {
 
       let deployedUrlPretty = deployedUrl.trim();
 
-      if (setCheckRun) {
-        await setCheckRun({
-          status: 'completed',
-          name: 'Deploy - now.sh (basic)',
-          conclusion: 'success',
-          output: {
-            title: 'Now.sh Basic Deploy',
-            summary: `
-      - ${deployedUrlPretty}
-            `.trim(),
-          },
-        });
-      }
+      await setCheckRun({
+        status: 'completed',
+        name: 'Deploy - now.sh (basic)',
+        conclusion: 'success',
+        output: {
+          title: 'Now.sh Basic Deploy',
+          summary: `
+    - ${deployedUrlPretty}
+          `.trim(),
+        },
+      });
 
       // await handleNowDeploy(child);
     } catch (error) {
       console.error('Error deploying:');
       console.log(error.stdout, error.stderr);
 
-      if (setCheckRun) {
-        await setCheckRun({
-          status: 'completed',
-          name: 'Deploy - now.sh',
-          conclusion: 'failure',
-          output: {
-            title: 'Now.sh Deploy failure',
-            summary: `
-  ${error.stdout}
-  ${error.stderr}
-            `.trim(),
-          },
-        });
-      }
+      await setCheckRun({
+        status: 'completed',
+        name: 'Deploy - now.sh',
+        conclusion: 'failure',
+        output: {
+          title: 'Now.sh Deploy failure',
+          summary: `
+${error.stdout}
+${error.stderr}
+          `.trim(),
+        },
+      });
       process.exit(1);
     }
   } catch (error) {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -2,7 +2,7 @@
 const shell = require('shelljs');
 const { outputBanner } = require('ci-utils');
 const { gitSha } = require('./utils');
-let setCheckRun = '';
+let setCheckRun;
 
 const {
   TRAVIS,
@@ -14,7 +14,7 @@ const {
   TRAVIS_BUILD_WEB_URL,
 } = require('./utils/travis-vars');
 
-if (TRAVIS !== undefined) {
+if (TRAVIS) {
   setCheckRun = require('./check-run');
 }
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -2,7 +2,7 @@
 const shell = require('shelljs');
 const { outputBanner } = require('ci-utils');
 const { gitSha } = require('./utils');
-let setCheckRun;
+const setCheckRun = require('./check-run');
 
 const {
   TRAVIS,
@@ -13,10 +13,6 @@ const {
   TRAVIS_TAG,
   TRAVIS_BUILD_WEB_URL,
 } = require('./utils/travis-vars');
-
-if (TRAVIS) {
-  setCheckRun = require('./check-run');
-}
 
 let { NOW_TOKEN, GITHUB_TOKEN } = process.env;
 

--- a/scripts/release/after-release.sh
+++ b/scripts/release/after-release.sh
@@ -8,7 +8,11 @@ CURRENT_VERSION=`git describe --tags --abbrev=0`
 git push origin :refs/tags/$CURRENT_VERSION
 node scripts/release/update-php-package-versions.js
 
-git add .
+find . -name '.incache' -exec rm -rf {} + # clear .incache file when doing a release
+npm run setup
+npm run build # regenerate the whole site so dropdown + cached result is always up to date
+git add . # add to version control
+
 git commit --amend --no-edit
 git tag -fa $CURRENT_VERSION -m $CURRENT_VERSION
 git push --no-verify

--- a/scripts/release/rc-release.sh
+++ b/scripts/release/rc-release.sh
@@ -18,7 +18,7 @@ elif [[ $CURRENT_BRANCH != 'next/2.x' && $CURRENT_BRANCH != 'next/1.x' ]]; then
 fi
 
 ./scripts/release/before-release.sh #verify everything is good to go before publishing
-npx lerna publish $BUMP --npm-tag next --preid rc --no-commit-hooks --no-git-reset --verify-access --conventional-commits
+npx lerna publish $BUMP --npm-tag next --preid rc
 ./scripts/release/after-release.sh #post-release work
 
 

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -18,7 +18,7 @@ elif [[ $CURRENT_BRANCH != 'release/2.x' && $CURRENT_BRANCH != 'release/1.x' ]];
 fi
 
 ./scripts/release/before-release.sh
-npx lerna publish $BUMP --no-commit-hooks --no-git-reset --verify-access --conventional-commits
+npx lerna publish $BUMP
 ./scripts/release/after-release.sh
 
 

--- a/scripts/report-nightwatch-results.js
+++ b/scripts/report-nightwatch-results.js
@@ -231,8 +231,14 @@ async function collectSauceLabResults(build) {
           }
         });
 
+        const filteredScreenshots = await Promise.all(
+          assetsNames.screenshots.filter(
+            screenshot => !screenshot.includes('0000screenshot.png'),
+          ),
+        );
+
         const screenshots = await Promise.all(
-          assetsNames.screenshots.map(screenshot =>
+          filteredScreenshots.map(screenshot =>
             transferFileFromSauceToNow(screenshot, buildJob.id),
           ),
         );

--- a/scripts/report-nightwatch-results.js
+++ b/scripts/report-nightwatch-results.js
@@ -315,7 +315,7 @@ async function setGithubAppSauceResults(sauceResults) {
               os,
             } = test;
             const { screenshots, finalScreenshot } = assets;
-            
+
             // this adds to the full Check Run grid of images
             allImages.push(
               ...screenshots.map((screenshot, i) => {
@@ -323,13 +323,17 @@ async function setGithubAppSauceResults(sauceResults) {
                 return {
                   image_url: screenshot,
                   alt: name,
-                  caption: `${i}/${screenshots.length}: ${testName} - ${browser} ${browserVer} ${os}`,
+                  caption: `${i}/${
+                    screenshots.length
+                  }: ${testName} - ${browser} ${browserVer} ${os}`,
                 };
               }),
             );
-            
+
             return `
-## ${passed ? ':+1:' : ':-1:'} ${browser} ${browserVer} ${os} ([details](${test.sauceLabsPage}))
+## ${passed ? ':+1:' : ':-1:'} ${browser} ${browserVer} ${os} ([details](${
+              test.sauceLabsPage
+            }))
 
 <details>
   

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -113,10 +113,24 @@ function getLatestDeploy() {
         const resultsWithGitSha = results.deployments.filter(
           d => d.meta.gitSha === gitSha,
         );
+
+        const fallbackResultsWithGitSha = results.deployments.filter(d =>
+          gitSha.includes(d.meta.gitSha),
+        );
+
         const result = resultsWithGitSha.find(d => d.url);
+
+        // if an exact match isn't found, check partial matches and sort by most recent
+        fallbackResultsWithGitSha.sort(function(a, b) {
+          // Turn created unix time strings into dates, and then sort by what happened most recently
+          return new Date(a.created) - new Date(b.created);
+        });
+        const fallbackResults = fallbackResultsWithGitSha.find(d => d.url);
 
         if (result) {
           resolve(`https://${result.url}`);
+        } else if (fallbackResults) {
+          resolve(`https://${fallbackResults.url}`);
         } else {
           reject(new Error('No deployments found'));
         }

--- a/scripts/utils/branch-name.js
+++ b/scripts/utils/branch-name.js
@@ -1,0 +1,34 @@
+const { spawnSync } = require('child_process');
+const {
+  TRAVIS,
+  TRAVIS_PULL_REQUEST,
+  TRAVIS_BRANCH,
+  TRAVIS_PULL_REQUEST_BRANCH,
+} = require('./travis-vars');
+
+
+let branchName = 'detached-HEAD';
+try {
+  branchName = spawnSync('git', ['symbolic-ref', 'HEAD'], {
+    encoding: 'utf8',
+  })
+    .stdout.replace('refs/heads/', '')
+    .replace(/\//g, '-')
+    .trim();
+} catch (error) {
+  process.exit(1);
+}
+
+if (TRAVIS === 'true') {
+  if (TRAVIS_PULL_REQUEST === 'false') {
+    branchName = TRAVIS_BRANCH;
+  } else {
+    branchName = TRAVIS_PULL_REQUEST_BRANCH;
+  }
+}
+
+console.log(`Branch Name: ${branchName}`);
+
+module.exports = {
+  branchName,
+};

--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -1,8 +1,8 @@
 const shell = require('shelljs');
 const { TRAVIS } = require('./travis-vars');
-let setCheckRun = '';
+let setCheckRun;
 
-if (TRAVIS !== undefined) {
+if (TRAVIS) {
   setCheckRun = require('../check-run');
 }
 

--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -29,7 +29,12 @@ async function aliasNowUrl(originalUrl, prefix) {
   }
 
   console.log(`Attempting to alias ${originalUrl} to ${aliasedUrl}...`);
-
+  
+  await setCheckRun({
+    status: 'in_progress',
+    name: 'Deploy - now.sh (alias)',
+  });
+  
   const aliasOutput = shell.exec(
     `now alias ${deployedUrl} ${aliasedUrl} --platform-version=1 --team=boltdesignsystem --token=${NOW_TOKEN}`,
   );
@@ -40,7 +45,7 @@ async function aliasNowUrl(originalUrl, prefix) {
 
     await setCheckRun({
       status: 'completed',
-      name: 'Deploy - now.sh',
+      name: 'Deploy - now.sh (alias)',
       conclusion: 'failure',
       output: {
         title: 'Now.sh Deploy failure',
@@ -59,7 +64,7 @@ ${aliasOutput.stderr}
     // console.log(aliasedUrl);
     await setCheckRun({
       status: 'completed',
-      name: 'Deploy - now.sh',
+      name: 'Deploy - now.sh (alias)',
       conclusion: 'success',
       output: {
         title: 'Now.sh Deploy',

--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -1,0 +1,85 @@
+const shell = require('shelljs');
+const { TRAVIS } = require('./travis-vars');
+let setCheckRun = '';
+
+if (TRAVIS !== undefined) {
+  setCheckRun = require('../check-run');
+}
+
+let { NOW_TOKEN } = process.env;
+const baseNowArgs = ['--platform-version=1', '--team=boltdesignsystem'];
+
+if (NOW_TOKEN) baseNowArgs.push(`--token=${NOW_TOKEN}`);
+
+async function aliasNowUrl(originalUrl, prefix) {
+  console.log(
+    'Creating now.sh alias off of the ' + originalUrl + ' deployment URL.',
+  );
+  const deployedUrl = originalUrl.trim();
+
+  let aliasedUrl = `https://boltdesignsystem.com`;
+
+  // passing an empty prefix will deploy to the main boltdesignsystem.com site
+  if (prefix) {
+    const normalizedUrlPrefix = prefix
+      .replace(/\//g, '-') // `/` => `-`
+      .replace('--', '-') // `--` => `-` now.sh subdomains can't have `--` for some reason
+      .replace(/\./g, '-'); // `.` => `-`
+    const normalizedUrlFull = `${encodeURIComponent(
+      normalizedUrlPrefix,
+    )}.boltdesignsystem`;
+
+    aliasedUrl = `https://${normalizedUrlFull}.com`;
+  }
+
+  console.log(`Attempting to alias ${originalUrl} to ${aliasedUrl}...`);
+
+  const aliasOutput = shell.exec(
+    `now alias ${deployedUrl} ${aliasedUrl} --platform-version=1 --team=boltdesignsystem --token=${NOW_TOKEN}`,
+  );
+
+  if (aliasOutput.code !== 0) {
+    console.log('Error aliasing:');
+    console.log(aliasOutput.stdout, aliasOutput.stderr);
+
+    if (setCheckRun) {
+      await setCheckRun({
+        status: 'completed',
+        name: 'Deploy - now.sh',
+        conclusion: 'failure',
+        output: {
+          title: 'Now.sh Deploy failure',
+          summary: `
+${aliasOutput.stdout}
+${aliasOutput.stderr}
+          `.trim(),
+        },
+      });
+    }
+
+    process.exit(1);
+  } else {
+    // console.log('Success Aliasing!');
+    console.log(aliasOutput.stdout);
+    // console.log(deployedUrl);
+    // console.log(aliasedUrl);
+    if (setCheckRun) {
+      await setCheckRun({
+        status: 'completed',
+        name: 'Deploy - now.sh',
+        conclusion: 'success',
+        output: {
+          title: 'Now.sh Deploy',
+          summary: `
+    - ${deployedUrl}
+    - ${aliasedUrl}
+          `.trim(),
+        },
+      });
+    }
+  }
+}
+
+module.exports = {
+  aliasNowUrl,
+};

--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const shell = require('shelljs');
 const { TRAVIS } = require('./travis-vars');
 const { setCheckRun } = require('../check-run');

--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -37,7 +37,7 @@ async function aliasNowUrl(originalUrl, prefix) {
   });
   
   const aliasOutput = shell.exec(
-    `now alias ${deployedUrl} ${aliasedUrl} --platform-version=1 --team=boltdesignsystem --token=${NOW_TOKEN}`,
+    `npx now alias ${deployedUrl} ${aliasedUrl} --platform-version=1 --team=boltdesignsystem --token=${NOW_TOKEN}`,
   );
 
   if (aliasOutput.code !== 0) {

--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -1,10 +1,6 @@
 const shell = require('shelljs');
 const { TRAVIS } = require('./travis-vars');
-let setCheckRun;
-
-if (TRAVIS) {
-  setCheckRun = require('../check-run');
-}
+const setCheckRun = require('../check-run');
 
 let { NOW_TOKEN } = process.env;
 const baseNowArgs = ['--platform-version=1', '--team=boltdesignsystem'];
@@ -42,20 +38,18 @@ async function aliasNowUrl(originalUrl, prefix) {
     console.log('Error aliasing:');
     console.log(aliasOutput.stdout, aliasOutput.stderr);
 
-    if (setCheckRun) {
-      await setCheckRun({
-        status: 'completed',
-        name: 'Deploy - now.sh',
-        conclusion: 'failure',
-        output: {
-          title: 'Now.sh Deploy failure',
-          summary: `
+    await setCheckRun({
+      status: 'completed',
+      name: 'Deploy - now.sh',
+      conclusion: 'failure',
+      output: {
+        title: 'Now.sh Deploy failure',
+        summary: `
 ${aliasOutput.stdout}
 ${aliasOutput.stderr}
-          `.trim(),
-        },
-      });
-    }
+        `.trim(),
+      },
+    });
 
     process.exit(1);
   } else {
@@ -63,20 +57,18 @@ ${aliasOutput.stderr}
     console.log(aliasOutput.stdout);
     // console.log(deployedUrl);
     // console.log(aliasedUrl);
-    if (setCheckRun) {
-      await setCheckRun({
-        status: 'completed',
-        name: 'Deploy - now.sh',
-        conclusion: 'success',
-        output: {
-          title: 'Now.sh Deploy',
-          summary: `
-    - ${deployedUrl}
-    - ${aliasedUrl}
-          `.trim(),
-        },
-      });
-    }
+    await setCheckRun({
+      status: 'completed',
+      name: 'Deploy - now.sh',
+      conclusion: 'success',
+      output: {
+        title: 'Now.sh Deploy',
+        summary: `
+  - ${deployedUrl}
+  - ${aliasedUrl}
+        `.trim(),
+      },
+    });
   }
 }
 

--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -1,6 +1,6 @@
 const shell = require('shelljs');
 const { TRAVIS } = require('./travis-vars');
-const setCheckRun = require('../check-run');
+const { setCheckRun } = require('../check-run');
 
 let { NOW_TOKEN } = process.env;
 const baseNowArgs = ['--platform-version=1', '--team=boltdesignsystem'];

--- a/scripts/utils/travis-vars.js
+++ b/scripts/utils/travis-vars.js
@@ -1,0 +1,28 @@
+const {
+  // if in Travis, then it's `"true"`
+  TRAVIS,
+  // for push builds, or builds not triggered by a pull request, this is the name of the branch.
+  // for builds triggered by a pull request this is the name of the branch targeted by the pull request.
+  // for builds triggered by a tag, this is the same as the name of the tag(TRAVIS_TAG).
+  TRAVIS_BRANCH,
+  // if the current job is a pull request, the name of the branch from which the PR originated
+  // if the current job is a push build, this variable is empty("").
+  TRAVIS_PULL_REQUEST_BRANCH,
+  // The pull request number if the current job is a pull request, “false” if it’s not a pull request.
+  TRAVIS_PULL_REQUEST,
+  // The slug (in form: owner_name/repo_name) of the repository currently being built.
+  TRAVIS_REPO_SLUG,
+  // If the current build is for a git tag, this variable is set to the tag’s name
+  TRAVIS_TAG,
+  TRAVIS_BUILD_WEB_URL,
+} = process.env;
+
+module.exports = {
+  TRAVIS,
+  TRAVIS_PULL_REQUEST,
+  TRAVIS_BRANCH,
+  TRAVIS_PULL_REQUEST_BRANCH,
+  TRAVIS_REPO_SLUG,
+  TRAVIS_TAG,
+  TRAVIS_BUILD_WEB_URL,
+};


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1024

## Summary
Implements several housekeeping updates, improvements and fixes to our DevOps CI / CD process to continue to improve how smooth we ship Bolt releases. There's still more work to be done but this should at least help tackle some of the more pressing issues. 

## Details
- Adds logic to auto-regenerate the Bolt version data used to populate the version select / dropdown menu on the boltdesignsystem.com site
  - Also adds logic to the after-publish script to regenerate and include this updated data after a release
- Updates our post-publish logic + root lerna.json config to try and fix the tagged version mis-match issues. This issue has been causing Lerna to think every single package in Bolt has been changed since the previous release (vs only a handful at times)
- Splits apart and simplifies our deployment logic to handle the initial now.sh deployment separately from the now.sh aliasing. This should help avoid some major problems that can occur if a Travis test fails AFTER a particular build has been pushed live to a specific branch or git tag alias.
- Updates the Github Checks API logic to try and remove the empty browser screenshots (the very first screenshot in the series taken)
- Updates the logic that handles grabbing the latest now.sh deployment URL (based on codebase's Git Hash) to handle situations where the results returned don't always  match up 1:1 with the local git SHA (partial match) + sorting the results to be in the correct order

## How to test
?
Publish a few extra releases? This is super tricky to fully test without publishing an actual release or release candidate in order to make sure we didn't miss anything.