### PR TITLE
Hotfix: Fix/2.x restore regular modal width

### DIFF
--- a/packages/components/bolt-modal/modal.schema.yml
+++ b/packages/components/bolt-modal/modal.schema.yml
@@ -26,6 +26,7 @@ properties:
     default: optimal
     enum:
       - auto
+      - regular
       - optimal
       - full
   spacing:

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -215,6 +215,10 @@ bolt-modal:not([ready]) {
 
 // Content width options
 @include bolt-mq($bolt-modal-breakpoint) {
+  .c-bolt-modal__content--width-regular {
+    width: 100% / 12 * 10;
+  }
+
   .c-bolt-modal__content--width-optimal {
     width: 75ch;
   }


### PR DESCRIPTION
## Summary

Dupe of #1292 but branched off of `release/2.x`.
