### PR TITLE
Image | JS | Fix JS error when images are rendered

### DIFF
--- a/packages/components/bolt-image/src/image.js
+++ b/packages/components/bolt-image/src/image.js
@@ -94,19 +94,24 @@ class BoltImage extends withLitHtml() {
   rendered() {
     super.rendered && super.rendered();
 
-    // @todo: update to not keep querySelecting if element already found OR lazyloading is disabled
-    const lazyImage = this.renderRoot.querySelector('.js-lazyload');
+    const { noLazy } = this.validateProps(this.props);
 
-    if (lazyImage) {
-      // check if placeholder image has loaded; lazySizes will only unveil an image that is "complete"
-      if (!this.isLoaded) {
+    // if image should lazyload
+    if (!noLazy) {
+      const lazyImage = this.renderRoot.querySelector(
+        `.${lazySizes.cfg.lazyClass}`,
+      );
+
+      // if component contains a lazy image that is rendering for the first time
+      if (lazyImage && !this.isLoaded) {
+        // set a flag so that image is not lazyloaded on subsequent re-renders
         this.isLoaded = true;
 
-        // give a hint to lazysizes about any new images injected / added
-        lazySizes.elements.push(
-          this.renderRoot.querySelector(`.${lazySizes.cfg.lazyClass}`),
-        );
-        // lazySizes.autoSizer.checkElems(); force rechecks -- probably not needed
+        // `lazySizes.elements` may be undefined on first load. That's ok - the line below is just to catch JS injected images.
+        lazySizes.elements && lazySizes.elements.push(lazyImage);
+
+        // force rechecks -- probably not needed. @todo: can we remove?
+        // lazySizes.autoSizer.checkElems();
       }
     }
   }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1800

## Summary
Fix JS error when images are rendered.

## Details

We are pushing to an array that is sometimes undefined. Add a check to prevent a JS error.

## How to test

- Run branch locally: `fix/image-lazysizes-error`
- View basic image demo page and verify image loads as expected.
- In the console, run the following JS:
```
document.querySelector('body').insertAdjacentHTML('beforeend',  `
  <bolt-image src="https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/sprint-logo-color.png?itok=reLNq5Ki" srcset="https://demo6.d8.pega.com/sites/default/files/styles/50/public/media/images/2018-11/sprint-logo-color.png?itok=tnJpDmF0 50w, https://demo6.d8.pega.com/sites/default/files/styles/100/public/media/images/2018-11/sprint-logo-color.png?itok=4-Z206MY 100w, https://demo6.d8.pega.com/sites/default/files/styles/200/public/media/images/2018-11/sprint-logo-color.png?itok=rgYyadPq 200w, https://demo6.d8.pega.com/sites/default/files/styles/320/public/media/images/2018-11/sprint-logo-color.png?itok=l5iq5V_C 320w, https://demo6.d8.pega.com/sites/default/files/styles/480/public/media/images/2018-11/sprint-logo-color.png?itok=uBlYrz7N 480w, https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/sprint-logo-color.png?itok=reLNq5Ki 640w" alt="Sprint Logo" sizes="auto" ratio="960/540" placeholder-color="hsl(233, 33%, 97%)" placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></bolt-image>
  <bolt-image src="https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/vodafone-logo-color.png?itok=TC9PNZ1r" srcset="https://demo6.d8.pega.com/sites/default/files/styles/50/public/media/images/2018-11/vodafone-logo-color.png?itok=I2uTd36m 50w, https://demo6.d8.pega.com/sites/default/files/styles/100/public/media/images/2018-11/vodafone-logo-color.png?itok=E-poLzW2 100w, https://demo6.d8.pega.com/sites/default/files/styles/200/public/media/images/2018-11/vodafone-logo-color.png?itok=xCcjsl2A 200w, https://demo6.d8.pega.com/sites/default/files/styles/320/public/media/images/2018-11/vodafone-logo-color.png?itok=ytq5Mf2U 320w, https://demo6.d8.pega.com/sites/default/files/styles/480/public/media/images/2018-11/vodafone-logo-color.png?itok=P9mmOjpx 480w, https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/vodafone-logo-color.png?itok=TC9PNZ1r 640w" alt="Vodafone" sizes="auto" ratio="960/540" placeholder-color="hsl(233, 33%, 97%)" placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></bolt-image>
  <bolt-image src="https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/ee-logo-color_0.png?itok=PXXBsjmr" srcset="https://demo6.d8.pega.com/sites/default/files/styles/50/public/media/images/2018-11/ee-logo-color_0.png?itok=GfPAeRqI 50w, https://demo6.d8.pega.com/sites/default/files/styles/100/public/media/images/2018-11/ee-logo-color_0.png?itok=3aSzO68E 100w, https://demo6.d8.pega.com/sites/default/files/styles/200/public/media/images/2018-11/ee-logo-color_0.png?itok=L_LRGYxJ 200w, https://demo6.d8.pega.com/sites/default/files/styles/320/public/media/images/2018-11/ee-logo-color_0.png?itok=7104cUnt 320w, https://demo6.d8.pega.com/sites/default/files/styles/480/public/media/images/2018-11/ee-logo-color_0.png?itok=Gj06mO6T 480w, https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/ee-logo-color_0.png?itok=PXXBsjmr 640w" sizes="auto" ratio="960/540" placeholder-color="hsl(233, 33%, 97%)" placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></bolt-image>
  <bolt-image src="https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/elisa-logo-color.png?itok=fYcxfO2g" srcset="https://demo6.d8.pega.com/sites/default/files/styles/50/public/media/images/2018-11/elisa-logo-color.png?itok=x5tWvNP2 50w, https://demo6.d8.pega.com/sites/default/files/styles/100/public/media/images/2018-11/elisa-logo-color.png?itok=JvoQqB4- 100w, https://demo6.d8.pega.com/sites/default/files/styles/200/public/media/images/2018-11/elisa-logo-color.png?itok=bWF6OScT 200w, https://demo6.d8.pega.com/sites/default/files/styles/320/public/media/images/2018-11/elisa-logo-color.png?itok=HiwaiFBl 320w, https://demo6.d8.pega.com/sites/default/files/styles/480/public/media/images/2018-11/elisa-logo-color.png?itok=9RbDJcVB 480w, https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/elisa-logo-color.png?itok=fYcxfO2g 640w" alt="Elisa logo" sizes="auto" ratio="960/540" placeholder-color="hsl(233, 33%, 97%)" placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></bolt-image>
  <bolt-image src="https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/etisalat-logo-color.png?itok=Njxy2yHb" srcset="https://demo6.d8.pega.com/sites/default/files/styles/50/public/media/images/2018-11/etisalat-logo-color.png?itok=qq83Y6I3 50w, https://demo6.d8.pega.com/sites/default/files/styles/100/public/media/images/2018-11/etisalat-logo-color.png?itok=IS2Qz_A5 100w, https://demo6.d8.pega.com/sites/default/files/styles/200/public/media/images/2018-11/etisalat-logo-color.png?itok=NPQ7sbOz 200w, https://demo6.d8.pega.com/sites/default/files/styles/320/public/media/images/2018-11/etisalat-logo-color.png?itok=vHtC9Yli 320w, https://demo6.d8.pega.com/sites/default/files/styles/480/public/media/images/2018-11/etisalat-logo-color.png?itok=1MneyYuE 480w, https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/etisalat-logo-color.png?itok=Njxy2yHb 640w" alt="Etisalat Logo" sizes="auto" ratio="960/540" placeholder-color="hsl(233, 33%, 97%)" placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></bolt-image>
  <bolt-image src="https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/etisalat-logo-color.png?itok=Njxy2yHb" srcset="https://demo6.d8.pega.com/sites/default/files/styles/50/public/media/images/2018-11/etisalat-logo-color.png?itok=qq83Y6I3 50w, https://demo6.d8.pega.com/sites/default/files/styles/100/public/media/images/2018-11/etisalat-logo-color.png?itok=IS2Qz_A5 100w, https://demo6.d8.pega.com/sites/default/files/styles/200/public/media/images/2018-11/etisalat-logo-color.png?itok=NPQ7sbOz 200w, https://demo6.d8.pega.com/sites/default/files/styles/320/public/media/images/2018-11/etisalat-logo-color.png?itok=vHtC9Yli 320w, https://demo6.d8.pega.com/sites/default/files/styles/480/public/media/images/2018-11/etisalat-logo-color.png?itok=1MneyYuE 480w, https://demo6.d8.pega.com/sites/default/files/styles/640/public/media/images/2018-11/etisalat-logo-color.png?itok=Njxy2yHb 640w" alt="Etisalat Logo" sizes="auto" ratio="960/540" placeholder-color="hsl(233, 33%, 97%)" placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></bolt-image>
`);
```
- Verify these image injected via JS properly lazyload without throwing any JS errors.