### PR TITLE
Fix Navbar Jest Test + Nightwatch Test Reporting

### DIFF
--- a/packages/components/bolt-navbar/__tests__/navbar.js
+++ b/packages/components/bolt-navbar/__tests__/navbar.js
@@ -203,12 +203,14 @@ describe('<bolt-navbar> Component', () => {
         document.body.appendChild(div);
       }, html);
 
+      const navigationPromise = page.waitForNavigation();
       await page.hover('.c-bolt-navbar__title--link');
 
       const image = await page.screenshot();
       expect(image).toMatchImageSnapshot(imageVrtConfig);
 
-      await page.tap('.c-bolt-navbar__title--link');
+      await page.click('.c-bolt-navbar__title--link');
+      await navigationPromise; // wait for page navigation to finish before verifying the navbar link rendered + brought us to the main docs site
 
       const pageTitle = await page.title();
       expect(pageTitle).toMatch('Bolt Design System');

--- a/scripts/report-nightwatch-results.js
+++ b/scripts/report-nightwatch-results.js
@@ -357,15 +357,15 @@ async function setGithubAppSauceResults(sauceResults) {
 <summary>Screenshots</summary>
 
 ${screenshots
-              .map(
-                (s, i) => `
+  .map(
+    (s, i) => `
 ###### Screenshot ${i}
 
 [![Screenshot ${i}](${s})](${s})
 
 `,
-              )
-              .join('')}
+  )
+  .join('')}
 
 </details>
 
@@ -378,17 +378,6 @@ ${screenshots
       })
       .join('');
 
-    const details = `
-<details>
-  <summary>Full Page Data</summary>
-
-\`\`\`json
-${JSON.stringify(sauceResults, null, '  ')}
-\`\`\`
-  
-</details>  
-    `.trim();
-
     return setCheckRun({
       name: 'Nightwatch',
       status: 'completed',
@@ -397,12 +386,7 @@ ${JSON.stringify(sauceResults, null, '  ')}
         title: `Nightwatch ${passed ? 'Success' : 'Failed'}`,
         summary,
         images: allImages,
-        text: `${text}
-
----
-
-${details}        
-        `,
+        text,
       },
     });
   } catch (error) {

--- a/scripts/report-nightwatch-results.js
+++ b/scripts/report-nightwatch-results.js
@@ -415,6 +415,7 @@ ${details}
 async function go() {
   try {
     const build = `build-${TRAVIS_JOB_NUMBER}`;
+    await sleep(15000); // wait 15 seconds first before tryhing to download assets from Sauce Labs
     const sauceResults = await collectSauceLabResults(build);
     const checkRunSubmitResults = await setGithubAppSauceResults(sauceResults);
     console.log(
@@ -422,6 +423,11 @@ async function go() {
     );
   } catch (err) {
     throw new Error(err);
+    // test if we can still try to send our results even if there's a test failure.
+    const checkRunSubmitResults = await setGithubAppSauceResults(sauceResults);
+    console.log(
+      `Submitted Check Run Results: ${checkRunSubmitResults.html_url}`,
+    );
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1313?filter=-1

## Summary
Fixes a failing Jest test + fixes our Nightwatch.js test reporting logic so the build status is correctly reported + the browser screenshots captured show up again.

## Details
1. Reduces the overall size of the Nightwatch.js test report sent back to Github so we don't exceed the max message size allowed.

![image](https://user-images.githubusercontent.com/1617209/58350358-a3ea8b80-7e33-11e9-9467-c27f6a765079.png)

2. Also adds a slight delay before starting to collect and report back on Nightwatch test results to address occasional issues with the test result asset (image) being requested not being immediately available.

![image](https://user-images.githubusercontent.com/1617209/58350610-5fabbb00-7e34-11e9-8bdc-0dd739e853cb.png)

3. Fixes the Navbar component's Jest test to have Puppeteer wait until page being navigated to has finished loading before the rest continuing. Addresses occasional Navbar test failures that are still popping up from time to time.

![image](https://user-images.githubusercontent.com/1617209/58351679-8ae3d980-7e37-11e9-943f-f8c4d18adf50.png)

## How to test
1. Does the Travis Nightwatch test status for this update / complete when finished?
2. Do Jest tests pass?
