### PR TITLE
Button | Twig | Add missing 'target' attribute

### DIFF
--- a/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
+++ b/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
@@ -22,6 +22,32 @@ exports[`button Basic usage 1`] = `
 </bolt-button>
 `;
 
+exports[`button Button adds target if passed via attributes 1`] = `
+<bolt-button size="medium"
+             color="primary"
+             width="auto"
+             border-radius="regular"
+             align="center"
+             transform="none"
+             url="http://pega.com"
+             target="_blank"
+>
+  <a href="http://pega.com"
+     target="_blank"
+     class="c-bolt-button c-bolt-button--medium c-bolt-button--primary c-bolt-button--border-radius-regular c-bolt-button--center"
+     is="shadow-root"
+  >
+    <replace-with-children class="c-bolt-button__icon is-empty">
+    </replace-with-children>
+    <replace-with-children class="c-bolt-button__item">
+      This is a button
+    </replace-with-children>
+    <replace-with-children class="c-bolt-button__icon is-empty">
+    </replace-with-children>
+  </a>
+</bolt-button>
+`;
+
 exports[`button Button tag: a 1`] = `
 <bolt-button size="medium"
              color="primary"

--- a/packages/components/bolt-button/__tests__/button.js
+++ b/packages/components/bolt-button/__tests__/button.js
@@ -41,6 +41,18 @@ describe('button', () => {
     expect(results.html).toMatchSnapshot();
   });
 
+  test('Button adds target if passed via attributes', async () => {
+    const results = await render('@bolt-components-button/button.twig', {
+      text: 'This is a button',
+      url: 'http://pega.com',
+      attributes: {
+        target: '_blank',
+      },
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
   tag.enum.forEach(async tagChoice => {
     test(`Button tag: ${tagChoice}`, async () => {
       const results = await render('@bolt-components-button/button.twig', {

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -54,6 +54,9 @@
   {% if url %}
     {% set inner_attributes = inner_attributes.setAttribute("href", url) %}
   {% endif %}
+  {% if attributes.target %}
+    {% set inner_attributes = inner_attributes.setAttribute("target", attributes.target) %}
+  {% endif %}
 {% elseif tag == "reset" %}
   {% set tag = "button" %}
   {% set inner_attributes = inner_attributes.setAttribute("type", "reset") %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1415

## Summary

Added `target` to Twig-rendered button-style link if passed in via attributes.

## Details

Currently the way to add a `target` to a button is to pass it in via Twig `attributes`. This adds the prop to the custom element but not the inner semantic `<a>`, so you have to wait until the JS kicks in for it to be added. This PR adds it to the Twig-rendered markup so that it works with and without JS.

Note: the button schema needs to be updated to include `url` and `target`. This will be handled in [a separate ticket](http://vjira2:8080/browse/BDS-1573).

## How to test

- Run the `fix/button-missing-target` branch locally.
- Add this code to any button demo page:
```
{% include "@bolt-components-button/button.twig" with {
  text: "This is a button",
  url: "http://pega.com",
  attributes: {
    target: "_blank"
  }
} only %}
```
- View the page with JS off and verify the link opens in a new window.
