### PR TITLE
Fix: selectively hide less essential video controls for smaller screens

### DIFF
--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -66,18 +66,18 @@ $bolt-video-background-max-height: 50.625vw;
   max-width: none;
   transition: transform 0.4s cubic-bezier(0.645, 0, 0.355, 1);
 
-  // Force icons to be visible at smaller layout sizes
+  // Force control icons to be visible at smaller layout sizes, commented out names are shown here to indicate which ones are hidden.
   .video-js.vjs-layout-tiny,
   .video-js.vjs-layout-x-small,
   .video-js.vjs-layout-small {
     &:not(.vjs-fullscreen) {
+      /* .vjs-time-divider, */
+      /* .vjs-duration, */
+      /* .vjs-volume-panel, */
+      /* .vjs-volume-control, */
       .vjs-mute-control,
-      .vjs-volume-panel,
-      .vjs-volume-control,
       .vjs-playback-rate,
       .vjs-current-time,
-      .vjs-time-divider,
-      .vjs-duration,
       .vjs-button.vjs-share-control {
         display: flex;
       }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1405
http://vjira2:8080/browse/BDS-1377

## Summary

Hide certain video controls when video is playing in smaller screens.

## Details

Removed some CSS overrides that were forcing ALL the controls to be visible in smaller screens. Now the video player will hide volume and duration controls in smaller screens, to make sure the toolbar is not overflowing. Volume and duration controls are available natively, so they are not essential to be shown in the toolbar.

## How to test

Run the branch locally, go to the video doc pages, and view those pages in small screen sizes. Make sure the toolbar fits all the controls and nothing is overflowing.
