### PR TITLE
Band | Bug | Do not merge: Remove extra space below background video in IE

### DIFF
--- a/packages/components/bolt-band/src/band.js
+++ b/packages/components/bolt-band/src/band.js
@@ -30,6 +30,8 @@ class BoltBand extends withLitHtml() {
       ready: false,
     };
 
+    this.innerBand = this.querySelector('.c-bolt-band');
+
     // Clone the shadow DOM template.
     if (this.state.ready === false) {
       this.state.ready = true;
@@ -105,7 +107,7 @@ class BoltBand extends withLitHtml() {
     this.lastRAF && cancelAnimationFrame(this.lastRAF);
     this.lastRAF = requestAnimationFrame(() => {
       this.lastRAF = requestAnimationFrame(() => {
-        this.style.minHeight = `${endingHeight}px`;
+        this.innerBand.style.minHeight = `${endingHeight}px`;
         this.lastRAF = null;
       });
     });
@@ -114,7 +116,8 @@ class BoltBand extends withLitHtml() {
 
     // clean up inline CSS after waiting just a bit
     setTimeout(function() {
-      elem.removeAttribute('style', 'minHeight');
+      console.log('@collapse');
+      elem.innerBand.removeAttribute('style', 'minHeight');
     }, 100);
   }
 
@@ -122,7 +125,7 @@ class BoltBand extends withLitHtml() {
     this.lastRAF && cancelAnimationFrame(this.lastRAF);
     this.lastRAF = requestAnimationFrame(() => {
       this.lastRAF = requestAnimationFrame(() => {
-        this.style.minHeight = this.expandedHeight;
+        this.innerBand.style.minHeight = this.expandedHeight;
         this.lastRAF = null;
       });
     });
@@ -151,7 +154,7 @@ class BoltBand extends withLitHtml() {
         this.lastRAF && cancelAnimationFrame(this.lastRAF);
         this.lastRAF = requestAnimationFrame(() => {
           this.lastRAF = requestAnimationFrame(() => {
-            this.style.minHeight = this.expandedHeight;
+            this.innerBand.style.minHeight = this.expandedHeight;
             this.lastRAF = null;
           });
         });


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1590

## Summary

Remove extra space below background video in IE.

## Details

Background videos were not properly expanding/collapsing. Now they do but there is some extra space below the background video. Remove the extra space if possible.

## How to test
1. View this page in IE11: https://master.boltdesignsystem.com/pattern-lab/patterns/02-components-video-45-video-with-inline-script-and-external-controls-as-background/02-components-video-45-video-with-inline-script-and-external-controls-as-background.html
2. Play the background video.
3. Resize the browser and notice that at certain screen sizes there is some extra space below the background video.
4. Run this branch locally and do the same. The space should be removed.
5. Also verify it works properly in Chrome.
