### PR TITLE
Repeat Rule | Tools | Add bolt-repeat-rule mixin

### DIFF
--- a/packages/core/styles/02-tools/tools-repeat-rule/README.md
+++ b/packages/core/styles/02-tools/tools-repeat-rule/README.md
@@ -1,0 +1,11 @@
+# @bolt/tools-repeat-rule
+
+Repeat a block of styles as a separate rule-set for each selector provided
+
+- [Sass Docs](https://www.boltdesignsystem.com/docs/#tools: repeat-rule)
+
+## Install
+
+```bash
+npm install @bolt/tools-repeat-rule
+```

--- a/packages/core/styles/02-tools/tools-repeat-rule/_tools-repeat-rule.scss
+++ b/packages/core/styles/02-tools/tools-repeat-rule/_tools-repeat-rule.scss
@@ -1,0 +1,23 @@
+/* ------------------------------------ *\
+  Repeat Rule
+\* ------------------------------------ */
+
+////
+/// @group Tools: Utilities
+/// @author Dan Morse
+////
+
+/// Repeat a block of styles as a separate rule-set for each selector provided. Does not combine multiple selectors with commas.
+/// Most often used with selectors like `:host` which do not work properly when combined with other selectors.
+/// @param {list} $selectors - A SASS list of selectors
+/// @example scss
+///  @include repeat-rule(('bolt-link', ':host')) {
+///    display: inline;
+///  }
+@mixin bolt-repeat-rule($selectors: null) {
+  @each $selector in $selectors {
+    #{$selector} {
+      @content;
+    }
+  }
+}

--- a/packages/core/styles/index.scss
+++ b/packages/core/styles/index.scss
@@ -50,6 +50,7 @@
 @import '02-tools/tools-opacity/_tools-opacity';
 @import '02-tools/tools-poly-fluid-sizing/_tools-poly-fluid-sizing';
 @import '02-tools/tools-px-to-rem/_tools-px-to-rem';
+@import '02-tools/tools-repeat-rule/_tools-repeat-rule';
 @import '02-tools/tools-sass-json-export/_tools.sass-json-export';
 @import '02-tools/tools-sass-json-export/encode/api/_json';
 @import '02-tools/tools-sass-json-export/encode/encode';


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1506

## Summary

Add new mixin to repeat a block of styles as a separate rule-set for each selector provided.

## Details

This mixin will most often be used with selectors like `:host` which do not work properly when combined with other selectors via comma.

## How to test

- Given I am running the `feature/repeat-rule-mixin` branch locally and I add the following CSS to any component's SCSS file:
```
@include bolt-repeat-rule(('html', 'body')) {
  border: 1px solid red;
}
```
- When I open a page in PL, for example: http://localhost:3000/pattern-lab/patterns/02-components-link-05-link/02-components-link-05-link.html
- Then I should see a red border around the `html` and `body` elements
- When I inspect the source `bolt-global.css` file
- Then I should find the red border output as separate rule-sets, like so:
```
html {
  border: 1px solid red
}
body {
  border: 1px solid red
}
```