### PR TITLE
Fix: change sticky z-index to not cover up mega nav

### DIFF
--- a/packages/components/bolt-sticky/src/sticky.scss
+++ b/packages/components/bolt-sticky/src/sticky.scss
@@ -11,6 +11,6 @@ bolt-sticky {
 .c-bolt-sticky {
   position: sticky;
   top: 0;
-  z-index: bolt-z-index('navFixed');
+  z-index: bolt-z-index(nav);
   width: 100%;
 }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1609

## Summary

Updates sticky component's z-index to be lower than mega nav.

## Details

The z-index conflicts with the mega nav and the modal will be fixed by an update from Bolt and an update from Drupal:

1. Bolt changes bolt-sticky to use `z-index: bolt-z-index(nav)`
2. Drupal changes .c-page-header to use `z-index: bolt-z-index(navFixed)`

## How to test

Get both updates in Drupal and make sure modals will cover up the mega nav.
