### PR TITLE
Chore: Rename Yeoman Component Generator's Package.json Name

### DIFF
--- a/__tests__/monorepo-deps.test.js
+++ b/__tests__/monorepo-deps.test.js
@@ -24,7 +24,7 @@ function pkgToHaveDependenciesOn(pkgName, deps) {
   deps.forEach(dep => {
     if (!listedDeps.some(d => d === dep)) {
       if (dep !== pkgName) {
-        if (dep !== '@bolt/global' && dep !== '@bolt/generator-bolt') {
+        if (dep !== '@bolt/global') {
           missingDeps.push(dep);
         }
       }
@@ -53,7 +53,7 @@ expect.extend({ pkgToHaveDependenciesOn });
 const boltPkgs = getPkgList();
 
 describe('Bolt Components declare dependencies in package.json if used in Twig files', () => {
-  const excludedPkgs = ['generator-bolt'];
+  const excludedPkgs = ['@bolt/generator-bolt'];
 
   boltPkgs
     .filter(boltPkg => !excludedPkgs.includes(boltPkg.name))

--- a/__tests__/monorepo-deps.test.js
+++ b/__tests__/monorepo-deps.test.js
@@ -24,7 +24,7 @@ function pkgToHaveDependenciesOn(pkgName, deps) {
   deps.forEach(dep => {
     if (!listedDeps.some(d => d === dep)) {
       if (dep !== pkgName) {
-        if (dep !== '@bolt/global') {
+        if (dep !== '@bolt/global' && dep !== '@bolt/generator-bolt') {
           missingDeps.push(dep);
         }
       }

--- a/packages/generators/yeoman-create-component/package.json
+++ b/packages/generators/yeoman-create-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "generator-bolt",
+  "name": "@bolt/generator-bolt",
   "version": "2.5.6",
   "description": "A yeoman generator for creating components for the Bolt Design System",
   "homepage": "https://boltdesignsystem.com",


### PR DESCRIPTION
## Jira
N/A

## Summary
Renames our Yeoman component generator NPM package name from `generator-bolt` to `@bolt/generator-bolt` to prevent future NPM publishing issues from not being under the @bolt org that @danielamorse and I had to work through during yesterday's release.

## Details
Previously Yeoman required generators to have the `generator-` prefix in the package name however it looks like the updates from https://github.com/yeoman/environment/pull/23 should have addressed this (even though the current Yeoman docs say otherwise).
 
I've already went ahead and told NPM to point the [old NPM package](https://www.npmjs.com/package/generator-bolt) to the new https://www.npmjs.com/package/@bolt/generator-bolt I'll be publishing as soon as this gets merged in. 