### PR TITLE
fix: update nightwatch config to fix chrome driver issues

### DIFF
--- a/packages/testing/testing-nightwatch/nightwatch.js
+++ b/packages/testing/testing-nightwatch/nightwatch.js
@@ -74,6 +74,7 @@ module.exports = {
         browserName: 'chrome',
         chromeOptions: {
           args: ['headless'],
+          w3c: false,
         },
       },
     },
@@ -84,9 +85,10 @@ module.exports = {
         version: '76',
         javascriptEnabled: true,
         acceptSslCerts: true,
-        //         chromeOptions: {
-        //           args: ['headless'],
-        //         },
+        chromeOptions: {
+          // args: ['headless'],
+          w3c: false,
+        },
       },
       build: `build-${process.env.TRAVIS_JOB_NUMBER}`,
       'tunnel-identifier': `${process.env.TRAVIS_JOB_NUMBER || ''}`,

--- a/packages/testing/testing-nightwatch/nightwatch.local.js
+++ b/packages/testing/testing-nightwatch/nightwatch.local.js
@@ -52,6 +52,7 @@ module.exports = {
         browserName: 'chrome',
         chromeOptions: {
           args: ['--headless'],
+          w3c: false,
         },
         javascriptEnabled: true,
         acceptSslCerts: true,
@@ -63,6 +64,7 @@ module.exports = {
         browserName: 'chrome',
         chromeOptions: {
           args: ['--headless'],
+          w3c: false,
         },
         javascriptEnabled: true,
         acceptSslCerts: true,


### PR DESCRIPTION
## Summary

All my local nightwatch tests started failing. After so investigation, I found that updates to chrome that happened around version 75 required updated config. This update fixes the issue for me.

## Details

All nightwatch/selenium tests started returning the following error:
```TypeError [ERR_UNESCAPED_CHARACTERS]: Error while trying to create HTTP request for "/wd/hub/session/1f46ad787c5fe86269b8302ca2414201/element/[object Object]/click": Request path contains unescaped characters```

I found a solution to the issue here: https://github.com/nightwatchjs/nightwatch/issues/2126

## How to test

Run nightwatch locally using `yarn test:e2e:quick-local`
