### PR TITLE
Band Component Refactor (Band Demo Cleanup from #1010)

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/00-overview.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/00-overview.twig
@@ -1,4 +1,4 @@
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "none",
   theme: "light",
   fullBleed: true,

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/band/00-band-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/band/00-band-docs.twig
@@ -1,6 +1,6 @@
 {% set usage %}{% verbatim %}
 {% include "@bolt-components-band/band.twig" with {
-  content: "Example Band Content",
+  content: "This is a band.",
 } only %}
 {% endverbatim %}{% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/band/05-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/band/05-band.twig
@@ -1,3 +1,3 @@
 {% include "@bolt-components-band/band.twig" with {
-  content: "Example Band Content",
+  content: "This is a band.",
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/band/40-band-video-background-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/band/40-band-video-background-variation.twig
@@ -1,4 +1,4 @@
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   theme: "dark",
   size: "medium",
   background: {

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/breadcrumb/15-breadcrumb-band-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/breadcrumb/15-breadcrumb-band-variation.twig
@@ -20,7 +20,7 @@
     ]
   } only %}
 {% endset %}
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "size": "xsmall",
   "theme": "light",
   "content": band_content
@@ -36,7 +36,7 @@
     "text": "The above example shows a xsmall band containing the breadcrumbs."
   } only %}
 {% endset %}
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "theme": "none",
   "content": band_content
 } only %}
@@ -68,12 +68,12 @@
 {% endset %}
 
 {% set stacked_bands %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "size": "small",
     "theme": "none",
     "content": breadcrumb_band_content
   } only %}
-  {% include "@bolt/band--feature.twig" with {
+  {% include "@bolt-components-band/band--feature.twig" with {
     "size": "large",
     "theme": "none",
     "primaryTeaser": {
@@ -112,7 +112,7 @@
   } only %}
 {% endset %}
 
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "size": "none",
   "theme": "dark",
   "content": stacked_bands
@@ -135,7 +135,7 @@
     "text": "There is an outer band containing the breadcrumb band and the featured band, background and theme should be set on that outer band."
   } only %}
 {% endset %}
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "theme": "none",
   "content": band_content
 } only %}
@@ -167,12 +167,12 @@
 {% endset %}
 
 {% set stacked_bands %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "size": "small",
     "theme": "none",
     "content": breadcrumb_band_content
   } only %}
-  {% include "@bolt/band--feature.twig" with {
+  {% include "@bolt-components-band/band--feature.twig" with {
     "size": "large",
     "theme": "none",
     "primaryTeaser": {
@@ -211,7 +211,7 @@
   } only %}
 {% endset %}
 
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "teaserPosition": "left",
   "teaserWidth": "2/3",
   "size": "none",
@@ -248,7 +248,7 @@
     "text": "A background image is set on the outer band and the theme is set to dark."
   } only %}
 {% endset %}
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "theme": "none",
   "content": band_content
 } only %}
@@ -280,12 +280,12 @@
 {% endset %}
 
 {% set stacked_bands %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "size": "xsmall",
     "theme": "dark",
     "content": breadcrumb_band_content
   } only %}
-  {% include "@bolt/band--feature.twig" with {
+  {% include "@bolt-components-band/band--feature.twig" with {
     "size": "large",
     "theme": "xdark",
     "primaryTeaser": {
@@ -324,7 +324,7 @@
   } only %}
 {% endset %}
 
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "size": "none",
   "theme": "none",
   "content": stacked_bands
@@ -347,7 +347,7 @@
     "text": "No background or theme is set on the outer band in this case because it's not neccessary."
   } only %}
 {% endset %}
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "theme": "none",
   "content": band_content
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/45-video-with-inline-script-and-external-controls-as-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/45-video-with-inline-script-and-external-controls-as-background.twig
@@ -1,4 +1,4 @@
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   theme: "dark",
   size: "medium",
   background: {

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/65-video-with-external-title.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/65-video-with-external-title.twig
@@ -32,7 +32,7 @@
   </figure>
 {% endset %}
 
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "size": "medium",
   "theme": "light",
   "content": content,
@@ -64,7 +64,7 @@
   } only %}
 {% endset %}
 
