### PR TITLE
fix(micro-journeys): add ie 11 shadow root wrapper to all bolt-animate

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/10-character.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/10-character.twig
@@ -4,16 +4,24 @@
         characterUrl="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/animated-bands-ltr.png"
     >
       <bolt-animate slot="top" idle="none">
-        Slot: top
+        <div is="shadow-root">
+          Slot: top
+        </div>
       </bolt-animate>
       <bolt-animate slot="left" idle="none">
-        Slot: left
+        <div is="shadow-root">
+          Slot: left
+        </div>
       </bolt-animate>
       <bolt-animate slot="right" idle="none">
-        Slot: right
+        <div is="shadow-root">
+         Slot: right
+        </div>
       </bolt-animate>
       <bolt-animate slot="bottom" idle="none">
-        Slot: bottom
+        <div is="shadow-root">
+          Slot: bottom
+        </div>
       </bolt-animate>
     </bolt-character>
   </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/15-character-kitchen-sink.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/15-character-kitchen-sink.twig
@@ -4,20 +4,28 @@
       size="small"
   >
     <bolt-animate slot="top" idle="none">
-      <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
-        <p slot="text">
-          I'm a small character
-        </p>
-      </bolt-status-dialogue-bar>
+      <div is="shadow-root">
+        <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
+          <p slot="text">
+            I'm a small character
+          </p>
+        </bolt-status-dialogue-bar>
+      </div>
     </bolt-animate>
     <bolt-animate slot="left" idle="none">
-      Slot: left
+      <div is="shadow-root">
+       Slot: left
+      </div>
     </bolt-animate>
     <bolt-animate slot="right" idle="none">
-      Slot: right
+      <div is="shadow-root">
+        Slot: right
+      </div>
     </bolt-animate>
     <bolt-animate slot="bottom" idle="none">
-      Slot: bottom
+      <div is="shadow-root">
+        Slot: bottom
+      </div>
     </bolt-animate>
   </bolt-character>
 </div>
@@ -27,17 +35,22 @@
       size="medium"
   >
     <bolt-animate slot="top" idle="none">
-      <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
-        <p slot="text">
-          I'm a medium character
-        </p>
-      </bolt-status-dialogue-bar>
+      <div is="shadow-root">
+        <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
+          <p slot="text">
+            I'm a medium character
+          </p>
+        </bolt-status-dialogue-bar>
+      </div>
     </bolt-animate>
     <bolt-animate slot="left" idle="none">
+      <div is="shadow-root"></div>
     </bolt-animate>
     <bolt-animate slot="right" idle="none">
+      <div is="shadow-root"></div>
     </bolt-animate>
     <bolt-animate slot="bottom" idle="none">
+      <div is="shadow-root"></div>
     </bolt-animate>
   </bolt-character>
 </div>
@@ -47,22 +60,28 @@
       size="large"
   >
     <bolt-animate slot="top" idle="none">
-      <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
-        <p slot="text">
-          I'm a large character
-        </p>
-      </bolt-status-dialogue-bar>
+      <div is="shadow-root">
+        <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
+          <p slot="text">
+            I'm a large character
+          </p>
+        </bolt-status-dialogue-bar>
+      </div>
     </bolt-animate>
     <bolt-animate slot="left">
-      <bolt-status-dialogue-bar icon-name="cloud" is-alert-message>
-        <p slot="text">
-          Bill is due!
-        </p>
-      </bolt-status-dialogue-bar>
+      <div is="shadow-root">
+        <bolt-status-dialogue-bar icon-name="cloud" is-alert-message>
+          <p slot="text">
+            Bill is due!
+          </p>
+        </bolt-status-dialogue-bar>
+      </div>
     </bolt-animate>
     <bolt-animate slot="right" idle="none">
+      <div is="shadow-root"></div>
     </bolt-animate>
     <bolt-animate slot="bottom" idle="none">
+      <div is="shadow-root"></div>
     </bolt-animate>
   </bolt-character>
 </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/20-connection.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/20-connection.twig
@@ -4,10 +4,14 @@
         connection-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/animated-bands-ltr.png"
     >
       <bolt-animate idle="none" slot="top">
-        top
+        <div is="shadow-root">
+          top
+        </div>
       </bolt-animate>
       <bolt-animate idle="pulse" slot="bottom">
