### PR TITLE
Chore: Add Missing @bolt/core Style Default Flags

### DIFF
--- a/packages/core/styles/01-settings/_settings-z-index.scss
+++ b/packages/core/styles/01-settings/_settings-z-index.scss
@@ -27,6 +27,6 @@ $bolt-z-indexes: (
     background: 0,
     backgroundBottom: -20,
   ),
-);
+) !default;
 
 @include export-data('z-indexes.bolt.json', $bolt-z-indexes);

--- a/packages/core/styles/01-settings/settings-breakpoints/_settings-breakpoints.scss
+++ b/packages/core/styles/01-settings/settings-breakpoints/_settings-breakpoints.scss
@@ -15,7 +15,7 @@ $bolt-breakpoints: (
   xlarge:   1200px,
   xxlarge:  1400px,
   xxxlarge: 1920px
-);
+) !default;
 
 /// A duplicate of $bolt-breakpoints - used within mq()
 /// @see {mixin} bolt-mq

--- a/packages/core/styles/01-settings/settings-colors/_settings-colors.scss
+++ b/packages/core/styles/01-settings/settings-colors/_settings-colors.scss
@@ -54,7 +54,7 @@ $bolt-brand-colors: (
   'white': (
     'base': hsl(0, 0%, 100%),
   ),
-);
+) !default;
 
 /// Bolt Status Colors - merged into $bolt-colors map
 /// @type map
@@ -79,7 +79,7 @@ $bolt-status-colors: (
     'base': hsl(51, 80%, 55%),
     'light': hsl(51, 80%, 90%),
   ),
-);
+) !default;
 
 /// Bolt Social Colors - merged into $bolt-colors map
 /// @type map
@@ -89,7 +89,7 @@ $bolt-social-colors: (
     'twitter': hsl(196, 100%, 46%),
     'linkedin': hsl(201, 96%, 36%),
   ),
-);
+) !default;
 
 /// All Bolt Colors - used within bolt-color @mixin and @function
 /// @type map
@@ -98,7 +98,7 @@ $bolt-social-colors: (
 $bolt-colors: map-merge(
   map-merge($bolt-brand-colors, $bolt-status-colors),
   $bolt-social-colors
-);
+) !default;
 
 @include bolt-export-data('colors/all.bolt.json', $bolt-colors);
 @include bolt-export-data('colors/status.bolt.json', $bolt-status-colors);

--- a/packages/core/styles/01-settings/settings-font-family/_settings-font-family.scss
+++ b/packages/core/styles/01-settings/settings-font-family/_settings-font-family.scss
@@ -22,11 +22,11 @@ $bolt-font-family--sans-fallback:
 
 /// Default serif font stack. Used within the $bolt-font-families map.
 /// @see $bolt-font-families
-$bolt-font-family--serif: 'Georgia', serif;
+$bolt-font-family--serif: 'Georgia', serif !default;
 
 /// Default monospace fallback font stack. Used within the $bolt-font-families map.
 /// @see $bolt-font-families
