### PR TITLE
Carousel | QA | Fix various JS issues

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/25-carousel-basic-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/25-carousel-basic-variations.twig
@@ -356,7 +356,7 @@
     ]
   } only %}
 
-  {# @todo: This is throwing lots of errors in the console #}
+  {# @todo: Requires more testing. It still throws errors when loop="true" and you resize too quickly, something to do with Brightcove cloning slides (?). Also, might want to add JS to pause a video when you navigate away from it. #}
   {# <h3>A carousel of videos</h3>
   {% include "@bolt-components-carousel/carousel.twig" with {
     loop: true,

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/15-figure-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/15-figure-with-web-component.twig
@@ -11,7 +11,7 @@
 
 {% set figure_web_component_demo %}
 <bolt-figure>
-  <img src="/images/placeholders/landscape-16x9-mountains.jpg" slot="media" />
+  <bolt-image src="/images/placeholders/landscape-16x9-mountains.jpg" slot="media"></bolt-image>
   This is a caption. Lorem ipsum <em>dolor sit amet</em>, consectetur adipiscing elit <a href="#">text link</a>.
 </bolt-figure>
 {% endset %}

--- a/packages/components/bolt-figure/__tests__/__snapshots__/figure.js.snap
+++ b/packages/components/bolt-figure/__tests__/__snapshots__/figure.js.snap
@@ -2,182 +2,206 @@
 
 exports[`figure figure with icon 1`] = `
 <bolt-figure>
-  <figure class="c-bolt-figure">
-    <div class="c-bolt-figure__media">
-      <bolt-icon name="add-open"
-                 size="large"
-      >
-      </bolt-icon>
-    </div>
-    <figcaption class="c-bolt-figure__caption">
-      Figure with icon.
-    </figcaption>
-  </figure>
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-icon name="add-open"
+                     size="large"
+          >
+          </bolt-icon>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with icon.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
 </bolt-figure>
 `;
 
 exports[`figure figure with image 1`] = `
 <bolt-figure>
-  <figure class="c-bolt-figure">
-    <div class="c-bolt-figure__media">
-      <bolt-image src="/fixtures/landscape-16x9-mountains.jpg"
-                  srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w"
-                  sizes="auto"
-                  ratio="1151/638"
-                  no-lazy
-                  style="background-color: hsl(233, 33%, 97%);"
-      >
-        <bolt-ratio ratio="1151/638">
-          <replace-with-children class="c-bolt-ratio"
-                                 style="padding-bottom: calc((638 / 1151) * 100%); --aspect-ratio: 1.8040752351097;"
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-image src="/fixtures/landscape-16x9-mountains.jpg"
+                      srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w"
+                      sizes="auto"
+                      ratio="1151/638"
+                      no-lazy
+                      style="background-color: hsl(233, 33%, 97%);"
           >
-            <img class="c-bolt-image__image-placeholder"
-                 sizes="auto"
-                 src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
-            >
-            <img class="c-bolt-image__image"
-                 srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w"
-                 sizes="auto"
-                 src="/fixtures/landscape-16x9-mountains.jpg"
-            >
-          </replace-with-children>
-        </bolt-ratio>
-      </bolt-image>
-    </div>
-    <figcaption class="c-bolt-figure__caption">
-      Figure with image.
-    </figcaption>
-  </figure>
+            <bolt-ratio ratio="1151/638">
+              <replace-with-children class="c-bolt-ratio"
+                                     style="padding-bottom: calc((638 / 1151) * 100%); --aspect-ratio: 1.8040752351097;"
+              >
+                <img class="c-bolt-image__image-placeholder"
+                     sizes="auto"
+                     src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                >
+                <img class="c-bolt-image__image"
+                     srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w"
+                     sizes="auto"
+                     src="/fixtures/landscape-16x9-mountains.jpg"
+                >
+              </replace-with-children>
+            </bolt-ratio>
+          </bolt-image>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with image.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
 </bolt-figure>
 `;
 
 exports[`figure figure with table 1`] = `
 <bolt-figure>
-  <figure class="c-bolt-figure">
-    <div class="c-bolt-figure__media">
-      <bolt-table format="regular">
-        <table class="c-bolt-table">
-          <thead class="c-bolt-table__head">
-            <tr class="c-bolt-table__row">
-              <td class="c-bolt-table__cell">
-              </td>
-              <th class="c-bolt-table__cell c-bolt-table__cell--header"
-                  scope="col"
-              >
-                Column 1
-              </th>
-              <th class="c-bolt-table__cell c-bolt-table__cell--header"
-                  scope="col"
-              >
-                Column 2
-              </th>
-              <th class="c-bolt-table__cell c-bolt-table__cell--header"
-                  scope="col"
-              >
-                Column 3
-              </th>
-            </tr>
-          </thead>
-          <tbody class="c-bolt-table__body">
-            <tr class="c-bolt-table__row">
-              <th class="c-bolt-table__cell c-bolt-table__cell--header"
-                  scope="row"
-              >
-                Row 1
-              </th>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R1C1
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R1C2
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R1C3
-              </td>
-            </tr>
-            <tr class="c-bolt-table__row">
-              <th class="c-bolt-table__cell c-bolt-table__cell--header"
-                  scope="row"
-              >
-                Row 2
-              </th>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R2C1
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R2C2
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R2C3
-              </td>
-            </tr>
-            <tr class="c-bolt-table__row">
-              <th class="c-bolt-table__cell c-bolt-table__cell--header"
-                  scope="row"
-              >
-                Row 3
-              </th>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R3C1
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R3C2
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                R3C3
-              </td>
-            </tr>
-          </tbody>
-          <tfoot class="c-bolt-table__foot">
-            <tr class="c-bolt-table__row">
-              <th class="c-bolt-table__cell c-bolt-table__cell--header">
-                Footer
-              </th>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                FC1
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                FC2
-              </td>
-              <td class="c-bolt-table__cell c-bolt-table__cell--data">
-                FC3
-              </td>
-            </tr>
-          </tfoot>
-        </table>
-      </bolt-table>
-    </div>
-    <figcaption class="c-bolt-figure__caption">
-      Figure with table.
-    </figcaption>
-  </figure>
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-table format="regular">
+            <table class="c-bolt-table">
+              <thead class="c-bolt-table__head">
+                <tr class="c-bolt-table__row">
+                  <td class="c-bolt-table__cell">
+                  </td>
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="col"
+                  >
+                    Column 1
+                  </th>
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="col"
+                  >
+                    Column 2
+                  </th>
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="col"
+                  >
+                    Column 3
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="c-bolt-table__body">
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="row"
+                  >
+                    Row 1
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R1C1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R1C2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R1C3
+                  </td>
+                </tr>
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="row"
+                  >
+                    Row 2
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R2C1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R2C2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R2C3
+                  </td>
+                </tr>
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="row"
+                  >
+                    Row 3
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R3C1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R3C2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R3C3
+                  </td>
+                </tr>
+              </tbody>
+              <tfoot class="c-bolt-table__foot">
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header">
+                    Footer
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    FC1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    FC2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    FC3
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </bolt-table>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with table.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
 </bolt-figure>
 `;
 
 exports[`figure figure with video 1`] = `
 <bolt-figure>
-  <figure class="c-bolt-figure">
-    <div class="c-bolt-figure__media">
-      <bolt-ratio ratio="16/9">
-        <replace-with-children class="c-bolt-ratio"
-                               style="padding-bottom: calc((9 / 16) * 100%); --aspect-ratio: 1.7777777777778;"
-        >
-          <bolt-video class="js-bolt-video-uuid--12345"
-                      video-id="3861325118001"
-                      account-id="1900410236"
-                      show-meta
-                      show-meta-title
-                      player-id="r1CAdLzTW"
-                      controls
-                      share-description="Share This Video"
-          >
-          </bolt-video>
-        </replace-with-children>
-      </bolt-ratio>
-    </div>
-    <figcaption class="c-bolt-figure__caption">
-      Figure with video.
-    </figcaption>
-  </figure>
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-ratio ratio="16/9">
+            <replace-with-children class="c-bolt-ratio"
+                                   style="padding-bottom: calc((9 / 16) * 100%); --aspect-ratio: 1.7777777777778;"
+            >
+              <bolt-video class="js-bolt-video-uuid--12345"
+                          video-id="3861325118001"
+                          account-id="1900410236"
+                          show-meta
+                          show-meta-title
+                          player-id="r1CAdLzTW"
+                          controls
+                          share-description="Share This Video"
+              >
+              </bolt-video>
+            </replace-with-children>
+          </bolt-ratio>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with video.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
 </bolt-figure>
 `;

--- a/packages/components/bolt-figure/src/figure.js
+++ b/packages/components/bolt-figure/src/figure.js
@@ -13,7 +13,6 @@ import styles from './figure.scss';
 let cx = classNames.bind(styles);
 
 @define
-@convertInitialTags('figure') // The first matching tag will have its attributes converted to component props
 class BoltFigure extends withLitHtml() {
   static is = 'bolt-figure';
 
@@ -25,8 +24,6 @@ class BoltFigure extends withLitHtml() {
 
   render() {
     const classes = cx('c-bolt-figure');
-
-    let renderedFigure;
 
     const slotMarkup = name => {
       switch (name) {
@@ -57,15 +54,9 @@ class BoltFigure extends withLitHtml() {
 
     const innerSlots = [slotMarkup('media'), slotMarkup('default')];
 
-    if (this.rootElement) {
-      renderedFigure = this.rootElement.firstChild.cloneNode(true);
-      renderedFigure.className += ' ' + classes;
-      render(this.slot('default'), renderedFigure);
-    } else {
-      renderedFigure = html`
-        <figure class="${classes}">${innerSlots}</figure>
-      `;
-    }
+    let renderedFigure = html`
+      <figure class="${classes}">${innerSlots}</figure>
+    `;
 
     return html`
       ${this.addStyles([styles])} ${renderedFigure}

--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -36,29 +36,35 @@
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ attributes|without('class') }}
 >
-  <figure {{ inner_attributes.addClass(inner_classes) }}>
-    {% if media %}
-      <div class="{{ "#{base_class}__media" }}">
-        {% set image = media.image %}
-        {% set icon = media.icon %}
-        {% set video = media.video %}
-        {% set table = media.table %}
+  <replace-with-grandchildren>
+    <figure {{ inner_attributes.addClass(inner_classes) }}>
+      {% if media %}
+        <replace-with-children class="{{ "#{base_class}__media" }}">
+          <div slot="media">
+            {% set image = media.image %}
+            {% set icon = media.icon %}
+            {% set video = media.video %}
+            {% set table = media.table %}
 
-        {% if image %}
-          {% include "@bolt-components-image/image.twig" with image only %}
-        {% elseif icon %}
-          {% include "@bolt-components-icon/icon.twig" with icon only %}
-        {% elseif video %}
-          {% include "@bolt-components-video/video.twig" with video only %}
-        {% elseif table %}
-          {% include "@bolt-components-table/table.twig" with table only %}
-        {% endif %}
-      </div>
-    {% endif %}
-    {% if caption %}
-      <figcaption class="{{ "#{base_class}__caption" }}">
-        {{ caption }}
-      </figcaption>
-    {% endif %}
-  </figure>
+            {% if image %}
+              {% include "@bolt-components-image/image.twig" with image only %}
+            {% elseif icon %}
+              {% include "@bolt-components-icon/icon.twig" with icon only %}
+            {% elseif video %}
+              {% include "@bolt-components-video/video.twig" with video only %}
+            {% elseif table %}
+              {% include "@bolt-components-table/table.twig" with table only %}
+            {% endif %}
+          </div>
+        </replace-with-children>
+      {% endif %}
+      {% if caption %}
+        <replace-with-grandchildren>
+          <figcaption class="{{ "#{base_class}__caption" }}">
+            {{ caption }}
+          </figcaption>
+        </replace-with-grandchildren>
+      {% endif %}
+    </figure>
+  </replace-with-grandchildren>
 </bolt-figure>


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1338

## Summary

Fix JS bugs in carousel component.

## Details

Carousel clones slides when `loop` is `true`. When `bolt-figure` elements were cloned they were not properly re-rendering. Update the Twig and JS so that initial tags are properly replaced by JS template each time it renders.

## How to test

tbd
