### PR TITLE
WIP: Testing Automatic Fetch Retries For Nightwatch Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "semantic-release": "^15.13.3"
   },
   "dependencies": {
+    "@zeit/fetch-retry": "^3.0.0",
     "ci-utils": "^0.5.0",
     "express": "^4.16.4",
     "jest-serializer-html": "^6.0.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
     "nightwatch": "nightwatch --config ../nightwatch.js --env chrome,ie11"
   },
   "dependencies": {
+    "@zeit/fetch-retry": "^3.0.0",
     "lodash": "^4.17.11",
     "querystring": "^0.2.0",
     "execa": "^1.0.0",

--- a/scripts/report-nightwatch-results.js
+++ b/scripts/report-nightwatch-results.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const sleep = require('sleep-promise');
 const crypto = require('crypto');
-const fetch = require('node-fetch');
+const fetch = require('@zeit/fetch-retry')(require('node-fetch'));
 const { groupBy } = require('lodash');
 const { setCheckRun } = require('../scripts/check-run');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,6 +2058,14 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
+"@zeit/fetch-retry@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@zeit/fetch-retry/-/fetch-retry-3.0.0.tgz#c3efab8f97d928b2f1a2cff36be9739713083adb"
+  integrity sha512-al7nNnE3kkvwqaFFUloXf/0ABKCZcsf1lldlrwF1wGS+39NZK9Yo27sYaIcBAfoyIFJGF3jItLsvD32O1a8ojQ==
+  dependencies:
+    async-retry "^1.1.3"
+    debug "^3.1.0"
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -2586,6 +2594,13 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
+
+async-retry@^1.1.3:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
+  integrity sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==
+  dependencies:
+    retry "0.12.0"
 
 async@0.2.6:
   version "0.2.6"
@@ -14983,15 +14998,15 @@ ret@~0.1.10:
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry@0.12.0, retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
 retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
-
-retry@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
-  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 rework-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Re-testing Nightwatch test reporting reliability after adding a wrapper around the node-fetch library to auto-retry failed requests that return a 500-series error.

Potential solution to infrequent / sometimes flaky serverless reliability.