### PR TITLE
RFC: Allow js to reveal form input errors

### DIFF
--- a/packages/components/bolt-form/src/form.js
+++ b/packages/components/bolt-form/src/form.js
@@ -40,7 +40,26 @@ for (let i = 0, len = inputs.length; i < len; i++) {
       return;
     }
 
+    input.showErrors();
+  };
+
+  // A custom event listener that allows other scripts to manually show errors.
+  input.addEventListener(
+    'showerrors',
+    function() {
+      input.showErrors();
+    },
+    false,
+  );
+
+  // Callback function to display validation errors for a given input.
+  input.showErrors = function() {
     input.classList.add('is-touched');
+
+    // Clear existing errors.
+    if (input.errors) {
+      input.errors.remove();
+    }
 
     if (input.validationMessage) {
       let error = document.createElement('div');


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1284

## Summary

Adds an event listener to bolt inputs for a new custom `showerrors` event.

## Details

Currently, Bolt's HTML5 form validation issues are invisible until a user blurs an input field.  Additionally, only user input works for this-- scripts that fire the `onblur` event on an input intentionally do NOT reveal these errors (see http://vjira2:8080/browse/WWWD-2345 for an explanation of why we did that).

The goal of this PR is to add a way for js to intentionally reveal validation errors.  The primary use case would be when submitting a form-- if there are validation errors when the user submits, we could stop the submission and fire the `showerrors` event on any invalid field.

## Questions for reviewers
- Is a custom event the best way to allow javascript to show errors for a given field?
- What's the best way to allow form submission to trigger this event for all invalid fields?  I'm thinking a declarative solution where you'd add a class like `js-bolt-validate-before-submit` to a `<form>` element.  If a form with this class contains any `.c-bolt-input:invalid` elements, you cancel submission and fire the `showerrors` event on those invalid elements.

## How to test

On this branch, run the following script.  It should display red bolt form validation errors for the first invalid field on the page.
```
const invalidInput = document.querySelector('.c-bolt-input:invalid');
const showerrors = new CustomEvent('showerrors');
invalidInput.dispatchEvent(showerrors);
```