### PR TITLE
Hotfix: Remove Device Viewer Logic Overriding The Image Component's `Sizes` Prop

### DIFF
--- a/packages/components/bolt-device-viewer/src/device-viewer.twig
+++ b/packages/components/bolt-device-viewer/src/device-viewer.twig
@@ -25,9 +25,8 @@
 {% set componentName = deviceName ~ "-viewer" %}
 {% set baseClass = prefix ~ componentName %}
 
-{% if image %}
+{% if image and magnify == true %}
   {% set image = image | merge({
-    sizes: "(min-width: 600px) 150vw, 100vw",
     zoom: true
   }) %}
 {% endif %}


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1521

## Summary
One line Twig template fix that removes an old override in the Device Viewer component that had been overriding the value set to the `sizes` prop in the nested image component. This fix allows for more optimally sized images to get auto/manually selected.

As an added bonus, this update appears to increase our Lighthouse performance scores when testing the device viewer demo page in Pattern Lab -- taking us from a 67/100 to 76/100 (on desktop)!

### Before and After Lighthouse Scores
![image](https://user-images.githubusercontent.com/1617209/61078234-2b915700-a3ee-11e9-8c36-55a2c2b76ac9.png)

## How to test
- Confirm tests passing as expected
- Review the device viewer demo in this PR's staged instance of Pattern Lab to confirm that the sizes prop is no longer getting overwritten (see Lighthouse test results)

CC @krlucas 
