### PR TITLE
fix: Restore Bolt namespaces	on Drupal admin info page

### DIFF
--- a/packages/drupal-modules/bolt_connect/src/Controller/BoltConnectController.php
+++ b/packages/drupal-modules/bolt_connect/src/Controller/BoltConnectController.php
@@ -42,11 +42,16 @@ class BoltConnectController extends ControllerBase {
     }
 
     $config = \Drupal::config('bolt_connect.settings');
-    $namespaces = \Drupal::service('bolt_connect.twig_namespaces');
+    $twig_namespaces = \Drupal::service('bolt_connect.twig_namespaces');
+
+    $namespaces = [];
+    foreach ($twig_namespaces->getNamespaces() as $namespace) {
+      $namespaces[$namespace]['paths'] = $twig_namespaces->getPaths($namespace);
+    }
 
     return [
       '#theme' => 'bolt_info_page',
-      '#namespaces' => $namespaces->twigLoaderConfig,
+      '#namespaces' => $namespaces,
       '#functions' => $functions,
       '#filters' => $filters,
     ];


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1400

## Summary

Restores missing namespaces on bolt_connect info page

## Details

When #1086 was merged, there was regression where the namespaces list on the bolt_connect module info page was now blank.  Specifically, once the data is cached on the first page load, subsequent loads don't populate the `BoltConnectTwigNamespaces->twigLoaderConfig` property.

![Namespaces empty](https://user-images.githubusercontent.com/677668/59068952-af9e6f00-8883-11e9-9213-7fae43e9fd88.png)

This PR restores that list without adding extra overhead to any page except the bolt_connect info page at `/admin/config/bolt_connect/info`.

![With namepaces (expected)](https://user-images.githubusercontent.com/677668/59068933-a1505300-8883-11e9-8eb9-b95689f504d4.png)

## How to test

Pull this version of the module into Drupal (either Drupal Lab or an actual site) and confirm that namespaces show as expected at `/admin/config/bolt_connect/info`.

Note: while it is a regression, it's not urgent enough to warrant a hotfix all by itself.  If a 1.4.x hotfix turns out to be necessary for some other reason, we may as well include it; otherwise, we can just merge into master instead.