### PR TITLE
Bolt v2.3.2 Hotfix

### DIFF
--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -55,8 +55,10 @@
         {% endif %}
       </div>
     {% endif %}
-    <figcaption class="{{ "#{base_class}__caption" }}">
-      {{ caption }}
-    </figcaption>
+    {% if caption %}
+      <figcaption class="{{ "#{base_class}__caption" }}">
+        {{ caption }}
+      </figcaption>
+    {% endif %}
   </figure>
 </bolt-figure>

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -34,6 +34,7 @@ class BoltLink extends BoltAction {
 
   render() {
     // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
+    // 2. Zero Width No-break Space (&#xfeff;) is needed to make the last word always stick with the icon, so the icon will never become an orphan.
 
     // Validate the original prop data passed along -- returns back the validated data w/ added default values
     const { display, valign, url, target, isHeadline } = this.validateProps(
@@ -62,9 +63,10 @@ class BoltLink extends BoltAction {
         case 'after':
           const iconClasses = cx('c-bolt-link__icon');
           // [1]
+          // [2]
           // prettier-ignore
           return name in this.slots
-            ? html`<span class="${iconClasses}">${this.slot(name)}</span>`
+            ? html`<span class="${iconClasses}">&#xfeff;${this.slot(name)}</span>`
             : html`<slot name="${name}" />`;
         default:
           const itemClasses = cx('c-bolt-link__text', {

--- a/packages/components/bolt-link/src/link.scss
+++ b/packages/components/bolt-link/src/link.scss
@@ -52,6 +52,7 @@ $bolt-link-spacing: 'xxsmall';
 .c-bolt-link--display-inline {
   .c-bolt-link__icon {
     display: inline;
+    white-space: nowrap; // Combine this with Zero Width No-break Space (&#xfeff; in the markup), it fixes the orphan icon issue. The last word will always wrap with the icon.
   }
 }
 

--- a/packages/global/styles/05-objects/objects-flag/src/flag.twig
+++ b/packages/global/styles/05-objects/objects-flag/src/flag.twig
@@ -29,14 +29,32 @@
 
 <div {{ attributes.addClass(classes | raw) }}>
   {% if figure %}
+    {% set old_figure_with_icon = figure.icon %}
+    {% set old_figure_with_image = figure.image %}
+
     <div class="o-bolt-flag__figure">
       {% block flag_figure %}
-        {% set figureContent %}  
-          {% include "@bolt/figure.twig" with figure only %}
+        {% set figureContent %}
+          {% if old_figure_with_icon %}
+            {% include "@bolt-components-figure/figure.twig" with {
+              media: {
+                icon: old_figure_with_icon
+              }
+            } only %}
+          {% elseif old_figure_with_image %}
+            {% include "@bolt-components-figure/figure.twig" with {
+              media: {
+                image: old_figure_with_image
+              }
+            } only %}
+          {% else %}
+            {% include "@bolt-components-figure/figure.twig" with figure only %}
+          {% endif %}
         {% endset %}
 
         {% if url %}
-          {% include "@bolt/link.twig" with {
+          {% include "@bolt-components-link/link.twig" with {
+            display: "flex",
             url: url,
             text: figureContent
           } only %}
@@ -56,7 +74,7 @@
           {{ item.text }}
         {% endif %}
       {% endfor %}
-      
+
       {{ content }}
 
     {% endblock %}


### PR DESCRIPTION
## Jira
Addresses:
- http://vjira2:8080/browse/BDS-1293
- http://vjira2:8080/browse/BDS-1292

## Summary
1. Fixed a regression where the flag component went missing. #1170 
2. Fixed an issue where the icon inside an inline link gets pushed to its own line. #1169 