### PR TITLE
Move getModifiedSchema to base

### DIFF
--- a/packages/components/bolt-blockquote/src/blockquote.js
+++ b/packages/components/bolt-blockquote/src/blockquote.js
@@ -78,22 +78,6 @@ class BoltBlockquote extends withLitHtml() {
     }
   }
 
-  getModifiedSchema(schema) {
-    var modifiedSchema = schema;
-
-    // Remove "content" from schema, does not apply to web component.
-    for (let property in modifiedSchema.properties) {
-      if (property === 'content') {
-        delete modifiedSchema.properties[property];
-      }
-    }
-
-    const index = modifiedSchema.required.indexOf('content');
-    modifiedSchema.required.splice(index, 1);
-
-    return modifiedSchema;
-  }
-
   getAlignItemsOption(prop) {
     switch (prop) {
       case 'right':

--- a/packages/components/bolt-image/src/image.js
+++ b/packages/components/bolt-image/src/image.js
@@ -34,21 +34,11 @@ class BoltImage extends withLitHtml() {
   constructor(self) {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
-    self.schema = this.getModifiedSchema(schema);
+    self.schema = this.getModifiedSchema(schema, [
+      'lazyload',
+      'useAspectRatio',
+    ]);
     return self;
-  }
-
-  getModifiedSchema(schema) {
-    var modifiedSchema = schema;
-
-    // Remove "lazyload" and "useAspectRatio" from schema, does not apply to web component.
-    for (let property in modifiedSchema.properties) {
-      if (property === 'lazyload' || property === 'useAspectRatio') {
-        delete modifiedSchema.properties[property];
-      }
-    }
-
-    return modifiedSchema;
   }
 
   lazyloadImage(image) {

--- a/packages/core/renderers/bolt-base.js
+++ b/packages/core/renderers/bolt-base.js
@@ -100,6 +100,45 @@ export function BoltBase(Base = HTMLElement) {
       return validatedData;
     }
 
+    /**
+     * Get modified version of schema, removing any properties not wanted on Web Component
+     * @param {object} schema A valid JSON schema
+     * @param {(string|string[])} propsToRemove A prop or list of props to be removed from the schema
+     * @returns {object} returns the modified JSON schema
+     */
+    getModifiedSchema(schema, propsToRemove = 'content') {
+      let modifiedSchema = schema;
+
+      if (typeof propsToRemove === 'string') {
+        propsToRemove = [propsToRemove];
+      }
+
+      try {
+        propsToRemove.forEach(item => {
+          if (modifiedSchema.properties && modifiedSchema.properties[item]) {
+            // Delete property key from schema
+            delete modifiedSchema.properties[item];
+          }
+
+          if (modifiedSchema.required) {
+            const index = modifiedSchema.required.indexOf(item);
+            if (index !== -1) {
+              // Remove from list of required fields
+              modifiedSchema.required.splice(index, 1);
+              if (!modifiedSchema.required.length) {
+                // If no required props remain, just delete the whole key
+                delete modifiedSchema.required;
+              }
+            }
+          }
+        });
+      } catch (e) {
+        console.warn(e.message, e.name);
+      }
+
+      return modifiedSchema;
+    }
+
     addStyles(stylesheet) {
       let styles = Array.from(stylesheet);
       styles = styles.join(' ');


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1135

## Summary

`getModifiedSchema()` is now used in image and blockquote components and will probably be used in more. Move it to base so that all components can benefit from the work we've already done.

## Details

I moved `getModifiedSchema()` to base and refactored it so that it accepts a list of props to be removed. Previously it was hardcoded.

The default value of `propsToRemove` is `content`. If you want to remove `content` *and* pass in additional props you must include `content` in the array, e.g. `getModifiedSchema(schema, ['content', 'prop2', 'prop3'])`.

## How to test

- Review code changes
- Run feature branch locally and view the blockquote and image demos
  - Verify there are no errors or visual regressions on these pages
  - Temporarily pass in additional props and log the modified schema to test that it's removing those props, e.g.:
```
// in blockquote.js
  constructor(self) {
    self = super(self);
    self.useShadow = hasNativeShadowDomSupport;
    self.schema = this.getModifiedSchema(schema, ['content', 'indent', 'border']); // <--
    console.log(self.schema.properties); // <--
    return self;
  }
```