-$bolt-font-family--mono-fallback: monospace, monospace;
+$bolt-font-family--mono-fallback: monospace, monospace !default;
 
 
 /*
@@ -44,7 +44,7 @@ $bolt-font-family--sans-subset: 'OpenSansSubset', 'Helvetica Neue', sans-serif !
 
 /// Default monospace font stack. Used within the $bolt-font-families map.
 /// @see $bolt-font-families
-$bolt-font-family--mono:  monospace, monospace;
+$bolt-font-family--mono:  monospace, monospace !default;
 
 
 /*
@@ -77,6 +77,6 @@ $bolt-font-families: (
       loaded-class:  $bolt-fonts--loaded-class
     )
   )
-);
+) !default;
 
 @include export-data('typography/font-families.bolt.#{$bolt-lang}.json', $bolt-font-families);

--- a/packages/core/styles/01-settings/settings-font-size/_settings-font-size.scss
+++ b/packages/core/styles/01-settings/settings-font-size/_settings-font-size.scss
@@ -7,9 +7,9 @@
 @import "../../02-tools/tools-px-to-rem/_tools-px-to-rem.scss";
 
 /// Small breakpoint font-size
-$bolt-font-size--small-bp: bolt-rem(bolt-breakpoint(xxsmall));
+$bolt-font-size--small-bp: bolt-rem(bolt-breakpoint(xxsmall)) !default;
 /// Medium breakpoint font-size
-$bolt-font-size--medium-bp: bolt-rem(bolt-breakpoint(medium));
+$bolt-font-size--medium-bp: bolt-rem(bolt-breakpoint(medium)) !default;
 
 
 /* ------------------------------------ *\
@@ -32,13 +32,13 @@ $bolt-font-size--xlarge: 1.417rem !default;
 $bolt-font-size--large: 1.111rem !default;
 /// Medium font-size. Used within $bolt-font-sizes map.
 /// @see $bolt-font-sizes
-$bolt-font-size--medium: 1rem;
+$bolt-font-size--medium: 1rem !default;
 /// Small font-size. Used within $bolt-font-sizes map.
 /// @see $bolt-font-sizes
-$bolt-font-size--small: 0.9rem;
+$bolt-font-size--small: 0.9rem !default;
 /// X Small font-size. Used within $bolt-font-sizes map.
 /// @see $bolt-font-sizes
-$bolt-font-size--xsmall: 0.8rem;
+$bolt-font-size--xsmall: 0.8rem !default;
 
 /// Default XXX Large line-height. Used within $bolt-font-sizes map.
 /// @see $bolt-font-sizes
@@ -125,4 +125,4 @@ $bolt-font-sizes: (
       )
     )
   )
-);
+) !default;

--- a/packages/core/styles/01-settings/settings-global/_settings-global.scss
+++ b/packages/core/styles/01-settings/settings-global/_settings-global.scss
@@ -28,41 +28,41 @@ $bolt-fonts--loaded-class: 'js-fonts-loaded' !default;
 // @todo Salem, we should probably deprecate these so there is only one way to do shadows
 // Shadows
 /// Bolt shadow color
-$bolt-shadow-color: bolt-color(black);
+$bolt-shadow-color: bolt-color(black) !default;
 /// Bolt small shadow
-$bolt-shadow--small: 0 2px 0.15rem rgba($bolt-shadow-color, 0.3);
+$bolt-shadow--small: 0 2px 0.15rem rgba($bolt-shadow-color, 0.3) !default;
 /// Bolt medium shadow
-$bolt-shadow--medium: 0 0.15rem 0.3rem rgba($bolt-shadow-color, 0.35);
+$bolt-shadow--medium: 0 0.15rem 0.3rem rgba($bolt-shadow-color, 0.35) !default;
 /// Bolt large shadow
-$bolt-shadow--large: 0 0.35rem 0.6rem rgba($bolt-shadow-color, 0.18);
+$bolt-shadow--large: 0 0.35rem 0.6rem rgba($bolt-shadow-color, 0.18) !default;
 
 // Border
 /// Bolt border width
-$bolt-border-width: 1px;
+$bolt-border-width: 1px !default;
 /// Bolt border style
-$bolt-border-style: solid;
+$bolt-border-style: solid !default;
 /// Bolt border color
-$bolt-border-color: rgba(bolt-color(gray), 0.2);
+$bolt-border-color: rgba(bolt-color(gray), 0.2) !default;
 /// Bolt border radius
-$bolt-border-radius: 3px;
+$bolt-border-radius: 3px !default;
 
 // Transition
 /// Bolt transition
-$bolt-transition: ease-in-out 200ms;
+$bolt-transition: ease-in-out 200ms !default;
 /// Bolt transition ease
-$bolt-transition-ease: ease-in-out;
+$bolt-transition-ease: ease-in-out !default;
 /// Bolt transition timing
-$bolt-transition-timing: 200ms;
+$bolt-transition-timing: 200ms !default;
 
 // Effects
 /// Bolt translate none effect
-$bolt-translate-none: translate3d(0, 0, 0);
+$bolt-translate-none: translate3d(0, 0, 0) !default;
 /// Bolt translate raised small effect
-$bolt-translate-raised--small: translate3d(0, -1px, 0);
+$bolt-translate-raised--small: translate3d(0, -1px, 0) !default;
 /// Bolt translate raised medium effect
-$bolt-translate-raised--medium: translate3d(0, -0.125rem, 0);
+$bolt-translate-raised--medium: translate3d(0, -0.125rem, 0) !default;
 /// Bolt translate raised large effect
-$bolt-translate-raised--large: translate3d(0, -0.25rem, 0);
+$bolt-translate-raised--large: translate3d(0, -0.25rem, 0) !default;
 
 
 // Global theming defaults -- TODO: move to standalone setting
@@ -74,7 +74,7 @@ $bolt-global-link-active-opacity: bolt-opacity(60) !default;
 /// Bolt default global border opacity
 $bolt-global-border-opacity: bolt-opacity(20) !default;
 /// Bolt default global border color
-$bolt-global-border-color: bolt-color(gray);
+$bolt-global-border-color: bolt-color(gray) !default;
 
 /// Bolt default global button hover mix %
 $bolt-global-button-hover-mix: 15% !default;
@@ -103,7 +103,7 @@ $bolt-block-elements-list: 'p',
   'details',
   'summary',
   'hr',
-  'address';
+  'address' !default;
 
 $bolt-unquoted-block-elements-list: ();
 
@@ -125,7 +125,7 @@ $bolt-heading-elements-list: 'h1',
   'h3',
   'h4',
   'h5',
-  'h6';
+  'h6' !default;
 
 $bolt-unquoted-heading-elements-list: ();
 

--- a/packages/core/styles/01-settings/settings-opacity/_settings-opacity.scss
+++ b/packages/core/styles/01-settings/settings-opacity/_settings-opacity.scss
@@ -18,6 +18,6 @@ $bolt-opacities: (
   60: .6,
   80: .8,
   100: 1
-);
+) !default;
 
 @include export-data('opacity.bolt.json', $bolt-opacities);

--- a/packages/core/styles/01-settings/settings-shadow/_settings-shadow.scss
+++ b/packages/core/styles/01-settings/settings-shadow/_settings-shadow.scss
@@ -50,7 +50,7 @@
         'raised': '0 10px 30px 1px #{transparentize($base-color, .90)}, 0 110px 130px 1px #{transparentize($base-color, .75)}, 0 130px 150px 0 #{transparentize($base-color, .65)}'
       )
     )
-  );
+  ) !default;
   @return $bolt-shadows;
 }
 

--- a/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
+++ b/packages/core/styles/01-settings/settings-spacing/_settings-spacing.scss
@@ -34,12 +34,12 @@ $bolt-spacing-values: (
 
 /// Bolt's definition of available spacing properties.
 /// @type Map
-$bolt-spacing-properties: ('padding', 'margin');
+$bolt-spacing-properties: ('padding', 'margin') !default;
 
 /// Bolt's definition of spacing directions.
 /// @type Map
-$bolt-spacing-directions: ('', 'top', 'right', 'bottom', 'left');
+$bolt-spacing-directions: ('', 'top', 'right', 'bottom', 'left') !default;
 
 /// Bolt's definition of spacing types.
 /// @type Map
-$bolt-spacing-types: ('', 'squished', 'stretched');
+$bolt-spacing-types: ('', 'squished', 'stretched') !default;

--- a/packages/core/styles/01-settings/settings-themes/index.scss
+++ b/packages/core/styles/01-settings/settings-themes/index.scss
@@ -71,7 +71,7 @@ $bolt-themes: (
   xdark: (
     background: bolt-color(indigo, dark),
   ),
-);
+) !default;
 
 // combine the two sets of theming system data and calculate the dynamic values
 @each $themeName, $themeProps in $bolt-themes {

--- a/packages/core/styles/index.scss
+++ b/packages/core/styles/index.scss
@@ -4,7 +4,6 @@
 
 @import 'sass-mq/_mq';
 @import 'sassy-maps/sass/sassy-maps';
-// @import '~@theme-tools/sass-export-data/export-data.scss';
 @import '@bolt/sass-export-data/export-data.scss';
 
 @import '01-settings/00-settings-lang/_settings.lang-en';


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds any missing `!default` flags to the `@bolt/core` style settings files to allow config options to be more easily updated and extended.

## How to test
- Confirm Travis build runs successfully
- Spot check visual styles / component styles to ensure Sass compiled as expected (Jest tests and VRT should fail if this wasn't the case...)
