### PR TITLE
Hotfix: Restore flag component

### DIFF
--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -55,8 +55,10 @@
         {% endif %}
       </div>
     {% endif %}
-    <figcaption class="{{ "#{base_class}__caption" }}">
-      {{ caption }}
-    </figcaption>
+    {% if caption %}
+      <figcaption class="{{ "#{base_class}__caption" }}">
+        {{ caption }}
+      </figcaption>
+    {% endif %}
   </figure>
 </bolt-figure>

--- a/packages/global/styles/05-objects/objects-flag/src/flag.twig
+++ b/packages/global/styles/05-objects/objects-flag/src/flag.twig
@@ -29,14 +29,32 @@
 
 <div {{ attributes.addClass(classes | raw) }}>
   {% if figure %}
+    {% set old_figure_with_icon = figure.icon %}
+    {% set old_figure_with_image = figure.image %}
+
     <div class="o-bolt-flag__figure">
       {% block flag_figure %}
-        {% set figureContent %}  
-          {% include "@bolt/figure.twig" with figure only %}
+        {% set figureContent %}
+          {% if old_figure_with_icon %}
+            {% include "@bolt-components-figure/figure.twig" with {
+              media: {
+                icon: old_figure_with_icon
+              }
+            } only %}
+          {% elseif old_figure_with_image %}
+            {% include "@bolt-components-figure/figure.twig" with {
+              media: {
+                image: old_figure_with_image
+              }
+            } only %}
+          {% else %}
+            {% include "@bolt-components-figure/figure.twig" with figure only %}
+          {% endif %}
         {% endset %}
 
         {% if url %}
-          {% include "@bolt/link.twig" with {
+          {% include "@bolt-components-link/link.twig" with {
+            display: "flex",
             url: url,
             text: figureContent
           } only %}
@@ -56,7 +74,7 @@
           {{ item.text }}
         {% endif %}
       {% endfor %}
-      
+
       {{ content }}
 
     {% endblock %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1293

## Summary

Fixes a regression where the flag component went missing.

## Details

I started by cherry picking 9893c60, which is part of https://github.com/bolt-design-system/bolt/pull/1064.  However, I noticed that commit also updated the spacing (before/after shown below, with the narrower one being after):

![flag spacing](https://user-images.githubusercontent.com/677668/57643157-141d2580-7587-11e9-97d6-c7ecfa7f1bc4.gif)

To limit this PR to the bug fix only (and exclude the spacing changes), I included only a subset of the files from Mike's full PR in this PR.

## How to test

### Confirm the regression
- Go to https://v2-3-0.boltdesignsystem.com/pattern-lab/?p=pages-product-landing
- Confirm that flag icons don't show up to the left of the 'Marketing', 'Sales and Automation', etc list items as they did in earlier versions (e.g. https://v2-1-4.boltdesignsystem.com/pattern-lab/?p=pages-product-landing-page)

### Confirm the fix
- Go to `/pattern-lab/?p=pages-product-landing-page` on this PR 
- Confirm that flag icons have been restored
