### PR TITLE
test: add type checking of JS using TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "test:js": "NODE_ENV='test' jest --all --colors",
     "test:js:update": "yarn run test:js -u",
     "test:monorepo": "jest __tests__/monorepo.test.js -c jest.config.quick.js",
-    "test:php": "cd packages/core-php -- composer run test"
+    "test:php": "cd packages/core-php -- composer run test",
+    "test:types": "tsc"
   },
   "husky": {
     "hooks": {
@@ -110,7 +111,8 @@
     "npm-run-all": "^4.1.5",
     "proxy-polyfill": "^0.3.0",
     "release-it": "^12.2.2",
-    "semantic-release": "^15.13.12"
+    "semantic-release": "^15.13.12",
+    "typescript": "^3.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/uikit-workshop/src/scripts/components/styleguide.js
+++ b/packages/uikit-workshop/src/scripts/components/styleguide.js
@@ -14,7 +14,7 @@
 // (function(w) {
 //   let sw = document.body.clientWidth; //Viewport Width
 
-  
+
 
   // const viewportResizeHandleWidth = 14; //Width of the viewport drag-to-resize handle
   // const $sgIframe = $('.pl-js-iframe'); //Viewport element
@@ -295,19 +295,19 @@
   //     } else {
   //       theSize = size;
   //     }
-  
+
   //     //Conditionally remove CSS animation class from viewport
   //     if (animate === false) {
   //       $('.pl-js-vp-iframe-container, .pl-js-iframe').removeClass('vp-animate'); //If aninate is set to false, remove animate class from viewport
   //     } else {
   //       $('.pl-js-vp-iframe-container, .pl-js-iframe').addClass('vp-animate');
   //     }
-  
+
   //     $('.pl-js-vp-iframe-container').width(theSize + viewportResizeHandleWidth); //Resize viewport wrapper to desired size + size of drag resize handler
   //     $sgIframe.width(theSize); //Resize viewport to desired size
   //     const state = store.getState();
   //     const isViewallPage = state.app.isViewallPage;
-  
+
   //     const targetOrigin =
   //       window.location.protocol === 'file:'
   //         ? '*'
@@ -319,7 +319,7 @@
   //     document
   //       .querySelector('.pl-js-iframe')
   //       .contentWindow.postMessage(obj, targetOrigin);
-  
+
   //     updateSizeReading(theSize); //Update values in toolbar
   //     saveSize(theSize); //Save current viewport to cookie
   //   }
@@ -495,7 +495,7 @@
 
         // // reset the defaults
         // urlHandler.skipBack = false;
-        
+
       } else if (data.event === 'patternLab.keyPress') {
         if (data.keyPress === 'ctrl+shift+s') {
           goSmall();
@@ -532,4 +532,4 @@
     }
   }
   window.addEventListener('message', receiveIframeMessage, false);
-})(this);
+// })(this);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,32 @@
 {
+  "include": [
+    "packages",
+    "scripts"
+  ],
+  "exclude": [
+    "dist",
+    "www",
+    "packages/generators/yeoman-create-component/generators/component",
+    "packages/components/bolt-icons/",
+    "packages/components/bolt-icon",
+  ],
   "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
     "target": "esnext",
+    "jsx": "react",
     "module": "esnext",
     "lib": ["es2017", "dom"],
     "sourceMap": true,
-    "allowJs": true,
     "moduleResolution": "node",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+  },
+  "typeAcquisition": {
+    "enable": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,9 +781,9 @@
     sleep-promise "^8.0.1"
 
 "@bolt/components-page-footer@file:packages/components/bolt-page-footer":
-  version "2.5.1"
+  version "2.5.2"
   dependencies:
-    "@bolt/core" "^2.5.1"
+    "@bolt/core" "^2.5.2"
 
 "@ckeditor/ckeditor5-build-classic@^12.1.0":
   version "12.2.0"
@@ -5999,7 +5999,7 @@ debug@4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -9584,7 +9584,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -11464,7 +11464,7 @@ libnpm@^2.0.1:
     read-package-json "^2.0.13"
     stringify-package "^1.0.0"
 
-libnpmaccess@*, libnpmaccess@^3.0.1:
+libnpmaccess@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
   integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
@@ -11493,7 +11493,7 @@ libnpmhook@^5.0.2:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmorg@*, libnpmorg@^1.0.0:
+libnpmorg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
   integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
@@ -11518,7 +11518,7 @@ libnpmpublish@^1.1.0:
     semver "^5.5.1"
     ssri "^6.0.1"
 
-libnpmsearch@*, libnpmsearch@^2.0.0:
+libnpmsearch@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.1.tgz#eccc73a8fbf267d765d18082b85daa2512501f96"
   integrity sha512-K0yXyut9MHHCAH+DOiglQCpmBKPZXSUu76+BE2maSEfQN15OwNaA/Aiioe9lRFlVFOr7WcuJCY+VSl+gLi9NTA==
@@ -11527,7 +11527,7 @@ libnpmsearch@*, libnpmsearch@^2.0.0:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmteam@*, libnpmteam@^1.0.1:
+libnpmteam@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
   integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
@@ -11777,11 +11777,6 @@ lodash._basefor@^3.0.0:
   resolved "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz#7550b4e9218ef09fad24343b612021c79b4c20c2"
   integrity sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -11790,22 +11785,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
 
 lodash._createset@~4.0.0:
   version "4.0.3"
@@ -11822,7 +11805,7 @@ lodash._createwrapper@~2.4.1:
     lodash._slice "~2.4.1"
     lodash.isfunction "~2.4.1"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -12122,11 +12105,6 @@ lodash.reject@4.6.0, lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.result@4.5.2:
   version "4.5.2"
@@ -13562,7 +13540,7 @@ npm-pick-manifest@^2.2.3:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
-npm-profile@*, npm-profile@^4.0.1:
+npm-profile@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
   integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==
@@ -16376,7 +16354,7 @@ readdir-enhanced@^1.4.0:
     es6-promise "^4.1.0"
     glob-to-regexp "^0.3.0"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
@@ -19379,6 +19357,11 @@ typedarray@^0.0.6:
 typescript@^3.5.1:
   version "3.5.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+
+typescript@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 ua-parser-js@0.7.17:


### PR DESCRIPTION
This add type checking (not compiling) of JS files using TypeScript via `yarn test:types`. Currently there are a lot of errors coming in and fine tuning the `includes` and `excludes` properties in `tsconfig.json` would be a good start to narrow the focus would be a good idea. The big advantage from this is much better editor auto-completion.