### PR TITLE
fix(core-php): moving phpunit from dep to devDep

### DIFF
--- a/packages/core-php/composer.json
+++ b/packages/core-php/composer.json
@@ -4,8 +4,7 @@
   "version": "2.3.0",
   "type": "library",
   "license": "MIT",
-  "authors": [
-    {
+  "authors": [{
       "name": "Salem Ghoweri",
       "role": "Maintainer"
     },
@@ -28,8 +27,10 @@
     "gregwar/image": "^2.0",
     "tooleks/php-avg-color-picker": "^1.1.2",
     "asm89/twig-lint": "^1.0",
-    "phpunit/phpunit": "^7",
     "nabil1337/case-helper": "^0.1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^7"
   },
   "scripts": {
     "setup": "@composer install --no-interaction --prefer-dist --no-progress",


### PR DESCRIPTION
## Summary

The PHP package `bolt-design-system/core-php` has `phpunit` v7 as a dependency in `require` and this moves it to a dev dependency in `require-dev`. When Drupal sites that want to install Bolt PHP packages have a PHPUnit dependency that is different, it throws an install error. We just use it for testing and it is not used for run time at all.