### PR TITLE
Improve Server Side Rendering Configuration + Auto-disable For Local Dev Perf

### DIFF
--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -33,6 +33,7 @@ async function getDefaultConfig() {
       port: ports[0],
       proxyPort: ports[1],
       ip,
+      enableSSR: configSchema.properties.enableSSR.default,
       mode: configSchema.properties.mode.default,
       env: process.env.NODE_ENV,
       enableCache: configSchema.properties.enableCache.default,

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -217,6 +217,12 @@
       type: boolean
       description: Production build, will compress assets.
       default: false
+    enableSSR:
+      type: boolean
+      description: Manually enables or disables server-side rendering web components regardless on the build enviornment (vs automatically disabling in dev mode, enabling when in prod mode).
+      enum:
+        - true
+        - false
     schemaErrorReporting:
       description: Setting for where schema errors should be reported.  Note that reporting to cli will cause builds to fail if there are errors.
       type: string

--- a/packages/build-tools/utils/log.js
+++ b/packages/build-tools/utils/log.js
@@ -112,7 +112,7 @@ function intro() {
   const CLI_TITLE = chalk.bold.underline('Bolt-CLI');
   const CLI_DESCRIPTION = 'Welcome to the Bolt CLI ⚡️  Have fun!';
   const CLI_USAGE = 'Usage: `bolt <command> [options ...]`';
-  const HELP_USAGE = 'Help: `bolt --help` or `bolt <command> --help`';
+  const HELP_USAGE = 'Help: `bolt -h` or `bolt <command> --help`';
 
   // const HELP_HEADER_BACKUP = `
   //     /˜˜˜˜˜˜˜˜˜˜˜˜\

--- a/packages/core-php/src/TwigFunctions.php
+++ b/packages/core-php/src/TwigFunctions.php
@@ -56,10 +56,20 @@ class TwigFunctions {
 
     // locate where the Bolt SSR Server script is physically located so we can call the script + pass along our HTML string to render
     $context = new ArrayFinder($context);
-    $configFileUsed = $context->get('bolt.data.config.configFileUsed');
+    $boltConfig = $context->get('bolt.data.config');
+
+    // if the config option used to manually set server-side rendering behavior (enabled, disabled, or auto) doesn't exist, automatically disable and exit early.  
+    if (!isset($boltConfig["enableSSR"])){
+      return $html;
+    }
+
+    // disable server-side rendering web components when manually disabled, or set to auto + running in dev mode
+    if (($boltConfig["enableSSR"] == false && $boltConfig["prod"] == false)){
+      return $html;
+    }
     
-    $ssrServerPath = dirname($configFileUsed, 2) . '/node_modules/@bolt/ssr-server/cli.js';
-    $ssrServerPathAlt = dirname($configFileUsed, 1) . '/node_modules/@bolt/ssr-server/cli.js';
+    $ssrServerPath = dirname($boltConfig["configFileUsed"], 2) . '/node_modules/@bolt/ssr-server/cli.js';
+    $ssrServerPathAlt = dirname($boltConfig["configFileUsed"], 1) . '/node_modules/@bolt/ssr-server/cli.js';
     $ssrServerLocation = '';
 
     // if we found the right SSR server file in one of two places, try to render using it. Otherwise return the original HTML.


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1207

## Summary
- Updates the Bolt Build Tools configuration + PHP logic to automatically enable server-side rendering in `prod` mode, disable in local `dev` mode, and provide a new `enableSSR` config option to allow SSR to be manually be enabled / disabled (overriding the default `auto` behavior).

## Details
- Should help speed up the initial compile times of Pattern Lab locally till we can get a more advanced caching system in place (prevent unnecessary recompiles when not needed). 

## How to test
- Confirm these updates speed up initial boot times for local development
- Confirm server-side rendering still working as expected on the prod version of the site built on Travis.

CC @mikemai2awesome 