### PR TITLE
Hotfix: Fix Nested Component Animations When Inside Modal

### DIFF
--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -224,16 +224,19 @@ bolt-modal:not([ready]) {
   }
 }
 
-// Container
+/**
+  * Modal Container
+  * 1. translate3d(0, 0, 0) is needed to fix http://vjira2:8080/browse/BDS-1672?filter=-1
+**/
 .c-bolt-modal__container {
   display: block;
   opacity: bolt-opacity(0);
-  transform: scale($bolt-modal-animation-scale);
+  transform: translate3d(0, 0, 0) scale($bolt-modal-animation-scale); /* [1] */
   transition: opacity $bolt-modal-transition, transform $bolt-modal-transition;
 
   @at-root .c-bolt-modal.is-open #{&} {
     opacity: bolt-opacity(100);
-    transform: scale(1);
+    transform: translate3d(0, 0, 0) scale(1); /* [1] */
   }
 
   @include bolt-mq($bolt-modal-breakpoint) {


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1672?filter=-1

## Summary
CSS fix to address quirky animation flashes reported in IE 11. 

## Details
Forcing the modal component to animate with `translate3d` + scale forces the browser's animation of this to be more accurate + less janky (especially since we're dealing with nested transform styles).

### Before
![CleanShot 2019-07-30 at 10 18 47](https://user-images.githubusercontent.com/1617209/62138023-ece81180-b2b4-11e9-8ace-a4c19bc3a899.gif)

### After
![CleanShot 2019-07-30 at 10 19 24](https://user-images.githubusercontent.com/1617209/62138043-f5d8e300-b2b4-11e9-8437-10ec3854c0ec.gif)


## How to test
Review this page in Pattern Lab to confirm that hovering over CSS-transformed components nested inside the modal no longer jumps around in IE 11:
  - pattern-lab/patterns/02-components-modal-55-modal-usage-form/02-components-modal-55-modal-usage-form.html
