### PR TITLE
Fix IE disappearing content bug

### DIFF
--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -24,7 +24,7 @@
 
     {% if content %}
       {% include "@bolt-components-headline/text.twig" with {
-        text: content | striptags('<a>'),
+        text: content,
         tag: "p"
       } only %}
     {% endif %}


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/BDS-1030

## Summary

In IE, content is disappearing from the first band on [this page](https://v2-3-0.boltdesignsystem.com/pattern-lab/patterns/04-pages-00-full-page-theming-01-full-page-theming--xlight/04-pages-00-full-page-theming-01-full-page-theming--xlight.html). Removing the 'striptags' filter from the teaser component fixes the problem.

## Details

Using the 'striptags' filter on `bolt-teaser` text, causes twig to render *only* the anchor tags, sans `bolt-link` custom element, like so:
```
<a href="google.com" is="shadow-root" class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center">Pega Customer Service</a>
```
In IE only, this results in everything inside the band getting replaced with *just* the link when web components boot up.

A simple fix for this is to remove the 'striptags' filter from the `bolt-teaser` component. I figure we might want to allow a link in this content. Are there any use cases you can think of that make this 'striptags' filter necessary?

## How to test
- View the issue on 2.3 (in IE): [view page](https://v2-3-0.boltdesignsystem.com/pattern-lab/patterns/04-pages-00-full-page-theming-01-full-page-theming--xlight/04-pages-00-full-page-theming-01-full-page-theming--xlight.html)
- Verify the fix (in IE): [view page](https://fix-vr-content-disappearing.boltdesignsystem.com/pattern-lab/patterns/04-pages-00-full-page-theming-01-full-page-theming--xlight/04-pages-00-full-page-theming-01-full-page-theming--xlight.html)
- Is it safe to remove the 'striptags' filter from the teaser component?