### PR TITLE
hotfix: update now.sh scaling max config

### DIFF
--- a/now.json
+++ b/now.json
@@ -5,7 +5,7 @@
   "scale": {
     "sfo1": {
       "min": 0,
-      "max": "1"
+      "max": 1
     }
   },
   "features": {

--- a/now.json
+++ b/now.json
@@ -4,8 +4,8 @@
   "type": "docker",
   "scale": {
     "sfo1": {
-      "min": 2,
-      "max": "auto"
+      "min": 0,
+      "max": "1"
     }
   },
   "features": {


### PR DESCRIPTION
Adds a max scale config of 1 to limit the total number of server instances running in the background. Might slow down response times for older servers that haven't been frequently accessed but should hopefully help to keep our "Premium" [now.sh v1 plan](https://zeit.co/account/plan-v1) down in the interim.
