### PR TITLE
Feature/breadcrumb tests

### DIFF
--- a/packages/components/bolt-breadcrumb/TESTING.md
+++ b/packages/components/bolt-breadcrumb/TESTING.md
@@ -1,23 +1,36 @@
-# Breadcrumb testing steps
+# Breadcrumb component testing steps
 
-## Breadcrumb render as expected
+## Breadcrumb render as expected (visually)
+                                 
+The server-side pre-rendered `bolt-breadcrumb` component should look almost identical to the client-side rendered version. To verify:
 
-- Component is rendered as `bolt-breadcrumb` with four text items seperated by a chevron (">"). The first three are inline links and the last one is the "Current Page".
+1. Disable javascript and view the [Breadcrumb Demo page](https://boltdesignsystem.com/pattern-lab/patterns/02-components-breadcrumb-05-breadcrumb/02-components-breadcrumb-05-breadcrumb.html).
+2. Then, enable javascript and watch the Breadcrumb re-renders on the client-side.
+3. The layout and styling should not change. The spacing in between each breadcrumb segment should be identical before and after enabling javascript.
 
-  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-05-breadcrumb/02-components-breadcrumb-05-breadcrumb.html`
-  
-- Breadcrumb's last item is a link that includes the attribute `aria-current`
-  
-  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-10-breadcrumb-current-page-aria-variation/02-components-breadcrumb-10-breadcrumb-current-page-aria-variation.html`
-  
-- Attributes passed to element are added to it
-  
-  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-05-breadcrumb/02-components-breadcrumb-05-breadcrumb.html`
-  
-## Icon as web component render as expected
+# List component functional testing steps
 
-- Component is rendered as `bolt-breadcrumb` with rendered text
-- By adding `url` attribute we can add link to breadcrumb
-- Attributes passed to element are added to it
+Functional testing should be performed manually by the QA team across the standard compliment of browsers. In each scenario, browser-type is specified when necessary. If browser type is not specified, the test applies to both "desktop" and "mobile" browsers.
 
-  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-10-breadcrumb-with-web-component/02-components-breadcrumb-10-breadcrumb-with-web-component.html`
+## Feature: breadcrumb
+
+    In order to present a secondary navigation scheme to reveal a user's location on a website
+    As a UX designer, developer or content administrator
+    I need to ensure the "bolt-breadcrumb" component renders and functions as expected
+
+## Scenario: basic variation
+
+1. Given I am viewing the [basic variation](https://www.boltdesignsystem.com/pattern-lab/patterns/02-components-breadcrumb-05-breadcrumb/02-components-breadcrumb-05-breadcrumb.html).
+2. Four segments of text should be visible, with segments seperated by a right facing chevron (">").
+3. The first three segments are links and are styled as links (colored text and underlined).
+
+## Scenario: "aria-current" variation
+
+1. Given I am viewing the ["aria-current" variation](https://www.boltdesignsystem.com/pattern-lab/patterns/02-components-breadcrumb-10-breadcrumb-current-page-aria-variation/02-components-breadcrumb-10-breadcrumb-current-page-aria-variation.html).
+2. Four segments of text should be visible, with segments seperated by a right facing chevron (">").
+3. All four segments are links and are styled as links (colored text and underlined).
+
+## Scenario: keyboard navigation
+
+1. Given I am viewing the [basic variation](https://www.boltdesignsystem.com/pattern-lab/patterns/02-components-breadcrumb-05-breadcrumb/02-components-breadcrumb-05-breadcrumb.html).
+2. Each link segment can be focused using the keyboard (by pressing tab).

--- a/packages/components/bolt-breadcrumb/TESTING.md
+++ b/packages/components/bolt-breadcrumb/TESTING.md
@@ -8,7 +8,7 @@ The server-side pre-rendered `bolt-breadcrumb` component should look almost iden
 2. Then, enable javascript and watch the Breadcrumb re-renders on the client-side.
 3. The layout and styling should not change. The spacing in between each breadcrumb segment should be identical before and after enabling javascript.
 
-# List component functional testing steps
+# Breadcrumb component functional testing steps
 
 Functional testing should be performed manually by the QA team across the standard compliment of browsers. In each scenario, browser-type is specified when necessary. If browser type is not specified, the test applies to both "desktop" and "mobile" browsers.
 

--- a/packages/components/bolt-breadcrumb/TESTING.md
+++ b/packages/components/bolt-breadcrumb/TESTING.md
@@ -1,0 +1,23 @@
+# Breadcrumb testing steps
+
+## Breadcrumb render as expected
+
+- Component is rendered as `bolt-breadcrumb` with four text items seperated by a chevron (">"). The first three are inline links and the last one is the "Current Page".
+
+  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-05-breadcrumb/02-components-breadcrumb-05-breadcrumb.html`
+  
+- Breadcrumb's last item is a link that includes the attribute `aria-current`
+  
+  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-10-breadcrumb-current-page-aria-variation/02-components-breadcrumb-10-breadcrumb-current-page-aria-variation.html`
+  
+- Attributes passed to element are added to it
+  
+  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-05-breadcrumb/02-components-breadcrumb-05-breadcrumb.html`
+  
+## Icon as web component render as expected
+
+- Component is rendered as `bolt-breadcrumb` with rendered text
+- By adding `url` attribute we can add link to breadcrumb
+- Attributes passed to element are added to it
+
+  Testing URL: `pattern-lab/patterns/02-components-breadcrumb-10-breadcrumb-with-web-component/02-components-breadcrumb-10-breadcrumb-with-web-component.html`

--- a/packages/components/bolt-breadcrumb/__tests__/__snapshots__/breadcrumb.js.snap
+++ b/packages/components/bolt-breadcrumb/__tests__/__snapshots__/breadcrumb.js.snap
@@ -44,7 +44,7 @@ exports[`<bolt-breadcrumb> Component basic usage with attributes 1`] = `
 </bolt-breadcrumb>
 `;
 
-exports[`<bolt-breadcrumb> Component basic usage with contentItems including links and strings 1`] = `
+exports[`<bolt-breadcrumb> Component basic usage with contentItems including rendered components and strings 1`] = `
 <bolt-breadcrumb bolt-component>
   <nav class="c-bolt-breadcrumb"
        aria-label="Breadcrumb"

--- a/packages/components/bolt-breadcrumb/__tests__/__snapshots__/breadcrumb.js.snap
+++ b/packages/components/bolt-breadcrumb/__tests__/__snapshots__/breadcrumb.js.snap
@@ -1,0 +1,242 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<bolt-breadcrumb> Component basic usage with attributes 1`] = `
+"<bolt-breadcrumb bolt-component>
+  <nav  data-foobar=\\"baz\\" aria-role=\\"list\\" class=\\"c-bolt-breadcrumb\\" aria-label=\\"Breadcrumb\\" role=\\"navigation\\">
+    <ol class=\\"c-bolt-breadcrumb__list\\">
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          <bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Home</replace-with-children></a></bolt-link>
+        </li>
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          <bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Other Page</replace-with-children></a></bolt-link>
+        </li>
+          </ol>
+  </nav>
+</bolt-breadcrumb>"
+`;
+
+exports[`<bolt-breadcrumb> Component basic usage with contentItems including links and strings 1`] = `
+"<bolt-breadcrumb bolt-component>
+  <nav  class=\\"c-bolt-breadcrumb\\" aria-label=\\"Breadcrumb\\" role=\\"navigation\\">
+    <ol class=\\"c-bolt-breadcrumb__list\\">
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Home</replace-with-children></a></bolt-link>
+        </li>
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Landing Page</replace-with-children></a></bolt-link>
+        </li>
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Sub Page</replace-with-children></a></bolt-link>
+        </li>
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          Current Page
+        </li>
+          </ol>
+  </nav>
+</bolt-breadcrumb>"
+`;
+
+exports[`<bolt-breadcrumb> Component current page aria variation 1`] = `
+"<bolt-breadcrumb bolt-component>
+  <nav  class=\\"c-bolt-breadcrumb\\" aria-label=\\"Breadcrumb\\" role=\\"navigation\\">
+    <ol class=\\"c-bolt-breadcrumb__list\\">
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Home</replace-with-children></a></bolt-link>
+        </li>
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Landing Page</replace-with-children></a></bolt-link>
+        </li>
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+  
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+    
+  ><replace-with-children class=\\"c-bolt-link__text\\">Sub Page</replace-with-children></a></bolt-link>
+        </li>
+              <li class=\\"c-bolt-breadcrumb__item\\">
+          
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<bolt-link
+   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
+      
+   aria-current
+><a
+     href=\\"#!\\"         is=\\"shadow-root\\"
+    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
+     aria-current
+  ><replace-with-children class=\\"c-bolt-link__text\\">Current Page</replace-with-children></a></bolt-link>
+        </li>
+          </ol>
+  </nav>
+</bolt-breadcrumb>"
+`;

--- a/packages/components/bolt-breadcrumb/__tests__/__snapshots__/breadcrumb.js.snap
+++ b/packages/components/bolt-breadcrumb/__tests__/__snapshots__/breadcrumb.js.snap
@@ -1,242 +1,179 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<bolt-breadcrumb> Component basic usage with attributes 1`] = `
-"<bolt-breadcrumb bolt-component>
-  <nav  data-foobar=\\"baz\\" aria-role=\\"list\\" class=\\"c-bolt-breadcrumb\\" aria-label=\\"Breadcrumb\\" role=\\"navigation\\">
-    <ol class=\\"c-bolt-breadcrumb__list\\">
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          <bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Home</replace-with-children></a></bolt-link>
-        </li>
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          <bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Other Page</replace-with-children></a></bolt-link>
-        </li>
-          </ol>
+<bolt-breadcrumb bolt-component>
+  <nav data-foobar="baz"
+       aria-role="list"
+       class="c-bolt-breadcrumb"
+       aria-label="Breadcrumb"
+       role="navigation"
+  >
+    <ol class="c-bolt-breadcrumb__list">
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Home
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Other Page
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+    </ol>
   </nav>
-</bolt-breadcrumb>"
+</bolt-breadcrumb>
 `;
 
 exports[`<bolt-breadcrumb> Component basic usage with contentItems including links and strings 1`] = `
-"<bolt-breadcrumb bolt-component>
-  <nav  class=\\"c-bolt-breadcrumb\\" aria-label=\\"Breadcrumb\\" role=\\"navigation\\">
-    <ol class=\\"c-bolt-breadcrumb__list\\">
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
-
-<bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Home</replace-with-children></a></bolt-link>
-        </li>
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
-
-<bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Landing Page</replace-with-children></a></bolt-link>
-        </li>
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
-
-<bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Sub Page</replace-with-children></a></bolt-link>
-        </li>
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          Current Page
-        </li>
-          </ol>
+<bolt-breadcrumb bolt-component>
+  <nav class="c-bolt-breadcrumb"
+       aria-label="Breadcrumb"
+       role="navigation"
+  >
+    <ol class="c-bolt-breadcrumb__list">
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Home
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Landing Page
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Sub Page
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+      <li class="c-bolt-breadcrumb__item">
+        Current Page
+      </li>
+    </ol>
   </nav>
-</bolt-breadcrumb>"
+</bolt-breadcrumb>
 `;
 
 exports[`<bolt-breadcrumb> Component current page aria variation 1`] = `
-"<bolt-breadcrumb bolt-component>
-  <nav  class=\\"c-bolt-breadcrumb\\" aria-label=\\"Breadcrumb\\" role=\\"navigation\\">
-    <ol class=\\"c-bolt-breadcrumb__list\\">
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
-
-<bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Home</replace-with-children></a></bolt-link>
-        </li>
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
-
-<bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Landing Page</replace-with-children></a></bolt-link>
-        </li>
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
-
-<bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-  
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-    
-  ><replace-with-children class=\\"c-bolt-link__text\\">Sub Page</replace-with-children></a></bolt-link>
-        </li>
-              <li class=\\"c-bolt-breadcrumb__item\\">
-          
-
-
-
-
-
-  
-
-
-
-
-
-
-
-
-
-<bolt-link
-   display=\\"inline\\"    valign=\\"center\\"    url=\\"#!\\"       
-      
-   aria-current
-><a
-     href=\\"#!\\"         is=\\"shadow-root\\"
-    class=\\"c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center\\"
-     aria-current
-  ><replace-with-children class=\\"c-bolt-link__text\\">Current Page</replace-with-children></a></bolt-link>
-        </li>
-          </ol>
+<bolt-breadcrumb bolt-component>
+  <nav class="c-bolt-breadcrumb"
+       aria-label="Breadcrumb"
+       role="navigation"
+  >
+    <ol class="c-bolt-breadcrumb__list">
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Home
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Landing Page
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Sub Page
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+      <li class="c-bolt-breadcrumb__item">
+        <bolt-link display="inline"
+                   valign="center"
+                   url="#!"
+                   aria-current
+        >
+          <a href="#!"
+             is="shadow-root"
+             class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+             aria-current
+          >
+            <replace-with-children class="c-bolt-link__text">
+              Current Page
+            </replace-with-children>
+          </a>
+        </bolt-link>
+      </li>
+    </ol>
   </nav>
-</bolt-breadcrumb>"
+</bolt-breadcrumb>
 `;

--- a/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
+++ b/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
@@ -1,6 +1,4 @@
-// import { render } from '@bolt/twig-renderer';
-const renderer = require('@bolt/twig-renderer');
-const { renderString, render } = renderer;
+import { render, renderString } from '@bolt/twig-renderer';
 
 describe('<bolt-breadcrumb> Component', () => {
   test('basic usage with attributes', async () => {

--- a/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
+++ b/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
@@ -1,0 +1,82 @@
+// import { render } from '@bolt/twig-renderer';
+const renderer = require('@bolt/twig-renderer');
+const { renderString, render } = renderer;
+
+describe('<bolt-breadcrumb> Component', () => {
+  test('basic usage with attributes', async () => {
+    const linkOne = await render('@bolt-components-link/link.twig', {
+      text: 'Home',
+      url: '#!',
+    });
+    const linkTwo = await render('@bolt-components-link/link.twig', {
+      text: 'Other Page',
+      url: '#!',
+    });
+    const results = await render(
+      '@bolt-components-breadcrumb/breadcrumb.twig',
+      {
+        contentItems: [linkOne.html, linkTwo.html],
+        attributes: {
+          'data-foobar': 'baz',
+          'aria-role': 'list',
+        },
+      },
+    );
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
+  test('basic usage with contentItems including links and strings', async () => {
+    const results = await renderString(`
+{% include "@bolt-components-breadcrumb/breadcrumb.twig" with {
+  "contentItems": [
+    include("@bolt-components-link/link.twig", {
+      "text": "Home",
+      "url": "#!"
+    }),
+    include("@bolt-components-link/link.twig", {
+      "text": "Landing Page",
+      "url": "#!"
+    }),
+    include("@bolt-components-link/link.twig", {
+      "text": "Sub Page",
+      "url": "#!"
+    }),
+    "Current Page"
+  ]
+} only %}
+    `);
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
+  test('current page aria variation', async () => {
+    const results = await renderString(`
+{% include "@bolt-components-breadcrumb/breadcrumb.twig" with {
+  "contentItems": [
+    include("@bolt-components-link/link.twig", {
+      text: "Home",
+      url: "#!"
+    }),
+    include("@bolt-components-link/link.twig", {
+      text: "Landing Page",
+      url: "#!"
+    }),
+    include("@bolt-components-link/link.twig", {
+      text: "Sub Page",
+      url: "#!"
+    }),
+    include("@bolt-components-link/link.twig", {
+      text: "Current Page",
+      url: "#!",
+      attributes: {
+        "aria-current": true
+      },
+    }),
+  ]
+} only %}
+    `);
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+});

--- a/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
+++ b/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
@@ -24,7 +24,7 @@ describe('<bolt-breadcrumb> Component', () => {
     expect(results.html).toMatchSnapshot();
   });
 
-  test('basic usage with contentItems including links and strings', async () => {
+  test('basic usage with contentItems including rendered components and strings', async () => {
     const results = await renderString(`
 {% include "@bolt-components-breadcrumb/breadcrumb.twig" with {
   "contentItems": [

--- a/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
+++ b/packages/components/bolt-breadcrumb/__tests__/breadcrumb.js
@@ -27,18 +27,18 @@ describe('<bolt-breadcrumb> Component', () => {
   test('basic usage with contentItems including rendered components and strings', async () => {
     const results = await renderString(`
 {% include "@bolt-components-breadcrumb/breadcrumb.twig" with {
-  "contentItems": [
+  contentItems: [
     include("@bolt-components-link/link.twig", {
-      "text": "Home",
-      "url": "#!"
+      text: "Home",
+      url: "#!"
     }),
     include("@bolt-components-link/link.twig", {
-      "text": "Landing Page",
-      "url": "#!"
+      text: "Landing Page",
+      url: "#!"
     }),
     include("@bolt-components-link/link.twig", {
-      "text": "Sub Page",
-      "url": "#!"
+      text: "Sub Page",
+      url: "#!"
     }),
     "Current Page"
   ]
@@ -51,7 +51,7 @@ describe('<bolt-breadcrumb> Component', () => {
   test('current page aria variation', async () => {
     const results = await renderString(`
 {% include "@bolt-components-breadcrumb/breadcrumb.twig" with {
-  "contentItems": [
+  contentItems: [
     include("@bolt-components-link/link.twig", {
       text: "Home",
       url: "#!"


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-940

## Summary

This is my first attempt to expand testing for a Bolt Component (Breadcrumb in this case).

## Details

I added three jest snapshot tests based on the use cases for Breadcrumb in PL:
- basic usage with attributes
- basic usage with contentItems including both rendered components and strings
- "current page aria" variation

I also took a stab at writing up the TESTING.md file based off what I saw in other testing.md files.

@margoromo The two line items from the ticket I was unsure of where:
- Docs on usage / best practices 
- Consolidated kitchen sink page for automated visual regression testing

## How to test

- Review file changes below
- Run 'yarn test:js' locally to make sure everything passes
