### PR TITLE
Focus Trap | JS | focus-trap IE JS error

### DIFF
--- a/packages/components/bolt-modal/focus-trap/focus-trap.js
+++ b/packages/components/bolt-modal/focus-trap/focus-trap.js
@@ -59,8 +59,10 @@ class FocusTrap extends withLitHtml() {
    */
   disconnecting() {
     super.disconnecting && super.disconnecting();
-    this.$start.removeEventListener('focus', this.focusLastElement);
-    this.$end.removeEventListener('focus', this.focusFirstElement);
+    // Check that $start and $end are defined. In IE, disconnecting() can be called while $start and $end are still undefined, which throws an error.
+    this.$start &&
+      this.$start.removeEventListener('focus', this.focusLastElement);
+    this.$end && this.$end.removeEventListener('focus', this.focusFirstElement);
     this.removeEventListener('focusin', this.onFocusIn);
     this.removeEventListener('focusout', this.onFocusOut);
   }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1682

## Summary

Fix `focus-trap` IE-only JS error that is causing images to be distorted.

## Details

Focus-trap, a subcomponent of modal, hits an error in IE that causes downstream issues with the ratio component. Due to the error, the ratio component defaults to 1:1 or "square" which distorts most images.

The error surfaced when `bolt-modal` was placed inside a `bolt-band`. In IE the band triggers modal to re-render and throw an error. This fix prevents the error on re-render.

## How to test
- Drop this code onto a Pattern Lab page and open in IE11. The image should be distorted.
```
<bolt-image
  src="https://via.placeholder.com/400x200"
  srcset="https://via.placeholder.com/400x200"
  alt="A Rock Climber"
  sizes="auto"
  ratio="2/1"
></bolt-image>

<bolt-band>
  <bolt-modal
  width="optimal"
  spacing="none"
  theme="none"
  scroll="container"
  uuid="1395045819"
  >
  </bolt-modal>
</bolt-band>
```
- Check out this branch and repeat. The image should be normal.