### PR TITLE
Fix Github Checks API Status for Now.sh

### DIFF
--- a/scripts/utils/handle-now-aliases.js
+++ b/scripts/utils/handle-now-aliases.js
@@ -17,7 +17,7 @@ async function aliasNowUrl(originalUrl, prefix) {
     outputBanner = require('ci-utils').outputBanner;
 
     await setCheckRun({
-      name: 'Deploy - now.sh (basic)',
+      name: 'Deploy - now.sh (alias)',
       status: 'in_progress',
     });
     outputBanner('Starting deploy...');


### PR DESCRIPTION
## Jira
N/A

## Summary
Fixes a typo with the Github Checks API name used to report back on which Travis CI steps are pending, in-progress, and pass / fail.

## Details
This should fix the recent issue relating to 1 out of the 7 status checks incorrectly reporting back as never finishing (specifically the Now.sh basic / alias deployments):

![image](https://user-images.githubusercontent.com/1617209/56053178-43324400-5d08-11e9-97b1-40a478a96a78.png)

## How to test
- Confirm the Travis build for this passes + all 7 status checks finish
