### PR TITLE
Fix/interactive step mobile basics

### DIFF
--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -10,9 +10,10 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 $bolt-tooltip-bubble-border-color: bolt-color(gray, light);
 $bolt-tooltip-transition: $bolt-transition;
 $bolt-interactive-step-left-padding: 42px;
-$bolt-interactive-step-bottom-padding: bolt-spacing(small);
 $bolt-interactive-step-line-left-pos: 4.5px;
 $bolt-interactive-step--dot-size: 1.2rem;
+$bolt-interactive-step-bottom-padding: 5rem;
+
 
 bolt-interactive-step {
   // Override generic styles from _generic-shared.scss
@@ -35,6 +36,14 @@ bolt-interactive-step {
     display: flex;
     align-items: center;
     padding-bottom: $bolt-interactive-step-bottom-padding;
+
+    .c-bolt-interactive-step--active & {
+      padding-bottom: 1.65rem;
+
+      @include bolt-mq(medium) {
+        padding-bottom: 0;
+      }
+    }
 
     @include bolt-mq(medium) {
       position: relative;
@@ -76,7 +85,6 @@ bolt-interactive-step {
 
   &__title {
     display: inline-block;
-    margin-bottom: 1.65rem;
     padding-top: .2em;
     padding-left: $bolt-interactive-step-left-padding;
     cursor: pointer;
@@ -94,11 +102,17 @@ bolt-interactive-step {
     .c-bolt-interactive-step--active & {
       height: auto;
       overflow: visible;
+      padding-bottom: $bolt-interactive-step-bottom-padding;
       padding-left: $bolt-interactive-step-left-padding;
 
       @include bolt-mq(medium) {
         margin-left: 0;
+        padding-bottom: 0;
       }
+    }
+
+    .c-bolt-interactive-step--last & {
+      padding-left: .75rem; // This puts it aligned with the line, relative to dot width.
     }
 
     // Move the step body to the right on desktop

--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -19,17 +19,10 @@ bolt-interactive-step {
   &:not(:last-child) {
     margin-bottom: 0;
   }
-
-  // @todo why was this here? since `bolt-animation-wrapper` became `bolt-animate` these styles haven't been applying for awhile, but might of been fixing something that is broken again
-  //&:last-of-type {
-  //  bolt-animation-wrapper {
-  //    position: relative;
-  //    left: -$bolt-interactive-step-left-padding + $bolt-interactive-step-line-left-pos;
-  //  }
-  //}
 }
 
 .c-bolt-interactive-step {
+  position: relative;
   //Styles go here. /* [1] */
   text-align: left;
   transition: font-size 0.5s ease;
@@ -41,9 +34,12 @@ bolt-interactive-step {
   &__nav-item-wrapper {
     display: flex;
     align-items: center;
-    position: relative;
-    top: 0;
     padding-bottom: $bolt-interactive-step-bottom-padding;
+
+    @include bolt-mq(medium) {
+      position: relative;
+      top: 0;
+    }
   }
 
   &__line {
@@ -98,6 +94,11 @@ bolt-interactive-step {
     .c-bolt-interactive-step--active & {
       height: auto;
       overflow: visible;
+      padding-left: $bolt-interactive-step-left-padding;
+
+      @include bolt-mq(medium) {
+        margin-left: 0;
+      }
     }
 
     // Move the step body to the right on desktop
@@ -114,6 +115,7 @@ bolt-interactive-step {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    max-width: 100%;
     @include bolt-mq(medium) {
       max-width: 700px;
     }

--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -126,6 +126,7 @@ bolt-interactive-step {
     font-weight: bolder;
 
     .c-bolt-interactive-step__dot {
+      left: 4.5px;
       transform: scale(1.5);
       color: orange;
     }


### PR DESCRIPTION
## Jira

(Enter a link to the Jira issue this PR applies to, if any)

## Summary

- Fix interactive step mobile display
- Fix step and last step body padding
- Fix width of step
- Consolidate padding vars
- Various alignment fixes compared against Sketch comps

## Details

Before:
<img width="678" alt="image" src="https://user-images.githubusercontent.com/1361104/63606321-6bbf2a00-c595-11e9-90b7-c4d89f3ba3a5.png">


After: 
<img width="685" alt="image" src="https://user-images.githubusercontent.com/1361104/63606285-50ecb580-c595-11e9-83a4-75635b4ffb3d.png">


There are still some issues, but these are not related to interactive-step. I pulled these out into tickets:

- https://app.asana.com/0/1126340469288208/1136844582647227/f
- https://app.asana.com/0/1126340469288208/1136844582647225/f

This one does relate to interactive step (dot size):
- https://app.asana.com/0/1126340469288208/1136845154729273

## How to test

Shrink down component at pattern-lab/patterns/02-components-micro-journeys-92-micro-journey-in-band/02-components-micro-journeys-92-micro-journey-in-band.html
