### PR TITLE
Fix / Improve Modal Animation

### DIFF
--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -37,7 +37,7 @@ $bolt-modal-border-radius: bolt-border-radius(small);
 $bolt-modal-max-height: 80vh;
 $bolt-modal-transition: $bolt-transition;
 $bolt-modal-breakpoint: 'small';
-$bolt-modal-animation-scale: 0.8;
+$bolt-modal-animation-scale: 0.95;
 
 // Hide all the non-trigger (button / link, etc) content inside the <bolt-modal> container before the JS kicks in
 bolt-modal:not([ready]) {
@@ -55,7 +55,6 @@ bolt-modal:not([ready]) {
   width: 100vw;
   height: 100vh;
   pointer-events: none;
-  background-color: $bolt-modal-overlay-bg-color-dark;
   transition: opacity $bolt-modal-transition;
   overflow-x: hidden;
   overflow-y: hidden;
@@ -70,8 +69,7 @@ bolt-modal:not([ready]) {
   @include bolt-mq($until: $bolt-modal-breakpoint) {
     visibility: hidden;
     opacity: 0;
-    transform: scale(0.95);
-    transition: opacity $bolt-modal-transition, transform $bolt-modal-transition;
+    transition: opacity $bolt-modal-transition;
 
     [class*='t-bolt-'] {
       color: bolt-color(black);
@@ -127,13 +125,12 @@ bolt-modal:not([ready]) {
     &.is-open {
       visibility: visible;
       opacity: 1;
-      transform: scale(1);
-      filter: blur(0);
     }
   }
 }
 
-// Dark overlay
+// Overlay color options
+.c-bolt-modal,
 .c-bolt-modal--overlay-dark {
   @include bolt-mq($bolt-modal-breakpoint) {
     background-color: $bolt-modal-overlay-bg-color-dark;
@@ -190,7 +187,7 @@ bolt-modal:not([ready]) {
       pointer-events: auto;
 
       .c-bolt-modal__content {
-        transform: translateX(0) translateY(-50%) scale(1) translateZ(0) perspective(1px); // The perspective hack here is to prevent the content from getting too blurry, a common CSS bug that happens to element with transform. Please note that this sub-pixel issue still persists at random breakpoints.
+        transform: translateX(0) translateY(-50%) translateZ(0) perspective(1px); // The perspective hack here is to prevent the content from getting too blurry, a common CSS bug that happens to element with transform. Please note that this sub-pixel issue still persists at random breakpoints.
       }
     }
   }
@@ -204,7 +201,7 @@ bolt-modal:not([ready]) {
 
     &.is-open {
       .c-bolt-modal__content {
-        transform: translateX(-50%) translateY(-50%) scale(1) translateZ(0) perspective(1px); // The perspective hack here is to prevent the content from getting too blurry, a common CSS bug that happens to element with transform. Please note that this sub-pixel issue still persists at random breakpoints.
+        transform: translateX(-50%) translateY(-50%) translateZ(0) perspective(1px); // The perspective hack here is to prevent the content from getting too blurry, a common CSS bug that happens to element with transform. Please note that this sub-pixel issue still persists at random breakpoints.
       }
     }
 
@@ -230,12 +227,12 @@ bolt-modal:not([ready]) {
 // Container
 .c-bolt-modal__container {
   display: block;
-  opacity: 0;
+  opacity: bolt-opacity(0);
   transform: scale($bolt-modal-animation-scale);
   transition: opacity $bolt-modal-transition, transform $bolt-modal-transition;
 
-  .c-bolt-modal.is-open & {
-    opacity: 1;
+  @at-root .c-bolt-modal.is-open #{&} {
+    opacity: bolt-opacity(100);
     transform: scale(1);
   }
 

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -155,7 +155,6 @@ bolt-modal:not([ready]) {
 
   @include bolt-mq($bolt-modal-breakpoint) {
     visibility: hidden; // @todo: once we figure out how to prevent keyboard access to modal content when the modal is closed, we can remove this line.
-    opacity: 0;
     position: fixed;
     top: 0;
     left: 0;
@@ -168,7 +167,6 @@ bolt-modal:not([ready]) {
   @at-root .c-bolt-modal.is-open #{&} {
     @include bolt-mq($bolt-modal-breakpoint) {
       visibility: visible; // @todo: once we figure out how to prevent keyboard access to modal content when the modal is closed, we can remove this line.
-      opacity: 1;
       cursor: auto;
     }
   }
@@ -231,6 +229,14 @@ bolt-modal:not([ready]) {
 // Container
 .c-bolt-modal__container {
   display: block;
+  opacity: 0;
+  transform: scale($bolt-modal-animation-scale);
+  transition: opacity $bolt-modal-transition, transform $bolt-modal-transition;
+
+  .c-bolt-modal.is-open & {
+    opacity: 1;
+    transform: scale(1);
+  }
 
   @include bolt-mq($bolt-modal-breakpoint) {
     border-radius: $bolt-modal-border-radius;

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -37,6 +37,7 @@ $bolt-modal-border-radius: bolt-border-radius(small);
 $bolt-modal-max-height: 80vh;
 $bolt-modal-transition: $bolt-transition;
 $bolt-modal-breakpoint: 'small';
+$bolt-modal-animation-scale: 0.8;
 
 // Hide all the non-trigger (button / link, etc) content inside the <bolt-modal> container before the JS kicks in
 bolt-modal:not([ready]) {
@@ -154,20 +155,21 @@ bolt-modal:not([ready]) {
   background: transparent;
 
   @include bolt-mq($bolt-modal-breakpoint) {
-    visibility: hidden; // @todo: once we figure out how to prevent keyboard access to modal content when the modal is closed, we can remove this line.
+    visibility: hidden;
     position: fixed;
     top: 0;
     left: 0;
     min-width: 200px; // Prevents content without defined width (such as image and video) from falling below 200px.
     max-width: calc(100% - #{bolt-spacing(medium) * 2});
     max-height: $bolt-modal-max-height;
-    transition: opacity $bolt-modal-transition, transform $bolt-modal-transition;
+    transition: visibility $bolt-transition-timing $bolt-transition-ease $bolt-transition-timing;
   }
 
   @at-root .c-bolt-modal.is-open #{&} {
     @include bolt-mq($bolt-modal-breakpoint) {
       visibility: visible; // @todo: once we figure out how to prevent keyboard access to modal content when the modal is closed, we can remove this line.
       cursor: auto;
+      transition: visibility 0s $bolt-transition-ease 0s;
     }
   }
 }
@@ -177,10 +179,9 @@ bolt-modal:not([ready]) {
   .c-bolt-modal--scroll-overall {
     .c-bolt-modal__content {
       @include bolt-margin(0 auto);
-
       position: relative;
       top: 50vh;
-      transform: translateX(0) translateY(-50%) scale(0.95);
+      transform: translateX(0) translateY(-50%);
     }
 
     &.is-open {
@@ -198,7 +199,7 @@ bolt-modal:not([ready]) {
     .c-bolt-modal__content {
       top: 50%;
       left: 50%;
-      transform: translateX(-50%) translateY(-50%) scale(0.95);
+      transform: translateX(-50%) translateY(-50%);
     }
 
     &.is-open {

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -68,7 +68,7 @@ bolt-modal:not([ready]) {
 
   @include bolt-mq($until: $bolt-modal-breakpoint) {
     visibility: hidden;
-    opacity: 0;
+    opacity: bolt-opacity(0);
     transition: opacity $bolt-modal-transition;
 
     [class*='t-bolt-'] {
@@ -124,7 +124,7 @@ bolt-modal:not([ready]) {
 
     &.is-open {
       visibility: visible;
-      opacity: 1;
+      opacity: bolt-opacity(100);
     }
   }
 }
@@ -164,7 +164,7 @@ bolt-modal:not([ready]) {
 
   @at-root .c-bolt-modal.is-open #{&} {
     @include bolt-mq($bolt-modal-breakpoint) {
-      visibility: visible; // @todo: once we figure out how to prevent keyboard access to modal content when the modal is closed, we can remove this line.
+      visibility: visible;
       cursor: auto;
       transition: visibility 0s $bolt-transition-ease 0s;
     }


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1431

## Summary
Adjusts how the new modal component's open / close animation is handled so the animation no longer skips to being open + the close animation fades the entire container correctly.

**Before:**
![CleanShot 2019-06-19 at 15 25 26](https://user-images.githubusercontent.com/1617209/59794351-c5119100-92a6-11e9-95ef-66378c218b39.gif)

**After:**
![2019-06-19 15-37-29 2019-06-19 15_41_54](https://user-images.githubusercontent.com/1617209/59795239-ce036200-92a8-11e9-82b0-2128b9fc61ff.gif)


## How to test
- Review code changes
- Confirm build passes as expected
- Manually test out the updated animation