### PR TITLE
Speed Up Jest Tests By ~70% (4 minutes faster!)

### DIFF
--- a/packages/analytics/autolink/__tests__/autolink.test.js
+++ b/packages/analytics/autolink/__tests__/autolink.test.js
@@ -9,12 +9,17 @@ describe('analytics autolinker', () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
       waitUntil: 'networkidle0',
+      timeout: 0,
     });
 
     await page.addScriptTag({
       url: 'https://www.google-analytics.com/analytics.js',
     });
   }, timeout);
+
+  afterEach(async () => {
+    await page.close();
+  });
 
   test('autolinker does not modify component URLs already containing an _ga query string', async function() {
     await page.addScriptTag({

--- a/packages/api/index.test.js
+++ b/packages/api/index.test.js
@@ -9,13 +9,13 @@ describe('Test the Bolt Twig Renderer API', () => {
     const result = await render(buttonTemplate, buttonData);
 
     expect(result.ok).toEqual(true);
-  });
+  }, 10000);
 
   test('handles missing data', async () => {
     const result = await render(buttonTemplate);
 
     expect(result.ok).toEqual(true);
-  });
+  }, 10000);
 
   test('handles non-existent template path', async () => {
     const result = await render('@bolt-components-button/button2.twig', {
@@ -23,7 +23,7 @@ describe('Test the Bolt Twig Renderer API', () => {
     });
 
     expect(result.ok).toEqual(false);
-  });
+  }, 10000);
 
   test('renders the button component correctly', async () => {
     const result = await render(buttonTemplate, {
@@ -31,7 +31,7 @@ describe('Test the Bolt Twig Renderer API', () => {
     });
 
     expect(result.html).toMatchSnapshot();
-  });
+  }, 10000);
 
   test('renders attributes on the button component correctly', async () => {
     const result = await render(buttonTemplate, {
@@ -42,7 +42,7 @@ describe('Test the Bolt Twig Renderer API', () => {
     });
 
     expect(result.html).toMatchSnapshot();
-  });
+  }, 10000);
 
   test('renders the secondary button correctly', async () => {
     const result = await render(buttonTemplate, {
@@ -51,5 +51,5 @@ describe('Test the Bolt Twig Renderer API', () => {
     });
 
     expect(result.html).toMatchSnapshot();
-  });
+  }, 10000);
 });

