### PR TITLE
Fix missing volume control

### DIFF
--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -1,15 +1,16 @@
 // Same as max-width of wrapper container
 $bolt-video-wrapper--max-width: bolt-breakpoint(xxlarge);
-$bolt-video-background-color: rgba(22, 26, 60, .8);
+$bolt-video-background-color: rgba(22, 26, 60, 0.8);
 $bolt-video-background-max-height: 50.625vw;
-
 
 #{$bolt-namespace}-video {
   display: block;
   width: 100%;
-  background-color: bolt-color(black); // placeholder color before poster loads up.
+  background-color: bolt-color(
+    black
+  ); // placeholder color before poster loads up.
 
-  &[is-background-video]{
+  &[is-background-video] {
     @include bolt-margin-right(auto);
     @include bolt-margin-left(auto);
     flex-grow: 1;
@@ -54,7 +55,6 @@ $bolt-video-background-max-height: 50.625vw;
   }
 }
 
-
 /**
   * 1. 90vw instead of 100vw so the video close button
   * doesn't spill outside of the video container in IE 11 /
@@ -64,7 +64,7 @@ $bolt-video-background-max-height: 50.625vw;
   z-index: bolt-z-index('tooltip');
   width: 100%;
   max-width: none;
-  transition: transform .4s cubic-bezier(.645, 0, .355, 1);
+  transition: transform 0.4s cubic-bezier(0.645, 0, 0.355, 1);
 
   &.c-#{$bolt-namespace}-video--background {
     display: block;
@@ -78,7 +78,7 @@ $bolt-video-background-max-height: 50.625vw;
       max-width: calc(100vw - 40px);
     }
 
-    @include bolt-mq(small){
+    @include bolt-mq(small) {
       width: calc(90vw - 7rem);
       max-width: 100vh;
       height: calc((90vw * (9 / 16)) - 4rem);
@@ -87,19 +87,17 @@ $bolt-video-background-max-height: 50.625vw;
   }
 }
 
-
-
 .c-#{$bolt-namespace}-video__close-button {
-  opacity: bolt-opacity(0); // Initial state before brightcove video player kicks in
+  opacity: bolt-opacity(
+    0
+  ); // Initial state before brightcove video player kicks in
   position: absolute;
   top: bolt-spacing(xsmall);
   right: bolt-spacing(xsmall);
   z-index: bolt-z-index('tooltip');
   color: bolt-color(orange);
   transition: all 0.3s ease;
-  @include bolt-css-vars((
-    --#{$bolt-namespace}-theme-icon: bolt-color(orange),
-  ));
+  @include bolt-css-vars((--#{$bolt-namespace}-theme-icon: bolt-color(orange)));
 
   @include bolt-mq(small) {
     right: (bolt-spacing(large) / -2) - bolt-spacing(xsmall);
@@ -158,7 +156,6 @@ $bolt-video-background-max-height: 50.625vw;
   color: bolt-color(white);
   text-decoration: underline;
 }
-
 
 .c-#{$bolt-namespace}-video--hide-controls {
   .video-js .vjs-control-bar {

--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -66,6 +66,24 @@ $bolt-video-background-max-height: 50.625vw;
   max-width: none;
   transition: transform 0.4s cubic-bezier(0.645, 0, 0.355, 1);
 
+  // Force icons to be visible at smaller layout sizes
+  .video-js.vjs-layout-tiny,
+  .video-js.vjs-layout-x-small,
+  .video-js.vjs-layout-small {
+    &:not(.vjs-fullscreen) {
+      .vjs-mute-control,
+      .vjs-volume-panel,
+      .vjs-volume-control,
+      .vjs-playback-rate,
+      .vjs-current-time,
+      .vjs-time-divider,
+      .vjs-duration,
+      .vjs-button.vjs-share-control {
+        display: flex;
+      }
+    }
+  }
+
   &.c-#{$bolt-namespace}-video--background {
     display: block;
     position: relative;


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/BDS-1164
- http://vjira2:8080/browse/WWWD-3278

## Summary

Brightcove hides volume and other video controls below 400px. Add CSS to show these controls. This issue was fixed on .COM site. I am moving the fix back into Bolt.

## How to test
- Open a [video page](https://master.boltdesignsystem.com/pattern-lab/patterns/02-components-video-05-video/02-components-video-05-video.html) on master with the browser window at < 425px wide.
- See that the volume controls do not appear.
- Run this feature branch locally and perform the same test.
- Verify on hover that the volume, time, playback-speed, and share icons are visible.
- Repeat @ < 320px and < 210px and verify the same.

Note: You must open page at the above sizes to test. Simply resizing the window will not hide the icons. That's how Video JS works (not a Bolt feature).
