### PR TITLE
Feat: Docs Site "Bolt Release" Banner

### DIFF
--- a/docs-site/.boltrc.js
+++ b/docs-site/.boltrc.js
@@ -81,6 +81,7 @@ const config = {
       '@bolt/analytics-autotrack',
       '@bolt/components-placeholder',
       '@bolt/components-action-blocks',
+      '@bolt/components-banner',
       '@bolt/components-dropdown',
       '@bolt/components-background',
       '@bolt/components-background-shapes',

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -33,6 +33,7 @@
     "@bolt/components-background": "^2.4.0-beta.0",
     "@bolt/components-background-shapes": "^2.4.0-beta.0",
     "@bolt/components-band": "^2.4.0-beta.0",
+    "@bolt/components-banner": "^2.4.0-beta.0",
     "@bolt/components-block-list": "^2.4.0-beta.0",
     "@bolt/components-blockquote": "^2.4.0-beta.0",
     "@bolt/components-breadcrumb": "^2.4.0-beta.0",

--- a/docs-site/src/components/banner/banner.scss
+++ b/docs-site/src/components/banner/banner.scss
@@ -15,18 +15,8 @@
   grid-column-start: 1;
   -ms-grid-column-span: 2;
   grid-column-end: 3;
-
   grid-row-start: 1;
 
-  // -ms-grid-column: 1;
-  // grid-column-start: 1;
-  // -ms-grid-column-span: 3;
-  // grid-column-end: 4;
-  // display: flex;
-  // flex-direction: column;
-  // justify-content: space-between;
-
-  // @include bolt-mq(medium) {
   .c-bds-layout--has-sidebar & {
     -ms-grid-column: 1;
     grid-column-start: 1;

--- a/docs-site/src/components/banner/package.json
+++ b/docs-site/src/components/banner/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@bolt/components-banner",
+  "description": "Banner Component",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "css framework",
+    "design system"
+  ],
+  "version": "2.4.0-beta.0",
+  "maintainers": [
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "web": "https://github.com/sghoweri"
+    }
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "license": "MIT",
+  "bugs": "https://github.com/bolt-design-system/bolt/issues",
+  "private": true,
+  "style": "banner.scss",
+  "dependencies": {
+    "@bolt/core": "^2.4.0-beta.0"
+  }
+}

--- a/docs-site/src/components/banner/release-banner.twig
+++ b/docs-site/src/components/banner/release-banner.twig
@@ -1,0 +1,72 @@
+{% set currentVersion = "v" ~ bolt.data.fullManifest.version %}
+{% set latestVersion = bolt.data.boltReleases.options[0] %}
+{% set isNotStable = 
+  "alpha" in currentVersion or 
+  "beta" in currentVersion or 
+  "rc" in currentVersion 
+    ? true : false 
+%}
+
+{% set latestStableVersion = "" %}
+{% set previousStableVersion = "" %}
+
+{# is this (the local version of Bolt) also the latest version? #}
+{% if latestVersion.label == currentVersion %}
+  {% set isLocalVersionTheLatest = true %}
+{% else %}
+  {% set isLocalVersionTheLatest = false %}
+{% endif %}
+
+{% for option in bolt.data.boltReleases.options %}
+  {% set v = option.label %}
+  {% set isStable = "alpha" not in v and "beta" not in v and "rc" not in v %}
+
+  {% if v != currentVersion and isStable and previousStableVersion == "" %}
+    {% set previousStableVersion = option %}
+  {% endif %}
+
+  {% if isStable and latestStableVersion == "" %}
+    {% set latestStableVersion = option %}
+  {% endif %}
+{% endfor %}
+
+{% if isLocalVersionTheLatest %}
+  {% set suggestedText = "alpha" not in previousStableVersion.value and "beta" not in previousStableVersion.value and "rc" not in previousStableVersion.value and isNotStable ? 'the latest stable' : 'the previous' %}
+  {% set suggestedLink = previousStableVersion %}
+{% elseif currentVersion != latestStableVersion.label %}
+  {% set suggestedText = "the latest stable" %}
+  {% set suggestedLink = latestStableVersion %}
+{% else %}
+  {% set suggestedText = "alpha" not in latestVersion.value and "beta" not in latestVersion.value and "rc" not in latestVersion.value ? 'the latest' : 'the upcoming' %}
+  {% set suggestedLink = latestVersion %}
+{% endif %}
+
+{% if isNotStable and latestVersion.label == currentVersion %}
+  {% set currentVersionText = "an upcoming " %}
+{% elseif latestStableVersion.label == currentVersion %}
+  {% set currentVersionText = "the latest stable " %}
+{% elseif latestVersion.label == currentVersion %}
+  {% set currentVersionText = "the latest " %}
+{% else %}
+  {% set currentVersionText = "a previous " %}
+{% endif %}
+
+{% set suggestedRenderedLink = include("@bolt-components-link/link.twig", {
+  text: suggestedLink.label,
+  url: suggestedLink.value,
+}) %}
+
+{% set text %}
+  {% spaceless %}
+    These are the docs for {{ currentVersionText }} release of the Bolt Design System. Looking for {{ suggestedText }} release, {{ suggestedRenderedLink }}?
+  {% endspaceless %}
+{% endset %}
+
+{% set bannerText = include("@bolt-components-headline/text.twig", {
+  size: "small",
+  text: text
+}) %}
+
+{% include "@bolt-site/banner.twig" with {
+  text:  bannerText
+} only %}

--- a/docs-site/src/index.scss
+++ b/docs-site/src/index.scss
@@ -1,4 +1,3 @@
-@import './components/banner/banner.scss';
 @import './components/animated-logo/animated-logo.scss';
 @import './components/animated-shapes/animated-shapes.scss';
 @import './components/site-layout/site-layout.scss';

--- a/docs-site/src/templates/_page-header.twig
+++ b/docs-site/src/templates/_page-header.twig
@@ -1,7 +1,5 @@
 {% set navbar %}
-  {% include "@bolt-site/banner.twig" with {
-    text: 'These are the docs for the upcoming v2.4.0 release of Bolt. View the docs for <a href="https://v2-3-0.boltdesignsystem.com/">v2.3.0</a>'
-  } only %}
+  {% include "@bolt-site/release-banner.twig" only %}
   {% include "@bolt-site/_navbar-with-version-selector.twig" with {
     theme: "xdark",
     width: "auto",


### PR DESCRIPTION
## Jira
TBD

![image](https://user-images.githubusercontent.com/1617209/56380543-6ebd9e80-61e0-11e9-82a3-dd5199f87ec2.png)

## Summary
Replaces the previously hard-coded logic in the docs site banner component (added right before Drupalcon) to now point out if you are viewing the latest stable version of the design system, a previous version, or a new upcoming version + suggest a different version to help that distinction a lot more straightfoward.

## Details
- Also adds a package.json to the very recently added banner component so pulling this component into **older versions of Bolt** shouldn't be an issue!

## How to test
No additional testing is needed until this is deployed and can get tested on a version different versions of Bolt.