### PR TITLE
Modal | JS | Add `toggle` method

### DIFF
--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -205,6 +205,20 @@ class BoltModal extends withLitHtml() {
   }
 
   /**
+   * Toggle the dialog element. If dialog is open, close it. If closed, open it.
+   *
+   * @param {Event} event
+   * @return {this}
+   */
+  toggle() {
+    if (this.open) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+
+  /**
    * Private event handler used when listening to some specific key presses
    * (namely ESCAPE and TAB)
    *


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/BDS-1616

## Summary

Add `toggle` method to modal.

## Details

Add `toggle` as an alternative to existing `show` and `hide` methods.

## How to test
- Run locally and go to [Basic modal page](http://localhost:3000/pattern-lab/patterns/02-components-modal-05-modal/02-components-modal-05-modal.html).
- Run the following JS in the console and the modal should open:
```
document.querySelector('bolt-modal').toggle()
```
- Run it again and it should close.