### PR TITLE
Feature: Improve Navbar Spacing

### DIFF
--- a/docs-site/src/components/docs-search/docs-search.scss
+++ b/docs-site/src/components/docs-search/docs-search.scss
@@ -3,7 +3,6 @@
 
 // temporary style overrides to the default form input until we're done refactoring to support additional input sizes + icon placement
 bds-docs-search {
-  @include bolt-padding-right(xsmall);
   flex-shrink: 1;
   max-width: 100%;
   margin-left: auto;
@@ -13,7 +12,7 @@ bds-docs-search {
     grid-column: 1/span 4;
     justify-self: center;
   }
-  
+
   @include bolt-mq($from: small){
     width: 50px;
     min-width: 100px;
@@ -23,7 +22,7 @@ bds-docs-search {
     width: auto;
     min-width: none;
   }
-  
+
   &:focus-within {
     width: 200px;
     transition: all 250ms;
@@ -68,7 +67,7 @@ bds-docs-search {
     pointer-events: none;
     border-radius: 50rem;
     background-color: transparent;
-    
+
 
     &:before {
       display: none;
@@ -81,7 +80,7 @@ bds-docs-search {
 
   .o-bolt-inline-list__item:first-child {
     display: none;
-    
+
     &:last-child {
       display: inline-block;
     }

--- a/docs-site/src/components/version-selector/version-selector.twig
+++ b/docs-site/src/components/version-selector/version-selector.twig
@@ -19,9 +19,6 @@
 {% endset %}
 
 {% include("@bolt-components-form/form-element.twig") with {
-  attributes: {
-    class: "u-bolt-margin-left-small"
-  },
   children: children,
 } only %}
 

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -43,6 +43,10 @@ bolt-navbar {
   @include bolt-padding-left(small);
   @include bolt-padding-right(small);
 
+  > *:not(:last-child){
+    @include bolt-margin-right(small);
+  }
+
   @include bolt-mq($bolt-navbar-xsmall-bp){
     @include bolt-padding-left(medium);
     @include bolt-padding-right(medium);
@@ -118,9 +122,9 @@ bolt-navbar {
     }
   }
 
-  // Don't include these inner "full-bleed" styles till Navbar is updated to support theming classes internally, 
+  // Don't include these inner "full-bleed" styles till Navbar is updated to support theming classes internally,
   // otherwise full bleed + center styling combos are broken
-  // @todo: uncomment once the [width*="full"] updates from above ^ are addressed 
+  // @todo: uncomment once the [width*="full"] updates from above ^ are addressed
   // &--full {
   //   @include bolt-full-bleed;
   // }
@@ -148,13 +152,14 @@ bolt-navbar {
   color: bolt-theme(headline);
   white-space: nowrap;
 
+  > *:not(:last-child){
+    @include bolt-margin-right(small);
+  }
+
   @supports (--css: variables) {
     padding-bottom: var(--bolt-vspacing, $bolt-navbar-vspacing-small);
   }
 
-  @include bolt-mq(medium){
-    @include bolt-margin-right(medium); // Maintain space between items
-  }
 
   &:only-child {
     @include bolt-margin-right(auto);


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1662

## Summary
Tweaks the Navbar component's CSS rules to better handle the space between extra items added to the Navbar Title section + extra items added to the main content section of the Navbar.

## Details
- Neither of these Navbar regions are frequently used as far as I know, however I know we certainly use them with the docs site global header to add the version selector to the Title section + the docs site to the default main content section). 

This update eliminates the need to have extra spacing hacks added to these individual components since this now gets taken care of by the main component itself.

## Before vs After Comparisons

![CleanShot 2019-07-25 at 10 44 07](https://user-images.githubusercontent.com/1617209/61885063-33abc500-aecb-11e9-9e8d-f4cb56eafe20.png)
> No visible change expected
<br>

![CleanShot 2019-07-25 at 10 47 49](https://user-images.githubusercontent.com/1617209/61885085-3d352d00-aecb-11e9-85cf-718526faf96b.png)
> No visible change expected
<br>

![CleanShot 2019-07-25 at 10 45 35](https://user-images.githubusercontent.com/1617209/61885086-3d352d00-aecb-11e9-92c8-b41d57aafeca.png)
> Small expected spacing change (improvement) to our own docs site nav
<br>

## How to test
- [ ] Review code changes
- [ ] Double-check Navbar demos in PL to make sure everything continues to work as expected (I already did an initial review of these and didn't see any unintended spacing / UI side-effects).  
