### PR TITLE
Fix: typo in image modal's caption markup

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/40-modal-usage-image-and-caption.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/40-modal-usage-image-and-caption.twig
@@ -10,7 +10,7 @@
     } only %}
   {% endset %}
   {% set caption %}
-    <div class="u-bolt-padding-top-xsmall u-bolt-padding-right-small u-bolt-padding-bottom-small u-bolt-padding-left-small" slot="footer">
+    <div class="u-bolt-padding-top-xsmall u-bolt-padding-right-small u-bolt-padding-bottom-small u-bolt-padding-left-small">
       {% include "@bolt-components-headline/text.twig" with {
         text: "This is the caption for the image.",
         size: "small",
@@ -87,7 +87,7 @@
     } only %}
   {% endset %}
   {% set caption %}
-    <div class="u-bolt-padding-top-xsmall u-bolt-padding-right-small u-bolt-padding-bottom-small u-bolt-padding-left-small" slot="footer">
+    <div class="u-bolt-padding-top-xsmall u-bolt-padding-right-small u-bolt-padding-bottom-small u-bolt-padding-left-small">
       {% include "@bolt-components-headline/text.twig" with {
         text: "This is the caption for the image.",
         size: "small",


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixed a typo in the image modal caption's markup that causes the caption text to not render.

## Details

`slot="footer"` was accidentally used on the figcaption container, which is a goof from an older mockup.

## How to test

Run the branch locally and make sure image modal examples have captions.
