### PR TITLE
Video | Docs | Add comment about autoplay on iOS

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop-hide-controls.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop-hide-controls.twig
@@ -1,6 +1,5 @@
-<p>
-  This video has <code>autoplay</code> set to <code>true</code>, <code>loop</code> set to <code>true</code>, and <code>controls</code> set to <code>false</code>. When a video is autoplaying without any controls, it is muted by default. This is purely intended for decorations and not practical. Autoplaying video with sound is against best practices.
-</p>
+<p>This video has <code>autoplay</code> set to <code>true</code>, <code>loop</code> set to <code>true</code>, and <code>controls</code> set to <code>false</code>. When a video is autoplaying without any controls, it is muted by default. This is purely intended for decorations and not practical. Autoplaying video with sound is against best practices.</p>
+<p><mark>Note: videos are not expected to autoplay on iOS.</mark></p>
 
 {% include "@bolt/video.twig" with {
   "videoId": "5780495299001",

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop.twig
@@ -1,6 +1,6 @@
-<p>
-  This video has <code>autoplay</code> set to <code>true</code> and <code>loop</code> set to <code>true</code>.
-</p>
+<p>This video has <code>autoplay</code> set to <code>true</code> and <code>loop</code> set to <code>true</code>.</p>
+<p><mark>Note: videos are not expected to autoplay on iOS.</mark></p>
+
 
 {% include "@bolt/video.twig" with {
   "videoId": "5780495299001",

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay.twig
@@ -1,6 +1,6 @@
-<p>
-  This video has <code>autoplay</code> set to <code>true</code>.
-</p>
+<p>This video has <code>autoplay</code> set to <code>true</code>.</p>
+<p><mark>Note: videos are not expected to autoplay on iOS.</mark></p>
+
 
 {% include "@bolt/video.twig" with {
   "videoId": "5780495299001",


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1768

## Summary

Add comment about autoplay on iOS: `Note: videos are not expected to autoplay on iOS.`

## Details

This is to avoid confusion when Bolt demos are tested by QA.

## How to test
- Review updated docs.