### PR TITLE
fix: remove extra status call to Github Checks API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ jobs:
         # Clear incache file on normal Travis builds
         - find . -name '.incache' -exec rm -rf {} +
         - yarn run setup
-        - ./scripts/check-run-in-progress.js 'Deploy - now.sh'
         - yarn run build
         - yarn run deploy
         # need to reset git repo before `update-read-only-git-repos.sh`


### PR DESCRIPTION
## Jira
N/A

## Summary
Removes the extra Github Checks API call that’s causing one of our status checks to never fully finish running. 

## How to test
- Confirm all Github Checks all finish running successfully.
