### PR TITLE
chore: reduce Git clone depth to speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install:
 
 services:
   - docker
+  
+git:
+  depth: 2
 
 # see more conditions: https://docs.travis-ci.com/user/conditions-v1
 # Stages run sequentially; the jobs in them run in parallel


### PR DESCRIPTION
## Jira
N/A

## Summary
Reduces the git repo clone depth on Travis to shave nearly 200 seconds off every single CI job being run 🎉

### Before
![3757673b-3b91-4133-ab69-3f6a26ff2705](https://user-images.githubusercontent.com/1617209/53956344-6171a800-40a9-11e9-9360-93c43210d6c1.jpeg)

### After
![edfa8fc5-81bf-4be2-9e8b-ebb5fdcd89f7](https://user-images.githubusercontent.com/1617209/53956343-60d91180-40a9-11e9-820d-a29f2540f9f4.jpeg)

## How to test
- Does the build pass?
- Is the git clone on Travis faster?