### PR TITLE
fix(api): handle requests w/o 'Content-Type': 'application/json' header

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,4 +1,5 @@
 const url = require('url');
+const { errorAndExit } = require('@bolt/build-tools/utils/log.js');
 const { render, renderString } = require('@bolt/twig-renderer');
 
 async function getBody(request) {
@@ -54,7 +55,7 @@ async function handleRequest(req, res, next) {
         }
         res.end(html);
       } catch (error) {
-        console.errorAndExit(
+        errorAndExit(
           'Error rendering Twig using the Twig rendering service...',
           error,
         );
@@ -77,7 +78,7 @@ async function handleRequest(req, res, next) {
         }
         res.end(html);
       } catch (error) {
-        console.errorAndExit(
+        errorAndExit(
           'Error rendering Twig string using the Twig rendering service...',
           error,
         );

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -44,7 +44,10 @@ async function handleRequest(req, res, next) {
           console.error('The template paramater is missing!');
         }
         const body = await getBody(req);
-        const { ok, html, message } = await render(query.template, body, true);
+        // if the request is sent w/ the header `'Content-Type': 'application/json'`, body is object, if not then it's a string that needs parsing
+        const data = typeof body === 'string' ? JSON.parse(body) : body;
+
+        const { ok, html, message } = await render(query.template, data, true);
 
         if (!ok) {
           console.error(message);

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,8 @@
     "type": "git",
     "url": "git+https://github.com/bolt-design-system/bolt.git"
   },
-  "peerDependencies": {
+  "dependencies": {
+    "really-relaxed-json": "^0.2.24",
     "@bolt/twig-renderer": ">=2.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15924,6 +15924,11 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+really-relaxed-json@^0.2.24:
+  version "0.2.24"
+  resolved "https://registry.npmjs.org/really-relaxed-json/-/really-relaxed-json-0.2.24.tgz#03122087b1807d450b20366a7b3ae43c55077607"
+  integrity sha512-YaY9fR3c+wKOJFSv5dXsPQGtp7zvuOKlmdzUvQvNI/+Hk1/S0eiH+/Pwj9eMRpxlC59lt/szUAG3BLoJaz8JnQ==
+
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"


### PR DESCRIPTION
## Summary

When rendering via the `/api/render` endpoint and forgetting to include the header of `'Content-Type': 'application/json'`, then this error was seen:

```
PHP TwigRenderer Error: The response callback is expected to resolve with an object implementing Psr\Http\Message\ResponseInterface, but rejected with "TypeError" instead.
```

## Details

Without that header, the body of the request is a string, with that header, it's parsed into an object. This allows both approaches via a conditional that can lead to a `JSON.parse()`. All fixed!

## How to test

Send an API request to `http://localhost:3004/api/render?template=%40bolt-components-text%2Ftext.twig` with the body:

```
{
   "text": "hi"
}
```

Try it with and without the header `'Content-Type': 'application/json'`