### PR TITLE
Fix: restore regular modal width

### DIFF
--- a/packages/components/bolt-modal/modal.schema.yml
+++ b/packages/components/bolt-modal/modal.schema.yml
@@ -26,6 +26,7 @@ properties:
     default: optimal
     enum:
       - auto
+      - regular
       - optimal
       - full
   spacing:

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -215,6 +215,10 @@ bolt-modal:not([ready]) {
 
 // Content width options
 @include bolt-mq($bolt-modal-breakpoint) {
+  .c-bolt-modal__content--width-regular {
+    width: 100% / 12 * 10;
+  }
+
   .c-bolt-modal__content--width-optimal {
     width: 75ch;
   }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1678

## Summary

Restores the `regular` option for the `width` prop.

## Details

CSS are added back in and schema is updated to have the prop available.

## How to test

Run the branch locally and check the modal width demo page. Make sure `regular` is one of the options.
