### PR TITLE
Fix: Version Lock Twig Version

### DIFF
--- a/packages/twig-renderer/composer.json
+++ b/packages/twig-renderer/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "bolt-design-system/core-php": "^2.3.0",
     "bolt-design-system/drupal-twig-extensions": "*",
-    "twig/twig": "^1.38.2",
+    "twig/twig": "1.38.2",
     "webmozart/path-util": "*",
     "symfony/finder": "*"
   },


### PR DESCRIPTION
## Jira
N/A

## Summary
Locks down the version of Twig installed and used by the Twig Renderer package. Temp workaround to to address build errors from recent upstream changes from Packagist.

## How to test
- Confirm the docs site builds as expected