### PR TITLE
Hotfix: Prevent Now.sh Deploy Alias Failures 

### DIFF
--- a/scripts/__tests__/now-url-alias.test.js
+++ b/scripts/__tests__/now-url-alias.test.js
@@ -1,0 +1,23 @@
+const { normalizeUrlAlias } = require('../utils/normalize-url-alias');
+const { branchName } = require('../utils/branch-name');
+
+describe('branch name for url aliases exists', () => {
+  test('current branch name exists', async () => {
+    expect(branchName).toBeDefined();
+  });
+
+  test('url-friendly branch name formatted correctly', async () => {
+    expect(branchName).toEqual(expect.not.stringContaining(' '));
+    expect(branchName).toEqual(expect.not.stringContaining('.'));
+    expect(branchName).toEqual(expect.not.stringContaining('--'));
+  });
+
+  test('now.sh deploy branch alias name', async () => {
+    const result = normalizeUrlAlias(branchName);
+    const resultWithoutHttps = result.replace('https://', '');
+
+    expect(result).toContain('boltdesignsystem.com');
+    expect(result).toContain('boltdesignsystem.com');
+    expect(resultWithoutHttps.length <= 62).toEqual(true);
+  });
+});

--- a/scripts/utils/normalize-url-alias.js
+++ b/scripts/utils/normalize-url-alias.js
@@ -1,0 +1,28 @@
+function normalizeUrlAlias(prefix, suffix = '.boltdesignsystem.com') {
+  // passing an empty prefix will deploy to the main boltdesignsystem.com site
+  if (prefix) {
+    const normalizedUrlPrefix = prefix
+      .replace(/\//g, '-') // `/` => `-`
+      .replace('--', '-') // `--` => `-` now.sh subdomains can't have `--` for some reason
+      .replace(/\./g, '-'); // `.` => `-`
+
+    let normalizedUrlBase = `${encodeURIComponent(normalizedUrlPrefix)}`;
+
+    // if the full url is 62 characters or longer, truncate to fix errors on now.sh errors when trying to alias
+    if (normalizedUrlBase.length + suffix.length >= 62) {
+      normalizedUrlBase = normalizedUrlBase.substring(0, 62 - suffix.length);
+
+      if (normalizedUrlBase.substr(normalizedUrlBase.length - 1) === '-') {
+        normalizedUrlBase = normalizedUrlBase.slice(0, -1);
+      }
+    }
+
+    let aliasedUrl = `https://${normalizedUrlBase}${suffix}`;
+    console.log(aliasedUrl);
+    return aliasedUrl;
+  }
+}
+
+module.exports = {
+  normalizeUrlAlias,
+};


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1186

## Summary
Updates the logic for our now.sh deploy URL aliases to ensure the alias name (based off of the name of the Git branch) doesn't exceed 63 characters long and cause the now.sh deployment to fail as seen on https://github.com/bolt-design-system/bolt/pull/1120 and https://github.com/bolt-design-system/bolt/pull/1120/checks?check_run_id=80710490

## Details
- Slightly refactors the deploy JS logic so the function that formats the URL is more easily testable
- Updates the logic to truncate URL aliases that would be 62 characters in length or longer
- Adds a few Jest tests to make sure the branch name and URL alias logic are working as expected

## How to test
- Confirm the URL alias for this branch is properly truncated
- Confirm the tests for this all pass