### PR TITLE
Hotfix: Fix `@bolt/build-tools` CLI `--config-file` Option

### DIFF
--- a/example-integrations/drupal-lab/web/themes/bolt-starter/.boltrc--ja.js
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/.boltrc--ja.js
@@ -1,0 +1,11 @@
+// Older method for generating a Japanese language-specific version of the build
+const config = require('./.boltrc.js');
+const updatedConfig =  Object.assign(config, {
+  lang: 'ja',
+  buildDir: './dist--ja',
+  dataDir: './dist--ja/data',
+  wwwDir: './dist--ja',
+  publicPath: '/themes/bolt-starter/dist--ja/',
+});
+
+module.exports = updatedConfig;

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/.gitignore
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/.gitignore
@@ -1,1 +1,2 @@
 dist
+dist--ja

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/__tests__/index.js
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/__tests__/index.js
@@ -31,4 +31,41 @@ describe('Check that the bolt-starter build has compiled as expected', () => {
     expect(colorData.indigo.xdark).toBe('rgb(6, 9, 35)');
     expect(colorData.yellow.base).toBe('rgb(255, 204, 77)');
   });
+
+  test('Check that a separate lang-specific build compiles as expected', async () => {
+    const getColorData = async function(){
+      try {
+        await fs.promises.access(path.resolve(__dirname, "../dist--ja/data/colors/brand.bolt.json"));
+        const colorData = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../dist--ja/data/colors/brand.bolt.json")));
+        return colorData;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    const colorData = await getColorData();
+
+    expect(colorData.indigo.xdark).toBe('rgb(6, 9, 35)');
+    expect(colorData.yellow.base).toBe('rgb(255, 204, 77)');
+  });
+
+  test('Check that the JA-specific CSS contains the correct font', async () => {
+    const getCSSData = async function(){
+      try {
+        const cssData = fs.readFileSync(path.resolve(__dirname, '../dist--ja/bolt-global-ja.css')).toString();
+        return cssData;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    const cssFile = await getCSSData();
+
+    const japaneseFontRule = 'font-family:-apple-system,BlinkMacSystemFont,"ヒラギノ角ゴ ProN","Hiragino Kaku Gothic ProN","游ゴシック","游ゴシック体",YuGothic,"Yu Gothic","メイリオ",Meiryo,"ＭＳ ゴシック","MS Gothic",HiraKakuProN-W3,"TakaoExゴシック",TakaoExGothic,MotoyaLCedar,"Droid Sans Japanese",sans-serif;';
+
+    const englishFontFamilyRule = 'font-family:"Open Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-heading)';
+
+    expect(cssFile).toEqual(expect.stringContaining(japaneseFontRule));
+    expect(cssFile).toEqual(expect.not.stringContaining(englishFontFamilyRule));
+  });
 });

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/__tests__/index.js
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/__tests__/index.js
@@ -61,7 +61,7 @@ describe('Check that the bolt-starter build has compiled as expected', () => {
 
     const cssFile = await getCSSData();
 
-    const japaneseFontRule = 'font-family:-apple-system,BlinkMacSystemFont,"ヒラギノ角ゴ ProN","Hiragino Kaku Gothic ProN","游ゴシック","游ゴシック体",YuGothic,"Yu Gothic","メイリオ",Meiryo,"ＭＳ ゴシック","MS Gothic",HiraKakuProN-W3,"TakaoExゴシック",TakaoExGothic,MotoyaLCedar,"Droid Sans Japanese",sans-serif;';
+    const japaneseFontRule = 'font-family:-apple-system,BlinkMacSystemFont,ヒラギノ角ゴ ProN,Hiragino Kaku Gothic ProN,游ゴシック,游ゴシック体,YuGothic,Yu Gothic,メイリオ,Meiryo,ＭＳ ゴシック,MS Gothic,HiraKakuProN-W3,TakaoExゴシック,TakaoExGothic,MotoyaLCedar,Droid Sans Japanese,sans-serif;';
 
     const englishFontFamilyRule = 'font-family:"Open Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-heading)';
 

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/package.json
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/package.json
@@ -7,7 +7,9 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bolt build --prod",
+    "build": "FORCE_COLOR=1 npx npm-run-all --parallel --aggregate-output build:*",
+    "build:en": "bolt build --prod",
+    "build:ja": "bolt build --prod --config-file .boltrc--ja.js",
     "start": "bolt start",
     "test": "jest __tests__/index.js",
     "postinstall": "patch-package"

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/package.json
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/package.json
@@ -9,11 +9,15 @@
   "scripts": {
     "build": "bolt build --prod",
     "start": "bolt start",
-    "test": "jest __tests__/index.js"
+    "test": "jest __tests__/index.js",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "jest": "^24.8.0",
+    "patch-package": "^6.1.2",
+    "postinstall-postinstall": "^2.0.0",
     "@bolt/build-tools": "latest",
+    "@bolt/build-utils": "latest",
     "@bolt/components-button": "latest",
     "@bolt/components-headline": "latest",
     "@bolt/components-icon": "latest",

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/patches/@bolt+build-tools+2.5.2.patch
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/patches/@bolt+build-tools+2.5.2.patch
@@ -1,0 +1,152 @@
+diff --git a/node_modules/@bolt/build-tools/LICENSE b/node_modules/@bolt/build-tools/LICENSE
+deleted file mode 100644
+index 0946736..0000000
+--- a/node_modules/@bolt/build-tools/LICENSE
++++ /dev/null
+@@ -1,21 +0,0 @@
+-MIT License
+-
+-Copyright (c) 2019 Pegasystems
+-
+-Permission is hereby granted, free of charge, to any person obtaining a copy
+-of this software and associated documentation files (the "Software"), to deal
+-in the Software without restriction, including without limitation the rights
+-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-copies of the Software, and to permit persons to whom the Software is
+-furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in all
+-copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-SOFTWARE.
+diff --git a/node_modules/@bolt/build-tools/cli.js b/node_modules/@bolt/build-tools/cli.js
+index b50f5eb..f7f1af9 100755
+--- a/node_modules/@bolt/build-tools/cli.js
++++ b/node_modules/@bolt/build-tools/cli.js
+@@ -5,21 +5,14 @@ const program = require('commander');
+ const cosmiconfig = require('cosmiconfig');
+ const explorer = cosmiconfig('bolt');
+ const configStore = require('@bolt/build-utils/config-store');
++const log = require('@bolt/build-utils/log');
+ const { readYamlFileSync } = require('@bolt/build-utils/yaml');
+ const configSchema = readYamlFileSync(
+   path.join(__dirname, './utils/config.schema.yml'),
+ );
+ const packageJson = require('./package.json');
+ 
+-const searchedFor = explorer.searchSync();
+-if (!searchedFor.config) {
+-  log.errorAndExit('Could not find config in a .boltrc file');
+-}
+-
+-let userConfig = {
+-  ...searchedFor.config,
+-  configFileUsed: searchedFor.filepath,
+-};
++let userConfig;
+ 
+ // global `bolt` cli options & meta
+ program
+@@ -47,6 +40,16 @@ if (program.configFile) {
+     ...configFile,
+     configFileUsed: configFilePath,
+   };
++} else {
++  try {
++    const searchedFor = explorer.searchSync();
++    userConfig = {
++      ...searchedFor.config,
++      configFileUsed: searchedFor.filepath,
++    };
++  } catch (error) {
++    log.errorAndExit('Could not find config in a .boltrc file', error);
++  }
+ }
+ 
+ (async () => {
+diff --git a/node_modules/@bolt/build-tools/create-webpack-config.js b/node_modules/@bolt/build-tools/create-webpack-config.js
+index 1f44ee2..03de6e5 100644
+--- a/node_modules/@bolt/build-tools/create-webpack-config.js
++++ b/node_modules/@bolt/build-tools/create-webpack-config.js
+@@ -15,15 +15,15 @@ const WriteFilePlugin = require('write-file-webpack-plugin');
+ const npmSass = require('npm-sass');
+ const merge = require('webpack-merge');
+ const SassDocPlugin = require('@bolt/sassdoc-webpack-plugin');
+-const { getConfig } = require('./utils/config-store');
+-const { boltWebpackProgress } = require('./utils/webpack-helpers');
+-const { webpackStats, statsPreset } = require('./utils/webpack-verbosity');
++const { getConfig } = require('@bolt/build-utils/config-store');
++const { boltWebpackProgress } = require('@bolt/build-utils/webpack-helpers');
++const { webpackStats, statsPreset } = require('@bolt/build-utils/webpack-verbosity');
+ 
+ const {
+   getBoltManifest,
+   mapComponentNameToTwigNamespace,
+-} = require('./utils/manifest');
+-const log = require('./utils/log');
++} = require('@bolt/build-utils/manifest');
++const log = require('@bolt/build-utils/log');
+ 
+ // Store set of webpack configs used in multiple builds
+ let webpackConfigs = [];
+diff --git a/node_modules/@bolt/build-tools/plugins/postcss-themify/LICENSE b/node_modules/@bolt/build-tools/plugins/postcss-themify/LICENSE
+deleted file mode 100644
+index 0946736..0000000
+--- a/node_modules/@bolt/build-tools/plugins/postcss-themify/LICENSE
++++ /dev/null
+@@ -1,21 +0,0 @@
+-MIT License
+-
+-Copyright (c) 2019 Pegasystems
+-
+-Permission is hereby granted, free of charge, to any person obtaining a copy
+-of this software and associated documentation files (the "Software"), to deal
+-in the Software without restriction, including without limitation the rights
+-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-copies of the Software, and to permit persons to whom the Software is
+-furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in all
+-copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-SOFTWARE.
+diff --git a/node_modules/@bolt/build-tools/tasks/api-tasks/bolt-versions.js b/node_modules/@bolt/build-tools/tasks/api-tasks/bolt-versions.js
+index d84190f..e9b1b45 100644
+--- a/node_modules/@bolt/build-tools/tasks/api-tasks/bolt-versions.js
++++ b/node_modules/@bolt/build-tools/tasks/api-tasks/bolt-versions.js
+@@ -47,8 +47,8 @@ const octokit = new Octokit({
+   debug: false,
+ });
+ 
+-const { getConfig } = require('../../utils/config-store');
+-const { fileExists } = require('../../utils/general');
++const { getConfig } = require('@bolt/build-utils/config-store');
++const { fileExists } = require('@bolt/build-utils/general');
+ const store = new InCache();
+ let isUsingOldData = false; // remember if we are using up to date version data or older (stale) data as a fallback
+ 
+diff --git a/node_modules/@bolt/build-tools/tasks/criticalcss-tasks.js b/node_modules/@bolt/build-tools/tasks/criticalcss-tasks.js
+index a1e7fc7..db98faf 100644
+--- a/node_modules/@bolt/build-tools/tasks/criticalcss-tasks.js
++++ b/node_modules/@bolt/build-tools/tasks/criticalcss-tasks.js
+@@ -1,7 +1,7 @@
+ // const penthouse = require('penthouse');
+ // const fs = require('fs');
+ // const path = require('path');
+-// const { getConfig } = require('../utils/config-store');
++// const { getConfig } = require('@bolt/build-utils/config-store');
+ // let config;
+ 
+ // async function build() {

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/patches/@bolt+build-tools+2.5.2.patch
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/patches/@bolt+build-tools+2.5.2.patch
@@ -71,10 +71,10 @@ index b50f5eb..f7f1af9 100755
  
  (async () => {
 diff --git a/node_modules/@bolt/build-tools/create-webpack-config.js b/node_modules/@bolt/build-tools/create-webpack-config.js
-index 1f44ee2..03de6e5 100644
+index 1f44ee2..53e95ca 100644
 --- a/node_modules/@bolt/build-tools/create-webpack-config.js
 +++ b/node_modules/@bolt/build-tools/create-webpack-config.js
-@@ -15,15 +15,15 @@ const WriteFilePlugin = require('write-file-webpack-plugin');
+@@ -15,15 +15,18 @@ const WriteFilePlugin = require('write-file-webpack-plugin');
  const npmSass = require('npm-sass');
  const merge = require('webpack-merge');
  const SassDocPlugin = require('@bolt/sassdoc-webpack-plugin');
@@ -83,7 +83,10 @@ index 1f44ee2..03de6e5 100644
 -const { webpackStats, statsPreset } = require('./utils/webpack-verbosity');
 +const { getConfig } = require('@bolt/build-utils/config-store');
 +const { boltWebpackProgress } = require('@bolt/build-utils/webpack-helpers');
-+const { webpackStats, statsPreset } = require('@bolt/build-utils/webpack-verbosity');
++const {
++  webpackStats,
++  statsPreset,
++} = require('@bolt/build-utils/webpack-verbosity');
  
  const {
    getBoltManifest,

--- a/example-integrations/drupal-lab/web/themes/bolt-starter/yarn.lock
+++ b/example-integrations/drupal-lab/web/themes/bolt-starter/yarn.lock
@@ -851,7 +851,7 @@
     yaml-loader "^0.5.0"
     yargs "^13.2.4"
 
-"@bolt/build-utils@^2.5.2":
+"@bolt/build-utils@^2.5.2", "@bolt/build-utils@latest":
   version "2.5.2"
   resolved "https://registry.npmjs.org/@bolt/build-utils/-/build-utils-2.5.2.tgz#de9f72f3c25090cb23bbe1851768b04318569ff1"
   integrity sha512-LlowNSwhGb17YoKIX9w1EPOZ0ao5cwF8Tj7pBScuuH2MvqBSSkRD8ueCVjVDjlFiEb4/ZhKd5/J+CjoK1QDO8A==
@@ -1587,6 +1587,11 @@
   version "4.2.2"
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 a-sync-waterfall@^1.0.0:
   version "1.0.1"
@@ -4660,6 +4665,14 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 findup-sync@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -4820,6 +4833,15 @@ fs-extra@^2.0.0:
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
@@ -6795,6 +6817,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -8424,6 +8453,25 @@ pascalcase@^0.1.1:
   resolved "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.npmjs.org/patch-package/-/patch-package-6.1.2.tgz#9ed0b3defb5c34ecbef3f334ddfb13e01b3d3ff6"
+  integrity sha512-5GnzR8lEyeleeariG+hGabUnD2b1yL7AIGFjlLo95zMGRWhZCel58IpeKD46wwPb7i+uNhUI8unV56ogk8Bgqg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    update-notifier "^2.5.0"
+
 path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -8949,6 +8997,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.5
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postinstall-postinstall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.0.0.tgz#7ba6711b4420575c4f561638836a81faad47f43f"
+  integrity sha512-3f6qWexsHiT4WKtZc5DRb0FPLilHtARi5KpY4fqban/DJNn8/YhZH8U7dVKVz51WbOxEnR31gV+qYQhvEdHtdQ==
 
 preact-compat@^3.18.5:
   version "3.19.0"

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -12,15 +12,7 @@ const configSchema = readYamlFileSync(
 );
 const packageJson = require('./package.json');
 
-const searchedFor = explorer.searchSync();
-if (!searchedFor.config) {
-  log.errorAndExit('Could not find config in a .boltrc file');
-}
-
-let userConfig = {
-  ...searchedFor.config,
-  configFileUsed: searchedFor.filepath,
-};
+let userConfig;
 
 // global `bolt` cli options & meta
 program
@@ -48,6 +40,16 @@ if (program.configFile) {
     ...configFile,
     configFileUsed: configFilePath,
   };
+} else {
+  try {
+    const searchedFor = explorer.searchSync();
+    userConfig = {
+      ...searchedFor.config,
+      configFileUsed: searchedFor.filepath,
+    };
+  } catch (error) {
+    log.errorAndExit('Could not find config in a .boltrc file', error);
+  }
 }
 
 (async () => {

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -8,7 +8,7 @@ const configStore = require('@bolt/build-utils/config-store');
 const log = require('@bolt/build-utils/log');
 const { readYamlFileSync } = require('@bolt/build-utils/yaml');
 const configSchema = readYamlFileSync(
-  path.join(__dirname, '@bolt/build-utils/config.schema.yml'),
+  path.join(__dirname, './utils/config.schema.yml'),
 );
 const packageJson = require('./package.json');
 

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -8,7 +8,7 @@ const configStore = require('@bolt/build-utils/config-store');
 const log = require('@bolt/build-utils/log');
 const { readYamlFileSync } = require('@bolt/build-utils/yaml');
 const configSchema = readYamlFileSync(
-  path.join(__dirname, './utils/config.schema.yml'),
+  path.join(__dirname, '@bolt/build-utils/config.schema.yml'),
 );
 const packageJson = require('./package.json');
 

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -5,6 +5,7 @@ const program = require('commander');
 const cosmiconfig = require('cosmiconfig');
 const explorer = cosmiconfig('bolt');
 const configStore = require('@bolt/build-utils/config-store');
+const log = require('@bolt/build-utils/log');
 const { readYamlFileSync } = require('@bolt/build-utils/yaml');
 const configSchema = readYamlFileSync(
   path.join(__dirname, './utils/config.schema.yml'),

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -17,7 +17,10 @@ const merge = require('webpack-merge');
 const SassDocPlugin = require('@bolt/sassdoc-webpack-plugin');
 const { getConfig } = require('@bolt/build-utils/config-store');
 const { boltWebpackProgress } = require('@bolt/build-utils/webpack-helpers');
-const { webpackStats, statsPreset } = require('@bolt/build-utils/webpack-verbosity');
+const {
+  webpackStats,
+  statsPreset,
+} = require('@bolt/build-utils/webpack-verbosity');
 
 const {
   getBoltManifest,

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -15,15 +15,15 @@ const WriteFilePlugin = require('write-file-webpack-plugin');
 const npmSass = require('npm-sass');
 const merge = require('webpack-merge');
 const SassDocPlugin = require('@bolt/sassdoc-webpack-plugin');
-const { getConfig } = require('./utils/config-store');
-const { boltWebpackProgress } = require('./utils/webpack-helpers');
-const { webpackStats, statsPreset } = require('./utils/webpack-verbosity');
+const { getConfig } = require('@bolt/build-utils/config-store');
+const { boltWebpackProgress } = require('@bolt/build-utils/webpack-helpers');
+const { webpackStats, statsPreset } = require('@bolt/build-utils/webpack-verbosity');
 
 const {
   getBoltManifest,
   mapComponentNameToTwigNamespace,
-} = require('./utils/manifest');
-const log = require('./utils/log');
+} = require('@bolt/build-utils/manifest');
+const log = require('@bolt/build-utils/log');
 
 // Store set of webpack configs used in multiple builds
 let webpackConfigs = [];

--- a/packages/build-tools/tasks/api-tasks/bolt-versions.js
+++ b/packages/build-tools/tasks/api-tasks/bolt-versions.js
@@ -47,8 +47,8 @@ const octokit = new Octokit({
   debug: false,
 });
 
-const { getConfig } = require('../../utils/config-store');
-const { fileExists } = require('../../utils/general');
+const { getConfig } = require('@bolt/build-utils/config-store');
+const { fileExists } = require('@bolt/build-utils/general');
 const store = new InCache();
 let isUsingOldData = false; // remember if we are using up to date version data or older (stale) data as a fallback
 

--- a/packages/build-tools/tasks/criticalcss-tasks.js
+++ b/packages/build-tools/tasks/criticalcss-tasks.js
@@ -1,7 +1,7 @@
 // const penthouse = require('penthouse');
 // const fs = require('fs');
 // const path = require('path');
-// const { getConfig } = require('../utils/config-store');
+// const { getConfig } = require('@bolt/build-utils/config-store');
 // let config;
 
 // async function build() {


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1527

## Summary
Updates the `@bolt/build-tools` to address two indirectly related issues that were causing the original approach for generating multiple language-specific builds to not work as expected.

This PR also adds two new Jest tests to Drupal Lab to now test to confirm that this particular configuration setup continues to work as expected.

> Note: the more up to date version of this language-specific build config involves adding a new `lang: ['en', 'ja']` setting to a single `.boltrc.js` config which will compile both sets of assets to the exact same build / dist folder, albeit with non-English languages getting an extra suffix added to the filenames.

```
# For Example
dist/
  bolt-global.css
  bolt-global-ja.css
  bolt-global.js
  bolt-global-ja.js
```

## Details
1. One of these changes involved updating the `@bolt/build-tools` CLI to better handle (prioritize) the `--config-file` argument instead of competing with the default [cosmic config](https://github.com/davidtheclark/cosmiconfig) behavior of trying to find and use the closest `.boltrc` file that can be found.

2. Another update here involves fixing several path references to files shipped in `@bolt/build-utils` -- especially the ones relating to the data store used to set and get the config settings used in the currently running build process.

Previously some of these imports were incorrectly referencing relative paths vs the `@bolt/build-utils` NPM namespaced path, causing a few critical build tasks (namely Webpack) to reference a _different_ data store instance that wasn't incorporating the custom build config options as expected.

3. Adds a new `.boltrc-ja.js` config file + build task to the Drupal Lab instance to similarly replicate the config setup downstream. This update will now build a separate language-specific build as part of our Travis CI process and use Jest to test to confirm that the language-specific JSON data created by Webpack exists _and_ that the Japanese-specific CSS file was generated + contains the correct font stack.

> Note: as vetted by @danielamorse, we're adding a temporary patch to Drupal Lab to include these upcoming fixes in the NPM-installed version of the build tools used by Drupal Lab so testing coverage for this is already in place. This patch can get removed as soon as the next hotfix release is published. 

## How to test
- [x] Review PR changes
- [x] Confirm all Travis checks pass