--- a/packages/components/bolt-accordion/__tests__/accordion.js
+++ b/packages/components/bolt-accordion/__tests__/accordion.js
@@ -23,14 +23,21 @@ describe('<bolt-accordion> Component', () => {
   let page;
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 
   afterAll(async () => {
     await stopTwigRenderer();
+    await page.close();
   }, timeout);
 
   test('basic usage', async () => {

--- a/packages/components/bolt-band/__tests__/band.js
+++ b/packages/components/bolt-band/__tests__/band.js
@@ -16,14 +16,21 @@ describe('<bolt-band> Component', () => {
   let page;
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 
   afterAll(async () => {
     await stopServer();
+    await page.close();
   }, 100);
 
   // Basic Usage

--- a/packages/components/bolt-blockquote/__tests__/blockquote.js
+++ b/packages/components/bolt-blockquote/__tests__/blockquote.js
@@ -22,12 +22,18 @@ describe('button', () => {
 
   afterAll(async () => {
     await stopServer();
+    await page.close();
   }, 100);
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
       timeout: 0,
     });
   }, timeout);

--- a/packages/components/bolt-button/__tests__/button.js
+++ b/packages/components/bolt-button/__tests__/button.js
@@ -13,21 +13,23 @@ const { tag } = schema.properties;
 const timeout = 90000;
 
 describe('button', () => {
-  let page, isOnline, context;
-
-  beforeAll(async () => {
-    isOnline = await isConnected();
-    context = await global.__BROWSER__.createIncognitoBrowserContext();
-  });
+  let page;
 
   afterAll(async () => {
     await stopServer();
+    await page.close();
   });
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 

--- a/packages/components/bolt-carousel/__tests__/carousel.js
+++ b/packages/components/bolt-carousel/__tests__/carousel.js
@@ -58,12 +58,22 @@ describe('carousel', () => {
   let page;
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+    await page.setViewport({ width: 800, height: 600 });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
       timeout: 0,
-      waitUntil: 'networkidle0',
     });
   }, timeout);
+
+  afterAll(async () => {
+    await page.close();
+  }, 100);
 
   // test('basic carousel component renders', async () => {
   //   const results = await render('@bolt-components-carousel/carousel.twig');

--- a/packages/components/bolt-headline/__tests__/__snapshots__/headline.js.snap
+++ b/packages/components/bolt-headline/__tests__/__snapshots__/headline.js.snap
@@ -243,6 +243,12 @@ exports[`<bolt-headline> Component basic usage subheadline 1`] = `
 </p>
 `;
 
+exports[`<bolt-headline> Component basic usage subheadline 2`] = `
+<p class="c-bolt-subheadline c-bolt-subheadline--regular c-bolt-subheadline--xlarge">
+  this is an subheadline
+</p>
+`;
+
 exports[`<bolt-headline> Component basic usage text 1`] = `
 <p class="c-bolt-text c-bolt-text--regular c-bolt-text--normal c-bolt-text--medium">
   this is text
@@ -309,6 +315,12 @@ exports[`<bolt-headline> Component tag display: h2 1`] = `
 `;
 
 exports[`<bolt-headline> Component tag display: h3 1`] = `
+<h3 class="c-bolt-headline c-bolt-headline--bold c-bolt-headline--xlarge">
+  Some text
+</h3>
+`;
+
+exports[`<bolt-headline> Component tag display: h3 2`] = `
 <h3 class="c-bolt-headline c-bolt-headline--bold c-bolt-headline--xlarge">
   Some text
 </h3>

--- a/packages/components/bolt-headline/__tests__/__snapshots__/headline.js.snap
+++ b/packages/components/bolt-headline/__tests__/__snapshots__/headline.js.snap
@@ -243,12 +243,6 @@ exports[`<bolt-headline> Component basic usage subheadline 1`] = `
 </p>
 `;
 
-exports[`<bolt-headline> Component basic usage subheadline 2`] = `
-<p class="c-bolt-subheadline c-bolt-subheadline--regular c-bolt-subheadline--xlarge">
-  this is an subheadline
-</p>
-`;
-
 exports[`<bolt-headline> Component basic usage text 1`] = `
 <p class="c-bolt-text c-bolt-text--regular c-bolt-text--normal c-bolt-text--medium">
   this is text
@@ -315,12 +309,6 @@ exports[`<bolt-headline> Component tag display: h2 1`] = `
 `;
 
 exports[`<bolt-headline> Component tag display: h3 1`] = `
-<h3 class="c-bolt-headline c-bolt-headline--bold c-bolt-headline--xlarge">
-  Some text
-</h3>
-`;
-
-exports[`<bolt-headline> Component tag display: h3 2`] = `
 <h3 class="c-bolt-headline c-bolt-headline--bold c-bolt-headline--xlarge">
   Some text
 </h3>

--- a/packages/components/bolt-icons/__tests__/icons.js
+++ b/packages/components/bolt-icons/__tests__/icons.js
@@ -13,12 +13,19 @@ describe('<bolt-icon> Component', () => {
 
   afterAll(async () => {
     await stopServer();
-  }, 100);
+    await page.close();
+  });
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 

--- a/packages/components/bolt-link/__tests__/link.js
+++ b/packages/components/bolt-link/__tests__/link.js
@@ -13,21 +13,23 @@ const { display, valign } = schema.properties;
 const timeout = 90000;
 
 describe('link', () => {
-  let page, isOnline, context;
-
-  beforeAll(async () => {
-    isOnline = await isConnected();
-    context = await global.__BROWSER__.createIncognitoBrowserContext();
-  });
+  let page;
 
   afterAll(async () => {
     await stopServer();
+    await page.close();
   });
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 

--- a/packages/components/bolt-logo/__tests__/logo.js
+++ b/packages/components/bolt-logo/__tests__/logo.js
@@ -12,18 +12,21 @@ describe('logo', () => {
   let page;
 
   beforeEach(async () => {
-    page = await global.__BROWSER__.newPage();
-    await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
     });
   }, timeout);
 
-  afterEach(async () => {
-    await page.close();
-  });
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage();
+    await page.goto('http://127.0.0.1:4444/', {
+      timeout: 0,
+    });
+  }, timeout);
 
   afterAll(async function() {
     await stopServer();
+    await page.close();
   });
 
   test('Basic usage', async () => {

--- a/packages/components/bolt-modal/__tests__/modal.js
+++ b/packages/components/bolt-modal/__tests__/modal.js
@@ -44,15 +44,22 @@ describe('<bolt-modal> Component', () => {
   let page;
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 
   afterAll(async () => {
     await stopTwigRenderer();
-  }, timeout);
+    await page.close();
+  });
 
   test('basic usage', async () => {
     const results = await renderTwig('@bolt-components-modal/modal.twig', {

--- a/packages/components/bolt-navbar/__tests__/navbar.js
+++ b/packages/components/bolt-navbar/__tests__/navbar.js
@@ -38,21 +38,24 @@ const viewportSizes = [
 ];
 
 describe('<bolt-navbar> Component', () => {
-  let page, isOnline, context;
+  let page, isOnline;
 
   beforeAll(async () => {
     isOnline = await isConnected();
-    context = await global.__BROWSER__.createIncognitoBrowserContext();
   });
 
   afterAll(async () => {
     await stopServer();
-  }, 100);
+  });
+
+  afterEach(async () => {
+    await page.close();
+  });
 
   beforeEach(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 

--- a/packages/components/bolt-ratio/__tests__/ratio.js
+++ b/packages/components/bolt-ratio/__tests__/ratio.js
@@ -17,15 +17,21 @@ describe('<bolt-ratio> Component', () => {
   let page;
 
   beforeEach(async () => {
-    page = await global.__BROWSER__.newPage();
-    await page.goto('http://127.0.0.1:4444/', {
-      timeout: 0,
-      waitUntil: 'networkidle0',
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
     });
   }, timeout);
 
-  afterAll(async function() {
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage();
+    await page.goto('http://127.0.0.1:4444/', {
+      timeout: 0,
+    });
+  }, timeout);
+
+  afterAll(async () => {
     await stopServer();
+    await page.close();
   });
 
   test('<bolt-ratio> compiles', async () => {

--- a/packages/components/bolt-text/__tests__/text.js
+++ b/packages/components/bolt-text/__tests__/text.js
@@ -13,12 +13,18 @@ describe('<bolt-text> Component', () => {
 
   afterAll(async () => {
     await stopServer();
+    await page.close();
   }, 100);
 
   beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
-      waitUntil: 'networkidle0',
       timeout: 0,
     });
   }, timeout);

--- a/packages/generators/yeoman-create-component/generators/component/templates/component.test.js
+++ b/packages/generators/yeoman-create-component/generators/component/templates/component.test.js
@@ -33,6 +33,7 @@ describe('<%= props.name.noCase %>', async () => {
     page = await global.__BROWSER__.newPage();
     await page.goto('http://127.0.0.1:4444/', {
       waitUntil: 'networkidle0',
+      timeout: 0,
     });
   }, timeout);
 

--- a/packages/servers/testing-server/index.js
+++ b/packages/servers/testing-server/index.js
@@ -77,14 +77,15 @@ getConfig().then(async boltConfig => {
             .filter(path => path.endsWith('.css'))
             .map(path => fs.readFileSync(outputPath + '/' + path))
             .join('\n')}</style>
+
+            ${normalizeAssets(assetsByChunkName['bolt-global'])
+            .filter(path => path.endsWith('.js'))
+            .map(path => `<script src="${path}"></script>`)
+            .join('\n')}
         </head>
         <body>
           <!-- set #root to inline-block so VRT screenshots are only as wide as the component vs are always full width -->
           <div id="root" style="display: inline-block"></div>
-          ${normalizeAssets(assetsByChunkName['bolt-global'])
-            .filter(path => path.endsWith('.js'))
-            .map(path => `<script src="${path}"></script>`)
-            .join('\n')}
         </body>
       </html>`,
     );

--- a/packages/servers/testing-server/index.js
+++ b/packages/servers/testing-server/index.js
@@ -79,9 +79,9 @@ getConfig().then(async boltConfig => {
             .join('\n')}</style>
 
             ${normalizeAssets(assetsByChunkName['bolt-global'])
-            .filter(path => path.endsWith('.js'))
-            .map(path => `<script src="${path}"></script>`)
-            .join('\n')}
+              .filter(path => path.endsWith('.js'))
+              .map(path => `<script src="${path}"></script>`)
+              .join('\n')}
         </head>
         <body>
           <!-- set #root to inline-block so VRT screenshots are only as wide as the component vs are always full width -->

--- a/packages/twig-renderer/twig-renderer.js
+++ b/packages/twig-renderer/twig-renderer.js
@@ -36,7 +36,7 @@ async function init(keepAlive = false) {
     debug: true,
     alterTwigEnv: config.alterTwigEnv,
     hasExtraInfoInResponses: false, // Will add `info` onto results with a lot of info about Twig Env
-    maxConcurrency: 10,
+    maxConcurrency: 30,
     keepAlive, // only set this to be true when doing in-browser requests to avoid issues with this process not exiting when complete
   });
   state = STATES.READY;


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1653

## Summary
Minor config updates that I noticed could speed up our Jest tests by quite a bit! 🎉

![B630DFCA-1E1B-4846-8F9D-B53379707A9C](https://user-images.githubusercontent.com/1617209/61565342-bbff1580-aa46-11e9-9e16-5f020da09c10.jpeg)

![276D22BE-75FF-416C-B1C7-BE41810A93BA](https://user-images.githubusercontent.com/1617209/61565341-bb667f00-aa46-11e9-89cb-134d04a2d378.jpeg)

## Details
- Adds a missing `timeout` config to avoid hitting the default Jest timeouts.
- Updates most Jest tests that use Puppeteer to now reuse the same browser tab (saving resources and increasing load times) and now clear out the inner HTML after each test has finished running (clean up Puppeteer for the next test)
- Tweaks the default testing server template to make it easier for tests to clean out the body’s inner HTML
- Also updates Jest test suites using Puppeteer to close the Puppeteer browser tab when complete to try and help reduce system resources

## Before vs After (Note the long running tests times in red)
<p>
<img width="48.8%" src="https://user-images.githubusercontent.com/1617209/61565167-38452900-aa46-11e9-8fca-db93d6c6a0a4.jpeg">
<img width="50%" src="https://user-images.githubusercontent.com/1617209/61565177-4430eb00-aa46-11e9-9712-978de19dc643.jpeg">
</p>

## How to test
- [ ]  Confirm Jest tests passing on Travis
- [ ]  Review changes