-{% include "@bolt/band.twig" with {
+{% include "@bolt-components-band/band.twig" with {
   "size": "medium",
   "theme": "dark",
   "content": content

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/00-full-page-theming/_full-page-theming.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/00-full-page-theming/_full-page-theming.twig
@@ -65,7 +65,7 @@
 
 
 
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
     size: "medium",
@@ -115,7 +115,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: qaTheme,
   fullBleed: true
@@ -154,7 +154,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   theme: qaTheme,
   size: "medium",
   background: {
@@ -279,7 +279,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: qaTheme,
   fullBleed: true
@@ -406,7 +406,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: qaTheme,
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/05-d8-homepage/00-d8-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/05-d8-homepage/00-d8-homepage.twig
@@ -69,7 +69,7 @@
 
 
 
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
     size: "medium",
@@ -110,7 +110,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true
@@ -149,7 +149,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "light",
   "size": "medium",
   "contentItems": [
@@ -255,7 +255,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xdark",
   fullBleed: true
@@ -303,7 +303,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "dark",
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/05-d8-homepage/05-d8-homepage-japanese.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/05-d8-homepage/05-d8-homepage-japanese.twig
@@ -598,7 +598,7 @@
 
 
 
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     size: "large",
     theme: "dark",
     teaserPosition: "left",
@@ -651,7 +651,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true
@@ -702,7 +702,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "xlight",
   "size": "large",
   "contentItems": [
@@ -798,7 +798,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "dark",
   fullBleed: true
@@ -837,7 +837,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "large",
   theme: "light",
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3-extra-videos.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3-extra-videos.twig
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
     size: "large",
@@ -57,7 +57,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "dark",
   fullBleed: true
@@ -192,7 +192,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -248,7 +248,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -301,7 +301,7 @@
   {% endblock %}
 {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xdark",
     fullBleed: true
@@ -341,7 +341,7 @@
     {% endblock %}
   {% endembed %}
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -427,7 +427,7 @@
   {% endblock %}
 {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xdark",
     fullBleed: true
@@ -467,7 +467,7 @@
     {% endblock %}
   {% endembed %}
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -517,7 +517,7 @@
 {% endembed %}
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true
@@ -559,7 +559,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "xlight",
   "size": "medium",
   "contentItems": [
@@ -692,7 +692,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xdark",
   fullBleed: true,
@@ -758,7 +758,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3.twig
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
     size: "large",
@@ -56,7 +56,7 @@
   {% endembed %}
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "dark",
   fullBleed: true
@@ -193,7 +193,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -249,7 +249,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -302,7 +302,7 @@
   {% endblock %}
 {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xdark",
     fullBleed: true
@@ -342,7 +342,7 @@
     {% endblock %}
   {% endembed %}
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -428,7 +428,7 @@
   {% endblock %}
 {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xdark",
     fullBleed: true
@@ -468,7 +468,7 @@
     {% endblock %}
   {% endembed %}
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -518,7 +518,7 @@
 {% endembed %}
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true
@@ -560,7 +560,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "xlight",
   "size": "medium",
   "contentItems": [
@@ -693,7 +693,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xdark",
   fullBleed: true,
@@ -759,7 +759,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-landing.twig
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
     size: "large",
@@ -63,7 +63,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "dark",
   fullBleed: true
@@ -198,7 +198,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -244,7 +244,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "light",
   "size": "medium",
   "contentItems": [
@@ -381,7 +381,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xdark",
   fullBleed: true,
@@ -450,7 +450,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t2.twig
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
     size: "large",
@@ -58,7 +58,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "dark",
   fullBleed: true
@@ -185,7 +185,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -242,7 +242,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -298,7 +298,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -354,7 +354,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -406,7 +406,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "xlight",
   "size": "medium",
   "contentItems": [
@@ -543,7 +543,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xdark",
   fullBleed: true,
@@ -612,7 +612,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t4.twig
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% embed "@bolt/band--feature.twig" with {
+  {% embed "@bolt-components-band/band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
     size: "large",
@@ -57,7 +57,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "dark",
   fullBleed: true
@@ -192,7 +192,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -249,7 +249,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -303,7 +303,7 @@
   {% endblock %}
 {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xdark",
     fullBleed: true
@@ -343,7 +343,7 @@
     {% endblock %}
   {% endembed %}
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -433,7 +433,7 @@
   {% endblock %}
 {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xdark",
     fullBleed: true
@@ -473,7 +473,7 @@
     {% endblock %}
   {% endembed %}
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "light",
   fullBleed: true
@@ -524,7 +524,7 @@
 {% endembed %}
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true
@@ -566,7 +566,7 @@
 
 
 
-{% embed "@bolt/band--collection.twig" with {
+{% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "xlight",
   "size": "medium",
   "contentItems": [
@@ -699,7 +699,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xdark",
   fullBleed: true,
@@ -765,7 +765,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   size: "small",
   theme: "xdark",
   fullBleed: true

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/15-d8-resource-details-pages/00-resource-details-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/15-d8-resource-details-pages/00-resource-details-page.twig
@@ -1,4 +1,4 @@
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   theme: "dark",
   size: "medium"
 } %}
@@ -68,7 +68,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   theme: "xlight",
   size: "medium"
 } %}
@@ -135,7 +135,7 @@
 
 
 
-{% embed "@bolt/band.twig" with {
+{% embed "@bolt-components-band/band.twig" with {
   theme: "light"
 } %}
   {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/20-d8-press-and-media/00-d8-news-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/20-d8-press-and-media/00-d8-news-landing.twig
@@ -313,7 +313,7 @@
   {% endembed %}
 
   {# Featured Resources #}
-  {% embed "@bolt/band--collection.twig" with {
+  {% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "dark",
   "size": "medium",
   "contentItems": [

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/20-d8-press-and-media/05-d8-browse-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/20-d8-press-and-media/05-d8-browse-page.twig
@@ -39,7 +39,7 @@
     {% endblock %}
   {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "large",
     theme: "dark",
     fullBleed: true,
@@ -174,7 +174,7 @@
   </div>
 
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "medium",
     theme: "light",
     fullBleed: true,

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/25-d8-agenda-manager/00-d8-agenda-manager-details.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/25-d8-agenda-manager/00-d8-agenda-manager-details.twig
@@ -1,7 +1,7 @@
 {% extends "@pl/_default-page-template.twig" %}
 
 {% block global_header %}
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "dark",
     attributes: {
@@ -16,7 +16,7 @@
 
 {% block main_content %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xlight"
   } %}
@@ -135,7 +135,7 @@
     {% endblock %}
   {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xlight"
   } only %}
@@ -166,7 +166,7 @@
   {% endembed %}
 
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xlight"
   } only %}
@@ -269,7 +269,7 @@
     {% endblock %}
   {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xlight",
     attributes: {
@@ -332,7 +332,7 @@
     {% endblock %}
   {% endembed %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     theme: "xdark",
     size: "medium"
   } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/30-d8-partners/00-d8-partners-search.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/30-d8-partners/00-d8-partners-search.twig
@@ -47,7 +47,7 @@
   } only %}{% endembed %}
 
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "light",
     fullBleed: true,

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/35-d8-events/00-event-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/35-d8-events/00-event-landing.twig
@@ -6,7 +6,7 @@
 
 {% block main_content %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "medium",
     theme: "xdark",
     fullBleed: true,
@@ -29,7 +29,7 @@
 
     {% block band_content %}
 
-      {% embed "@bolt/band.twig" with {
+      {% embed "@bolt-components-band/band.twig" with {
         size: "medium",
         theme: "none"
       } only %}
@@ -53,7 +53,7 @@
         {% endblock %}
       {% endembed %}
 
-      {% embed "@bolt/band.twig" with {
+      {% embed "@bolt-components-band/band.twig" with {
         size: "medium",
         theme: "none"
       } only %}
@@ -216,7 +216,7 @@
   {% endembed %}
 
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     theme: "xlight",
     size: "medium"
   } %}
@@ -345,7 +345,7 @@
   {% endembed %}
 
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "large",
     theme: "xdark"
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/35-d8-events/05-event-detail.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/35-d8-events/05-event-detail.twig
@@ -6,7 +6,7 @@
 
 {% block main_content %}
 
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "medium",
     theme: "dark"
   } only %}
@@ -82,7 +82,7 @@
     {% endblock %}
   {% endembed %}
 
- {% embed "@bolt/band.twig" with {
+ {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xlight"
   } only %}
@@ -268,7 +268,7 @@
   {% endembed %}
 
 {# Start Location Details section #}
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -334,7 +334,7 @@
 {# End Location Details section #}
 
 {# Start Speakers section #}
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
   size: "medium",
   theme: "xlight",
   fullBleed: true
@@ -497,7 +497,7 @@
 {# End Speakers section #}
 
 {# Start 2017 Highlights section #}
-  {% embed "@bolt/band--collection.twig" with {
+  {% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "xlight",
   "size": "large",
   "contentItems": [
@@ -599,7 +599,7 @@
 {# End 2017 Highlights section#}
 
 {# Start Events Sponsors section#}
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
   size: "large",
   theme: "light",
   fullBleed: true
@@ -645,7 +645,7 @@
 
 
 {# Start Related Resources section #}
-  {% embed "@bolt/band--collection.twig" with {
+  {% embed "@bolt-components-band/band--collection.twig" with {
   "theme": "dark",
   "size": "large",
   "contentItems": [

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/35-d8-events/10-event-form-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/35-d8-events/10-event-form-example.twig
@@ -1,4 +1,4 @@
- {% embed "@bolt/band.twig" with {
+ {% embed "@bolt-components-band/band.twig" with {
     size: "small",
     theme: "xlight"
   } only %}
@@ -37,12 +37,12 @@
               }
             } only %}
           </p>
-          
+
           {% include "@pl/_event-register-form.twig" %}
 
         {% endblock %}
 
       {% endembed %}
-       
+
     {% endblock %}
   {% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/40-d8-content-hub/00-sticky-navbar.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/40-d8-content-hub/00-sticky-navbar.twig
@@ -7,7 +7,7 @@
 {% block main_content %}
 
   {# hero band #}
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "large",
     theme: "dark",
     fullBleed: true,
@@ -30,7 +30,7 @@
 
     {% block band_content  %}
     {% grid "o-bolt-grid--flex o-bolt-grid--large o-bolt-grid--middle o-bolt-grid--matrix" %}
-      {% cell 'u-bolt-width-1/1 u-bolt-width-2/3@medium' %}    
+      {% cell 'u-bolt-width-1/1 u-bolt-width-2/3@medium' %}
         {% include "@bolt/headline.twig" with {
             text: "ROBOTIC AUTOMATION",
             size: "xsmall",
@@ -103,7 +103,7 @@
   {% endblock %}
 {% endembed %}
 
-  
+
   {# End Anchor Band #}
 
 
@@ -118,7 +118,7 @@
     ]
   }
 } %}
-  
+
       {% block band_content  %}
         {% grid "o-bolt-grid--large o-bolt-grid--matrix" %}
           {% cell 'u-bolt-width-1/1 u-bolt-width-3/5@medium' %}
@@ -128,10 +128,10 @@
             tag: "h2"
             } only %}
             <p>At Pega, we’re obsessed with being unified. Our mobility, real-time AI, robotic automation, BPM, and case management are best in breed – go ask the analysts. But we didn’t cobble this together from pieces of dead companies – we built it from the ground up on a unified, enterprise-ready architecture.</p>
-            
+
             <p>When you don’t have to waste time feeding the Frankenstack, you can focus on stuff that matters: designing awesome customer experiences. Automating your most complicated processes. Innovating in ways that disrupt the market."</p>
           {% endcell %}
-      
+
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@medium" %}
             {% include "@bolt-components-card/card.twig" with {
               url: "#!",
@@ -180,7 +180,7 @@
     ]
   }
 } %}
-  
+
       {% block band_content  %}
         {% grid "o-bolt-grid--large o-bolt-grid--matrix o-bolt-grid--rev" %}
             {% cell 'u-bolt-width-1/1 u-bolt-width-3/5@medium' %}
@@ -245,7 +245,7 @@
     ]
   }
 } %}
-  
+
       {% block band_content  %}
         {% grid "o-bolt-grid--large o-bolt-grid--matrix" %}
           {% cell 'u-bolt-width-1/1 u-bolt-width-3/5@medium' %}
@@ -309,7 +309,7 @@
     ]
   }
 } %}
-  
+
       {% block band_content  %}
         {% grid "o-bolt-grid--large o-bolt-grid--matrix o-bolt-grid--rev" %}
           {% cell 'u-bolt-width-1/1 u-bolt-width-3/5@medium' %}
@@ -324,7 +324,7 @@
 
             <p>Pega Workforce Intelligence captures insights at the desktop. It gets you the details of how work gets done. It uses real-time AI to tell you what systems and processes are getting in the way of employee productivity.</p>
 
-            <p>Because once you know the details, you can act. And that makes all the difference.</p>            
+            <p>Because once you know the details, you can act. And that makes all the difference.</p>
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@small" %}
             {% include "@bolt-components-card/card.twig" with {
@@ -374,7 +374,7 @@
     ]
   }
 } %}
-  
+
       {% block band_content  %}
         {% grid "o-bolt-grid--large o-bolt-grid--matrix" %}
           {% cell 'u-bolt-width-1/1 u-bolt-width-3/5@medium' %}
@@ -438,7 +438,7 @@
     ]
   }
 } %}
-  
+
       {% block band_content  %}
         {% grid "o-bolt-grid--large o-bolt-grid--matrix o-bolt-grid--rev" %}
           {% cell 'u-bolt-width-1/1 u-bolt-width-3/5@medium' %}
@@ -451,7 +451,7 @@
 
             <p>Pega’s enterprise process transformation platform helps orchestrate complex processes, and the Pega Customer Decision Hub supports deterministic rules in addition to advanced adaptive analytics. Rest assured regulatory compliance is maintained across the enterprise.</p>
 
-            <p>Capabilities such as auto self-documentation ensure an audit trail is maintained of all activities so compliance risk is minimized and required reporting is streamlined and automated.</p>      
+            <p>Capabilities such as auto self-documentation ensure an audit trail is maintained of all activities so compliance risk is minimized and required reporting is streamlined and automated.</p>
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-2/5@small u-bolt-margin---small" %}
             {% include "@bolt-components-card/card.twig" with {
@@ -490,7 +490,7 @@
     {% endembed %}
 {# End governance #}
 
-  
+
     {% include '@bolt-components-share/share.twig' with {
       text: 'Custom label',
       sources: [
@@ -513,7 +513,7 @@
       ]
     } only %}
 
-  
+
     {% include '@bolt-components-share/share.twig' with {
       sources: [
         {
@@ -534,6 +534,6 @@
         }
       ]
     } only %}
-    
-  
+
+
 {% endblock %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/99999-bolt-dev-sandbox/-05-ckeditor-5.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/99999-bolt-dev-sandbox/-05-ckeditor-5.twig
@@ -50,12 +50,12 @@
     <script src="https://cdn.ckeditor.com/ckeditor5/11.1.1/balloon/ckeditor.js"></script> #}
 
   {% endset %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "theme": "dark",
     "size": "large",
     "content": header
   } only %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "theme": "xlight",
     "content": article
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/99999-bolt-dev-sandbox/-10-ckeditor-4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/99999-bolt-dev-sandbox/-10-ckeditor-4.twig
@@ -50,12 +50,12 @@
     <script src="https://cdn.ckeditor.com/ckeditor5/11.1.1/balloon/ckeditor.js"></script> #}
 
   {% endset %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "theme": "dark",
     "size": "large",
     "content": header
   } only %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "theme": "xlight",
     "content": article
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/99999-bolt-dev-sandbox/00-wysiwyg-kitchen-sink.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/99999-bolt-dev-sandbox/00-wysiwyg-kitchen-sink.twig
@@ -199,12 +199,12 @@ ClassicEditor
 
 
 
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "theme": "dark",
     "size": "large",
     "content": header
   } only %}
-  {% include "@bolt/band.twig" with {
+  {% include "@bolt-components-band/band.twig" with {
     "theme": "xlight",
     "content": article
   } only %}

--- a/docs-site/src/templates/homepage.twig
+++ b/docs-site/src/templates/homepage.twig
@@ -1,7 +1,7 @@
 {% extends "@bolt-site/default-redesign.twig" %}
 
 {% set content %}
-  {% embed "@bolt/band.twig" with {
+  {% embed "@bolt-components-band/band.twig" with {
     size: "none",
     theme: "xdark",
     fullBleed: true,

--- a/packages/components/bolt-band/__examples__/band--card-collection.twig
+++ b/packages/components/bolt-band/__examples__/band--card-collection.twig
@@ -1,2 +1,2 @@
 {% set pattern = "card" %}
-{% extends "@bolt/band--collection.twig" %}
+{% extends "@bolt-components-band/band--collection.twig" %}

--- a/packages/components/bolt-band/__examples__/band--collection.twig
+++ b/packages/components/bolt-band/__examples__/band--collection.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/band.twig" %}
+{% extends "@bolt-components-band/band.twig" %}
 {% block band_content %}
 
   {% grid "o-bolt-grid--flex o-bolt-grid--matrix" %}

--- a/packages/components/bolt-band/__examples__/band--feature.twig
+++ b/packages/components/bolt-band/__examples__/band--feature.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/band.twig" %}
+{% extends "@bolt-components-band/band.twig" %}
 {% block band_content %}
   {% grid "o-bolt-grid--flex o-bolt-grid--large o-bolt-grid--matrix" %}
 

--- a/packages/components/bolt-band/__examples__/band--flag.twig
+++ b/packages/components/bolt-band/__examples__/band--flag.twig
@@ -1,4 +1,4 @@
-{% extends "@bolt/band.twig" %}
+{% extends "@bolt-components-band/band.twig" %}
 
 {% set size = size | default("large") %}
 

--- a/packages/components/bolt-band/__examples__/band--teaser-collection.twig
+++ b/packages/components/bolt-band/__examples__/band--teaser-collection.twig
@@ -1,2 +1,2 @@
 {% set layout = "teaser" %}
-{% extends "@bolt/band--collection.twig" %}
+{% extends "@bolt-components-band/band--collection.twig" %}


### PR DESCRIPTION
@mikemai2awesome - this is another PR subset of the full #1010 PR -- this one only includes the Twig-specific updates that didn't require any Band component-specific updates (so before the schema changed).

This helps simplify what changes this PR involves + allows us to only PR the changes involved from #1010 (minus #1088) to make things a lot more easily reviewable + more easily understand if an update is a breaking vs non-breaking change. Only one more Band-specific PR after this one!

## Jira
http://vjira2:8080/browse/BDS-828

## Summary
Updates all Band components being used in Bolt (docs site, demos, etc) to use the full Twig namespace include path. Subset of work involved to refactor the Bolt Band component.

## How to test
- Confirm Travis CI build runs as expected
- Confirm Pattern Lab demos work (no missing Twig templates) 