-        bottom
+        <div is="shadow-root">
+          bottom
+        </div>
       </bolt-animate>
     </bolt-connection>
   </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/60-two-character-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/60-two-character-layout.twig
@@ -4,37 +4,47 @@
 {% set content %}
   <bolt-two-character-layout>
     <bolt-animate slot="character--left" in-order="1" in="fade-in-slide-up" out="fade-out" out-order="10">
-      <bolt-character size="medium">
+      <div is="shadow-root">
+       <bolt-character size="medium">
         <bolt-animate in="fade-in-slide-up" in-order="3" out="fade-out" slot="top" out-order="5">
-          <bolt-status-dialogue-bar is-alert-message>
-            <p slot="text">
-              Wow! That's a large bill!
-            </p>
-          </bolt-status-dialogue-bar>
+          <div is="shadow-root">
+            <bolt-status-dialogue-bar is-alert-message>
+              <p slot="text">
+                Wow! That's a large bill!
+              </p>
+            </bolt-status-dialogue-bar>
+          </div>
         </bolt-animate>
         <span slot="left" idle="none">
         </span>
         <span slot="bottom" idle="none">
         </span>
       </bolt-character>
+      </div>
     </bolt-animate>
     <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
-      <bolt-connection></bolt-connection>
+      <div is="shadow-root">
+        <bolt-connection></bolt-connection>
+      </div>
     </bolt-animate>
     <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" idle="pulse" idle-duration="2000" out-order="10">
-      <bolt-character size="medium">
+      <div is="shadow-root">
+       <bolt-character size="medium">
         <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
-          <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
-            <p slot="text">
-              Here to Help!
-            </p>
-          </bolt-status-dialogue-bar>
+          <div is="shadow-root">
+            <bolt-status-dialogue-bar dialogue-arrow-direction="down" icon-name="cloud">
+              <p slot="text">
+                Here to Help!
+              </p>
+            </bolt-status-dialogue-bar>
+          </div>
         </bolt-animate>
         <span slot="right" idle="none">
         </span>
         <span slot="bottom" idle="none">
         </span>
       </bolt-character>
