### PR TITLE
BDS-709 remove uft8

### DIFF
--- a/packages/components/bolt-list/src/_list-item.twig
+++ b/packages/components/bolt-list/src/_list-item.twig
@@ -20,7 +20,7 @@
   <replace-with-grandchildren>
     <{{ tag }} {{ attributes.addClass(classes) }}>
       {% if item is iterable %}
-        {{ item.content | join }}
+        {{ item.content }}
       {% else %}
         {{ item }}
       {% endif %}

--- a/packages/components/bolt-table/src/table.twig
+++ b/packages/components/bolt-table/src/table.twig
@@ -51,7 +51,7 @@
             %}
             <th {{ cell_attributes.addClass(cell_classes) }} scope="col">
               {% if cell is iterable %}
-                {{ cell.content|join("") }}
+                {{ cell.content }}
               {% else %}
                 {{ cell }}
               {% endif %}
@@ -76,7 +76,7 @@
               {% if cell is not empty %}
                 <th {{ cell_attributes.addClass(cell_classes) }} scope="row">
                   {% if cell is iterable %}
-                    {{ cell.content|join("") }}
+                    {{ cell.content }}
                   {% else %}
                     {{ cell }}
                   {% endif %}
@@ -92,7 +92,7 @@
               %}
               <td {{ cell_attributes.addClass(cell_classes) }}>
                 {% if cell is iterable %}
-                  {{ cell.content|join("") }}
+                  {{ cell.content }}
                 {% else %}
                   {{ cell }}
                 {% endif %}
@@ -110,7 +110,7 @@
               {% if loop.last %}
                 <th class="{{ "#{base_class}__cell #{base_class}__cell--header" }}">
                   {% if cell is iterable %}
-                    {{ cell.content|join("") }}
+                    {{ cell.content }}
                   {% else %}
                     {{ cell }}
                   {% endif %}
@@ -127,7 +127,7 @@
             %}
             <td {{ cell_attributes.addClass(cell_classes) }}>
               {% if cell is iterable %}
-                {{ cell.content|join("") }}
+                {{ cell.content }}
               {% else %}
                 {{ cell }}
               {% endif %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-709

## Summary

Fixes character encoding string "UTF-8" when passing content into table

## Details

Removing the `join` function here fixes the bug, and _as far as we can tell_, it was an unnecessary vestige of some past problem that is no longer present.

Admittedly, removing things that don't appear to be necessary without knowing why they were originally added is a dangerous game.  In this case, the purpose of the join would be to support passing an array of renderable items for {{item.content}}.  I could not find any instance of this happening in pattern lab, and I can't think of any use case where that would be anything more than a convenience.  Given that, I think it's as low risk as you can get without knowing the origin story. 

## How to test

- Go to https://fix-bds-709-remove-uft8.boltdesignsystem.com/pattern-lab/?p=components-table-item-variations and confirm that the original bug is no longer present.
- Confirm no other visible changes in pattern lab
