### PR TITLE
Fix: remove development code from homepage

### DIFF
--- a/docs-site/src/templates/homepage.twig
+++ b/docs-site/src/templates/homepage.twig
@@ -3,9 +3,6 @@
 {% set content %}
   {% set band_content %}
 
-{% include "@bolt-components-stack/stack.twig" with {
-  content: "This is another stack."
-} only %}
     {% include "@bolt-site/animated-shapes.twig" %}
 
     <svg style="display: none;" width="1" height="1" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Jira

N/A

## Summary

Removes a piece of junk code from the homepage.

## Details

There's a piece of development code that didn't get removed while working on the Stack component. This fix removes it and make sure the homepage is not broken.

## How to test

Check the homepage and make sure there's no extra content other than the banner, the nav, the logo, the tagline, and the buttons.