+      </div>
     </bolt-animate>
   </bolt-two-character-layout>
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-five.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-five.twig
@@ -1,50 +1,61 @@
 <bolt-interactive-step tab-title="Fewer calls">
 {#  <span slot="title">Fewer calls</span>#}
-
   <bolt-animate slot="top" in="fade-in-slide-up" in-order="1" out="fade-out-slide-down" out-order="2">
     <bolt-two-character-layout>
       <bolt-animate slot="character--left" in-order="1" in="fade-in-slide-up" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
-          <bolt-animate in="fade-in-slide-up" in-order="20" out="fade-out" slot="top" out-order="5">
-            <bolt-status-dialogue-bar  dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
-                Thanks for being a valued customer!
-              </bolt-text>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <span slot="left"></span>
-          <span slot="bottom"></span>
-        </bolt-character>
+        <div is="shadow-root">
+          <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
+            <bolt-animate in="fade-in-slide-up" in-order="20" out="fade-out" slot="top" out-order="5">
+              <div is="shadow-root">
+                <bolt-status-dialogue-bar  dialogue-arrow-direction="down">
+                  <bolt-text slot="text" align="start" font-size="xsmall">
+                    Thanks for being a valued customer!
+                  </bolt-text>
+                </bolt-status-dialogue-bar>
+              </div>
+            </bolt-animate>
+            <span slot="left"></span>
+            <span slot="bottom"></span>
+          </bolt-character>
+        </div>
       </bolt-animate>
       <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
-        <bolt-connection connection-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/animated-bands-rtl.png"></bolt-connection>
+        <div is="shadow-root">
+          <bolt-connection connection-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/animated-bands-rtl.png"></bolt-connection>
+        </div>
       </bolt-animate>
       <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-happy.png">
-          <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
-            <bolt-status-dialogue-bar dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
-                Thanks so much for waiving my late fee!
-              </bolt-text>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <span slot="right" idle="none"></span>
-          <span slot="bottom" idle="none"></span>
-        </bolt-character>
+        <div is="shadow-root">
+          <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-happy.png">
+            <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
+              <div is="shadow-root">
+                <bolt-status-dialogue-bar dialogue-arrow-direction="down">
+                  <bolt-text slot="text" align="start" font-size="xsmall">
+                    Thanks so much for waiving my late fee!
+                  </bolt-text>
+                </bolt-status-dialogue-bar>
+              </div>
+            </bolt-animate>
+            <span slot="right" idle="none"></span>
+            <span slot="bottom" idle="none"></span>
+          </bolt-character>
+        </div>
       </bolt-animate>
     </bolt-two-character-layout>
   </bolt-animate>
 
   <bolt-animate slot="bottom" in="fade-in-slide-up" in-order="2" out-order="1" out="fade-out-slide-down">
-    <bolt-text>
-      When your customers’ billing issues are resolved quickly, you see results. Think higher customer satisfaction, fewer repeat calls, and lower average handle time (AHT).
-    </bolt-text>
-    <bolt-cta>
-      <bolt-text font-size="xsmall" slot="link" display="inline">
-        Find out how Cisco cut AHT in half
-        <bolt-icon name="chevron-right"></bolt-icon>
+    <div is="shadow-root">
+      <bolt-text>
+        When your customers’ billing issues are resolved quickly, you see results. Think higher customer satisfaction, fewer repeat calls, and lower average handle time (AHT).
       </bolt-text>
-    </bolt-cta>
+      <bolt-cta>
+        <bolt-text font-size="xsmall" slot="link" display="inline">
+          Find out how Cisco cut AHT in half
+          <bolt-icon name="chevron-right"></bolt-icon>
+        </bolt-text>
+      </bolt-cta>
+    </div>
   </bolt-animate>
 </bolt-interactive-step>
 

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-four.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-four.twig
@@ -1,58 +1,71 @@
 <bolt-interactive-step tab-title="Empowered agents">
 {#  <span slot="title">Empowered agents</span>#}
-
   <bolt-animate slot="top" in="fade-in-slide-up" in-order="1" out="fade-out-slide-down" out-order="2">
-    <bolt-two-character-layout>
-      <bolt-animate slot="character--left" in-order="1" in="fade-in-slide-up" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
-          <bolt-animate in="fade-in-slide-up" in-order="2" out="fade-out" slot="top" out-order="5">
-            <bolt-status-dialogue-bar  dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
-                You have a data roaming charge and a late fee. Would you like to waive the late fee?
-              </bolt-text>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <span slot="left"></span>
-          <span slot="bottom">
-            <bolt-cta>
-              <bolt-icon slot="icon" name="eye"></bolt-icon>
-              <bolt-text font-size="xsmall" slot="link" display="inline">
-                Agent view of billing charges
-                <bolt-icon name="chevron-right"></bolt-icon>
-              </bolt-text>
-            </bolt-cta>
-          </span>
-        </bolt-character>
-      </bolt-animate>
-      <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
-        <bolt-connection connection-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/animated-bands-rtl.png"></bolt-connection>
-      </bolt-animate>
-      <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-sad.png">
-          <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
-            <bolt-status-dialogue-bar icon-name="email" dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
-                Why is my bill so high?
-              </bolt-text>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <span slot="right" idle="none"></span>
-          <span slot="bottom" idle="none"></span>
-        </bolt-character>
-      </bolt-animate>
-    </bolt-two-character-layout>
+    <div is="shadow-root">
+      <bolt-two-character-layout>
+        <bolt-animate slot="character--left" in-order="1" in="fade-in-slide-up" out="fade-out" out-order="10">
+          <div is="shadow-root">
+            <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
+              <bolt-animate in="fade-in-slide-up" in-order="2" out="fade-out" slot="top" out-order="5">
+                <div is="shadow-root">
+                  <bolt-status-dialogue-bar  dialogue-arrow-direction="down">
+                  <bolt-text slot="text" align="start" font-size="xsmall">
+                    You have a data roaming charge and a late fee. Would you like to waive the late fee?
+                  </bolt-text>
+                </bolt-status-dialogue-bar>
+                </div>
+              </bolt-animate>
+              <span slot="left"></span>
+              <span slot="bottom">
+                <bolt-cta>
+                  <bolt-icon slot="icon" name="eye"></bolt-icon>
+                  <bolt-text font-size="xsmall" slot="link" display="inline">
+                    Agent view of billing charges
+                    <bolt-icon name="chevron-right"></bolt-icon>
+                  </bolt-text>
+                </bolt-cta>
+              </span>
+            </bolt-character>
+          </div>
+        </bolt-animate>
+        <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
+          <div is="shadow-root">
+            <bolt-connection connection-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/animated-bands-rtl.png"></bolt-connection>
+          </div>
+        </bolt-animate>
+        <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" out-order="10">
+          <div is="shadow-root">
+            <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-sad.png">
+            <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
+              <div is="shadow-root">
+                <bolt-status-dialogue-bar icon-name="email" dialogue-arrow-direction="down">
+                  <bolt-text slot="text" align="start" font-size="xsmall">
+                    Why is my bill so high?
+                  </bolt-text>
+                </bolt-status-dialogue-bar>
+              </div>
+            </bolt-animate>
+            <span slot="right" idle="none"></span>
+            <span slot="bottom" idle="none"></span>
+          </bolt-character>
+          </div>
+        </bolt-animate>
+      </bolt-two-character-layout>
+    </div>
   </bolt-animate>
 
   <bolt-animate slot="bottom" in="fade-in-slide-up" in-order="2" out-order="1" out="fade-out-slide-down">
-    <bolt-text>
-      If a customer does pick up the phone, your agents will be ready. Pega provides a detailed view of charges over time, and self-learning adaptive models guide agents with scripts. That way  they can always take the next best action for both your customer and your business.
-    </bolt-text>
-    <bolt-cta>
-      <bolt-text font-size="xsmall" slot="link" display="inline">
-        What do we mean by “next best action”?
-        <bolt-icon name="chevron-right"></bolt-icon>
+    <div is="shadow-root">
+      <bolt-text>
+        If a customer does pick up the phone, your agents will be ready. Pega provides a detailed view of charges over time, and self-learning adaptive models guide agents with scripts. That way  they can always take the next best action for both your customer and your business.
       </bolt-text>
-    </bolt-cta>
+      <bolt-cta>
+        <bolt-text font-size="xsmall" slot="link" display="inline">
+          What do we mean by “next best action”?
+          <bolt-icon name="chevron-right"></bolt-icon>
+        </bolt-text>
+      </bolt-cta>
+    </div>
   </bolt-animate>
 </bolt-interactive-step>
 

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-one.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-one.twig
@@ -1,51 +1,55 @@
 <bolt-interactive-step tab-title="Proactive service">
 {#  <span slot="title">Proactive service</span>#}
-
-  <bolt-animate slot="top" in-order="1" in="fade-in" out="fade-out-slide-down" out-order="2">
-    <bolt-two-character-layout>
-      <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
-          <span slot="top"></span>
-          <span slot="left"></span>
-          <span slot="bottom"><bolt-text font-size="xsmall">Company</bolt-text></span>
-          <bolt-animate slot="background" in="fade-in-fade-out" in-order="2" in-duration="4000">
-            <bolt-svg-animations
-                speed="4000"
-                animtype="Radar"
-                theme="dark"
-            ></bolt-svg-animations>
-          </bolt-animate>
-        </bolt-character>
-      </bolt-animate>
-      <bolt-animate slot="connection" in="fade-in" in-order="2" in-delay="3500" out="fade-out" out-order="1">
-        <bolt-connection></bolt-connection>
-      </bolt-animate>
-      <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-surprise.png">
-          <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
-            <bolt-status-dialogue-bar icon-name="mobility">
-              <bolt-text slot="text" align="start" font-size="xsmall">
-                You are about to reach <br>your monthly data limit...
-              </bolt-text>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <span slot="right" idle="none"></span>
-          <span slot="bottom" idle="none"><bolt-text font-size="xsmall">Customer</bolt-text></span>
-        </bolt-character>
-      </bolt-animate>
-    </bolt-two-character-layout>
+  <bolt-animate slot="top" in="fade-in-slide-up" in-order="1" out="fade-out-slide-down" out-order="2">
+    <div is="shadow-root">
+      <bolt-two-character-layout>
+        <bolt-animate slot="character--left" in-order="1" in="fade-in-slide-up" out="fade-out" out-order="10">
+          <div is="shadow-root">
+            <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png" animtype="Radar">
+              <span slot="top"></span>
+              <span slot="left"></span>
+              <span slot="bottom"><bolt-text font-size="xsmall">Company</bolt-text></span>
+            </bolt-character>
+          </div>
+        </bolt-animate>
+        <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
+          <div is="shadow-root">
+            <bolt-connection></bolt-connection>
+          </div>
+        </bolt-animate>
+        <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" out-order="10">
+          <div is="shadow-root">
+            <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-surprise.png">
+              <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
+                <div is="shadow-root">
+                  <bolt-status-dialogue-bar icon-name="mobility">
+                    <bolt-text slot="text" align="start" font-size="xsmall">
+                      You are about to reach <br>your monthly data limit...
+                    </bolt-text>
+                  </bolt-status-dialogue-bar>
+                </div>
+              </bolt-animate>
+              <span slot="right" idle="none"></span>
+              <span slot="bottom" idle="none"><bolt-text font-size="xsmall">Customer</bolt-text></span>
+            </bolt-character>
+          </div>
+        </bolt-animate>
+      </bolt-two-character-layout>
+    </div>
   </bolt-animate>
 
   <bolt-animate slot="bottom" in="fade-in-slide-up" in-order="2" out-order="1" out="fade-out-slide-down">
-    <bolt-text>
-      To avoid costly calls to your service center (and keep customers happy), you need to stay one step ahead. That’s why Pega’s real-time monitoring and pattern detection lets you sense a potential billing issue, then send your customer a proactive notification.
-    </bolt-text>
-    <bolt-cta>
-      <bolt-icon size="medium" slot="icon" name="asset-presentation"></bolt-icon>
-      <bolt-text font-size="xsmall" slot="link" display="inline">
-        It’s not mind-reading. It’s signals
-        <bolt-icon name="chevron-right"></bolt-icon>
+    <div is="shadow-root">
+      <bolt-text>
+        To avoid costly calls to your service center (and keep customers happy), you need to stay one step ahead. That’s why Pega’s real-time monitoring and pattern detection lets you sense a potential billing issue, then send your customer a proactive notification.
       </bolt-text>
-    </bolt-cta>
+      <bolt-cta>
+        <bolt-icon size="medium" slot="icon" name="asset-presentation"></bolt-icon>
+        <bolt-text font-size="xsmall" slot="link" display="inline">
+          It’s not mind-reading. It’s signals
+          <bolt-icon name="chevron-right"></bolt-icon>
+        </bolt-text>
+      </bolt-cta>
+    </div>
   </bolt-animate>
 </bolt-interactive-step>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-six.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-six.twig
@@ -1,37 +1,37 @@
 <bolt-interactive-step tab-title="What's next?">
 {#  <span slot="title">What's next?</span>#}
-
   <span slot="top">
   </span>
-
   <bolt-animate slot="bottom" in="fade-in-slide-up" in-order="1" out-order="1" out="fade-out-slide-down">
-    <bolt-text font-size="large">
-      Proactive customer service. Streamlined billing inquiries. Start delivering all of this and more with Pega Customer Service™.
-    </bolt-text>
-    <br>
-    <bolt-cta>
-      <bolt-icon size="medium" slot="icon" name="co-browse"></bolt-icon>
-      <bolt-text font-size="xsmall" slot="link" display="inline">
-        Explore our industry-leading software
-        <bolt-icon name="chevron-right"></bolt-icon>
+    <div is="shadow-root">
+      <bolt-text font-size="large">
+        Proactive customer service. Streamlined billing inquiries. Start delivering all of this and more with Pega Customer Service™.
       </bolt-text>
-    </bolt-cta>
-    <br>
-    <bolt-cta>
-      <bolt-icon size="medium" slot="icon" name="customer-service"></bolt-icon>
-      <bolt-text font-size="xsmall" slot="link" display="inline">
-        Learn more about intelligent guidance
-        <bolt-icon name="chevron-right"></bolt-icon>
-      </bolt-text>
-    </bolt-cta>
-    <br>
-    <bolt-cta>
-      <bolt-icon size="medium" slot="icon" name="eye"></bolt-icon>
-      <bolt-text font-size="xsmall" slot="link" display="inline">
-        Sign up for an upcoming demo
-        <bolt-icon name="chevron-right"></bolt-icon>
-      </bolt-text>
-    </bolt-cta>
+      <br>
+      <bolt-cta>
+        <bolt-icon size="medium" slot="icon" name="co-browse"></bolt-icon>
+        <bolt-text font-size="xsmall" slot="link" display="inline">
+          Explore our industry-leading software
+          <bolt-icon name="chevron-right"></bolt-icon>
+        </bolt-text>
+      </bolt-cta>
+      <br>
+      <bolt-cta>
+        <bolt-icon size="medium" slot="icon" name="customer-service"></bolt-icon>
+        <bolt-text font-size="xsmall" slot="link" display="inline">
+          Learn more about intelligent guidance
+          <bolt-icon name="chevron-right"></bolt-icon>
+        </bolt-text>
+      </bolt-cta>
+      <br>
+      <bolt-cta>
+        <bolt-icon size="medium" slot="icon" name="eye"></bolt-icon>
+        <bolt-text font-size="xsmall" slot="link" display="inline">
+          Sign up for an upcoming demo
+          <bolt-icon name="chevron-right"></bolt-icon>
+        </bolt-text>
+      </bolt-cta>
+    </div>
   </bolt-animate>
 </bolt-interactive-step>
 

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-three.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-three.twig
@@ -1,56 +1,64 @@
 <bolt-interactive-step tab-title="Smart offers">
 {#  <span slot="title">Smart offers</span>#}
-
   <bolt-animate slot="top" in="fade-in-slide-up" in-order="1" out="fade-out-slide-down" out-order="2">
-    <bolt-two-character-layout>
-      <bolt-animate slot="character--left" in-order="1" in="fade-in-slide-up" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
-          <bolt-animate in="fade-in-slide-up" in-order="2" out="fade-out" slot="top" out-order="5">
-            <bolt-status-dialogue-bar>
-              <bolt-text slot="text" align="start" font-size="xsmall">
-                Customer is 79% likely to call<br>about their bill.
-              </bolt-text>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <span slot="left"></span>
-          <span slot="bottom"><bolt-text font-size="xsmall">Company</bolt-text></span>
-          <bolt-svg-animations
-              slot="background"
-              speed="4000"
-              animtype="Orbit"
-          ></bolt-svg-animations>
-        </bolt-character>
-      </bolt-animate>
-      <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
-        <bolt-connection></bolt-connection>
-      </bolt-animate>
-      <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" out-order="10">
-        <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-neutral.png">
-          <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
-            <bolt-status-dialogue-bar icon-name="email">
-              <bolt-text slot="text" align="start" font-size="xsmall">
-                Offer to waive late fee.
-              </bolt-text>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <span slot="right" idle="none"></span>
-          <span slot="bottom" idle="none"><bolt-text font-size="xsmall">Customer</bolt-text></span>
-        </bolt-character>
-      </bolt-animate>
-    </bolt-two-character-layout>
+    <div is="shadow-root">
+      <bolt-two-character-layout>
+        <bolt-animate slot="character--left" in-order="1" in="fade-in-slide-up" out="fade-out" out-order="10">
+          <div is="shadow-root">
+            <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png" animtype="Orbit">
+              <bolt-animate in="fade-in-slide-up" in-order="2" out="fade-out" slot="top" out-order="5">
+                <div is="shadow-root">
+                  <bolt-status-dialogue-bar>
+                    <bolt-text slot="text" align="start" font-size="xsmall">
+                      Customer is 79% likely to call<br>about their bill.
+                    </bolt-text>
+                  </bolt-status-dialogue-bar>
+                </div>
+              </bolt-animate>
+              <span slot="left"></span>
+              <span slot="bottom"><bolt-text font-size="xsmall">Company</bolt-text></span>
+            </bolt-character>
+          </div>
+        </bolt-animate>
+        <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
+          <div is="shadow-root">
+           <bolt-connection></bolt-connection>
+          </div>
+        </bolt-animate>
+        <bolt-animate slot="character--right" in="fade-in-slide-up" in-order="10" out="fade-out" out-order="10">
+          <div is="shadow-root">
+            <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-neutral.png">
+              <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
+                <div is="shadow-root">
+                  <bolt-status-dialogue-bar icon-name="email">
+                    <bolt-text slot="text" align="start" font-size="xsmall">
+                      Offer to waive late fee.
+                    </bolt-text>
+                  </bolt-status-dialogue-bar>
+                </div>
+              </bolt-animate>
+              <span slot="right" idle="none"></span>
+              <span slot="bottom" idle="none"><bolt-text font-size="xsmall">Customer</bolt-text></span>
+            </bolt-character>
+          </div>
+        </bolt-animate>
+      </bolt-two-character-layout>
+    </div>
   </bolt-animate>
 
   <bolt-animate slot="bottom" in="fade-in-slide-up" in-order="2" out-order="1" out="fade-out-slide-down">
-    <bolt-text>
-      Use Pega’s AI-powered propensity modeling to determine the appropriate offer that gives your customer resolution she needs – without having to call your service center.
-    </bolt-text>
-    <bolt-cta>
-      <bolt-icon slot="icon" name="asset-presentation"></bolt-icon>
-      <bolt-text font-size="xsmall" slot="link" display="inline">
-        See this in action
-        <bolt-icon name="chevron-right"></bolt-icon>
+    <div is="shadow-root">
+      <bolt-text>
+        Use Pega’s AI-powered propensity modeling to determine the appropriate offer that gives your customer resolution she needs – without having to call your service center.
       </bolt-text>
-    </bolt-cta>
+      <bolt-cta>
+        <bolt-icon slot="icon" name="asset-presentation"></bolt-icon>
+        <bolt-text font-size="xsmall" slot="link" display="inline">
+          See this in action
+          <bolt-icon name="chevron-right"></bolt-icon>
+        </bolt-text>
+      </bolt-cta>
+    </div>
   </bolt-animate>
 </bolt-interactive-step>
 

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-two.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-two.twig
@@ -1,34 +1,39 @@
-<bolt-interactive-step tab-title="Customer-facing insights">
-{#  <span slot="title">Customer-facing insights</span>#}
-
+<bolt-interactive-step tab-title="Proactive service">
+  {#  <span slot="title">Proactive service</span>#}
   <bolt-animate slot="top" in="fade-in-slide-up" in-order="1" out="fade-out-slide-down" out-order="2">
-    <bolt-one-character-layout>
-      <bolt-character size="medium"  character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-sad.png">
-        <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
-          <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="down">
-            <bolt-text slot="text" align="start" font-size="xsmall">
-              Why is my bill so high? Let me check.
-            </bolt-text>
-          </bolt-status-dialogue-bar>
-        </bolt-animate>
-        <span slot="left"></span>
-        <span slot="right"></span>
-        <span slot="bottom">
-          <bolt-cta>
-            <bolt-icon slot="icon" name="eye"></bolt-icon>
-            <bolt-text font-size="xsmall" slot="link" display="inline">
-              Customer billing view
-              <bolt-icon name="chevron-right"></bolt-icon>
-            </bolt-text>
-          </bolt-cta>
-        </span>
-      </bolt-character>
-    </bolt-one-character-layout>
+    <div is="shadow-root">
+      <bolt-one-character-layout>
+        <bolt-character size="medium"  character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-sad.png">
+          <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
+            <div is="shadow-root">
+              <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="down">
+              <bolt-text slot="text" align="start" font-size="xsmall">
+                Why is my bill so high? Let me check.
+              </bolt-text>
+            </bolt-status-dialogue-bar>
+            </div>
+          </bolt-animate>
+          <span slot="left"></span>
+          <span slot="right"></span>
+          <span slot="bottom">
+            <bolt-cta>
+              <bolt-icon slot="icon" name="eye"></bolt-icon>
+              <bolt-text font-size="xsmall" slot="link" display="inline">
+                Customer billing view
+                <bolt-icon name="chevron-right"></bolt-icon>
+              </bolt-text>
+            </bolt-cta>
+          </span>
+        </bolt-character>
+      </bolt-one-character-layout>
+    </div>
   </bolt-animate>
 
   <bolt-animate slot="bottom" in="fade-in-slide-up" in-order="2" out-order="1" out="fade-out-slide-down">
-    <bolt-text>
-      If the billing issue is due to new fees and charges, the customer can log in and easily see what’s changed, thanks to Pega’s customer self-service view.
-    </bolt-text>
+    <div is="shadow-root">
+      <bolt-text>
+        If the billing issue is due to new fees and charges, the customer can log in and easily see what’s changed, thanks to Pega’s customer self-service view.
+      </bolt-text>
+    </div>
   </bolt-animate>
 </bolt-interactive-step>


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1131972308862944/f

## Summary

Wrap all `bolt-animate` internal contents with ` <div is="shadow-root"></div>` for ShadyDOM.


## How to test

Scan all micro journey components and ensure that they all look the same as before.

