### PR TITLE
fix(pl-build): bump memory for PL build

### DIFF
--- a/packages/build-tools/tasks/pattern-lab-tasks.js
+++ b/packages/build-tools/tasks/pattern-lab-tasks.js
@@ -76,7 +76,7 @@ async function compile(errorShouldExit, dataOnly = false) {
       'php',
       [
         '-d',
-        'memory_limit=4048M',
+        'memory_limit=5072M',
         consolePath,
         '--generate',
         dataOnly ? '--dataonly' : '',


### PR DESCRIPTION
This fixes the out of memory errors I am getting on `epics/with-without`. It's a rather brute-force solution, so it is intended to start a conversation.

Originally, as I listed below, `yarn build` was working while `yarn start` was not, but now `yarn build` is not working either.

To replicate:
1. Checkout epics/with-without
2. rm -rf www
3. yarn start

Log:

```
[jeremy:~/www/bolt] epics/with-without(+532/-397,1)+* 2d1h43m6s 130 ± yarn start
yarn run v1.16.0
$ cd docs-site && yarn run start
$ bolt start


Verbosity: 2
Prod: false
i18n: true
enableSSR: false (auto set)
Rendering Mode: client
✔️ Finished gathering data on the latest Bolt Design System releases!
✔️ Finished building Bolt SVG Icons and schema!
✔️ Processed images in 227ms
✔️ Compiled Pattern Lab Data in 1.9s
⠋ Compiling Static Site...⠋ Building Pattern Lab for the first time...
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 548864 bytes) in /Users/jeremy/www/bolt/node_modules/@basalt/twig-renderer/vendor/ringcentral/psr7/src/functions.php on line 87
⠙ Building Pattern Lab for the first time...Error: request to http://127.0.0.1:36105/?type=renderFile failed, reason: connect ECONNREFUSED 127.0.0.1:36105
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```