### PR TITLE
Hotfix: inline link text's last word and icon wrap together

### DIFF
--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -34,6 +34,7 @@ class BoltLink extends BoltAction {
 
   render() {
     // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
+    // 2. Zero Width No-break Space (&#xfeff;) is needed to make the last word always stick with the icon, so the icon will never become an orphan.
 
     // Validate the original prop data passed along -- returns back the validated data w/ added default values
     const { display, valign, url, target, isHeadline } = this.validateProps(
@@ -62,9 +63,10 @@ class BoltLink extends BoltAction {
         case 'after':
           const iconClasses = cx('c-bolt-link__icon');
           // [1]
+          // [2]
           // prettier-ignore
           return name in this.slots
-            ? html`<span class="${iconClasses}">${this.slot(name)}</span>`
+            ? html`<span class="${iconClasses}">&#xfeff;${this.slot(name)}</span>`
             : html`<slot name="${name}" />`;
         default:
           const itemClasses = cx('c-bolt-link__text', {

--- a/packages/components/bolt-link/src/link.scss
+++ b/packages/components/bolt-link/src/link.scss
@@ -52,6 +52,7 @@ $bolt-link-spacing: 'xxsmall';
 .c-bolt-link--display-inline {
   .c-bolt-link__icon {
     display: inline;
+    white-space: nowrap; // Combine this with Zero Width No-break Space (&#xfeff; in the markup), it fixes the orphan icon issue. The last word will always wrap with the icon.
   }
 }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1292

## Summary

Fixes an issue where the icon inside an inline link gets pushed to its own line. 

## Details

CSS is updated for inline links to have the last word to always wrap together with the icon. The icon will never be by itself on its own line.

![orphan](https://user-images.githubusercontent.com/3027663/57646975-dc66ab80-758f-11e9-8776-58dd7e5192a4.gif)

## How to test

1. Run the branch locally.
2. Go to this page: http://localhost:3000/pattern-lab/patterns/02-components-link-15-link-theme-variation/02-components-link-15-link-theme-variation.html
3. Adjust the page width to make the headline link to wrap to a second line, make sure the icon NEVER wraps to a new line by itself.
