### PR TITLE
feat: remove srcset not found example from image page

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/image/15-image-source-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/image/15-image-source-variations.twig
@@ -37,20 +37,6 @@
   alt: "Bill Murray",
 } only %}
 
-<h4>Srcset only that won't be found in <code>bolt.data.images</code> and not lazy loaded</h4>
-{% include '@bolt-components-image/image.twig' with {
-  srcset: "/images/placeholders/500x500-320.jpg 1w",
-  alt: "Bill Murray",
-  lazyload: false,
-} only %}
-
-<h4>Srcset only that won't be found in <code>bolt.data.images</code> and lazy loaded</h4>
-{% include '@bolt-components-image/image.twig' with {
-  srcset: "/images/placeholders/500x500-320.jpg 1w",
-  alt: "Bill Murray",
-  lazyload: true,
-} only %}
-
 <h4>Absolute src - not lazy loaded</h4>
 {% include '@bolt-components-image/image.twig' with {
   src: "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg",


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1289

## Summary

Remove the image examples from the docs-site where srcset is not found in bolt data. This was originally included so that all possible config options were shown, but this one is not needed for our documentation and causing confusion amongst the QA team.

Before merging, I will be sure to update release notes so that the QA team is expecting this visual change and does not flag as a regression.

## Details

n/a

## How to test

- Are you ok with these demos being removed?
- Review the code changes
