### PR TITLE
Fix/tab panel restyling

### DIFF
--- a/packages/core/styles/01-settings/settings-themes/index.scss
+++ b/packages/core/styles/01-settings/settings-themes/index.scss
@@ -5,6 +5,7 @@
 
 // pre-defined theming system values
 $bolt-theme-ui-colors: (
+  // This is actually dark.
   light: (
     border: bolt-color(white),
     contrast-filter: grayscale(100%) invert(100%) brightness(150%),
@@ -19,6 +20,7 @@ $bolt-theme-ui-colors: (
     neutral: bolt-color(gray),
     brand: bolt-color(indigo),
   ),
+  // This is actually light.
   dark: (
     border: bolt-color(indigo, dark),
     contrast-filter: none,

--- a/packages/micro-journeys/src/interactive-pathway.scss
+++ b/packages/micro-journeys/src/interactive-pathway.scss
@@ -1,4 +1,5 @@
 @import '@bolt/core';
+@import './nav-shared';
 
 // Local interactive-pathway Variables
 
@@ -13,6 +14,9 @@
 //@import "@bolt/animations/utilities/utilities-animation";
 $bolt-interactive-step--dot-size: 1.2rem;
 .c-bolt-interactive-pathway {
+  $nav-circle-size: 12px;
+  $nav-circle-size--active: 14px;
+
   display: none;
   position: relative;
 
@@ -26,43 +30,41 @@ $bolt-interactive-step--dot-size: 1.2rem;
   @include bolt-mq(medium) {
     flex-wrap: nowrap;
     justify-content: space-between;
+
     &__nav {
       display: block;
-      flex-grow: 0;
-      flex-shrink: 0;
-      width: 300px;
-      padding-left: 20px;
+      flex: 0 1;
+      position: relative;
+      margin-right: bolt-spacing(large);
     }
+
     &__nav-item {
       position: relative;
-      cursor: pointer;
+      @include bolt-micro-journeys-nav-title;
 
       &:before {
-        content: '';
-        display: inline-block;
-        position: absolute;
-        top: 0;
-        left: 4px;
-        z-index: 10;
-        margin-bottom: 1.65rem;
-        color: #AAB2F2;
-        font-size: $bolt-interactive-step--dot-size;
-        transition: color 0.5s ease, transform 0.5s ease;
+        @include bolt-micro-journeys-nav-dot($nav-circle-size, $nav-circle-size--active);
       }
+
+      &:after {
+        @include bolt-micro-journeys-nav-line;
+      }
+
       &--active {
-        transform: scale(1.1) translateX(4px);
-        color: orange;
-        cursor: default;
+        @include bolt-micro-journeys-nav-title($active: true);
+
         &:before {
-          transform: scale(1.5);
-          color: orange;
+          @include bolt-micro-journeys-nav-dot($nav-circle-size, $nav-circle-size--active, $active: true);
         }
       }
+
+      &:last-of-type:after {
+        display: none;
+      }
     }
+
     &__items {
-      flex-grow: 0;
-      flex-shrink: 0;
-      width: calc(100% - 301px);
+      flex: 1 1;
     }
   }
 }
@@ -75,3 +77,6 @@ bolt-interactive-pathway {
   margin-bottom: 0 !important; // override the global vertical spacing rhythm, as only one is visible in any list
 }
 
+.c-bolt-interactive-pathway__nav-item:last-of-type {
+
+}

--- a/packages/micro-journeys/src/interactive-step.js
+++ b/packages/micro-journeys/src/interactive-step.js
@@ -92,9 +92,7 @@ class BoltInteractiveStep extends withLitHtml() {
     );
   }
 
-  getThemeFromParent() {
-
-  }
+  getThemeFromParent() {}
 
   render() {
     // validate the original prop data passed along -- returns back the validated data w/ added default values

--- a/packages/micro-journeys/src/interactive-step.js
+++ b/packages/micro-journeys/src/interactive-step.js
@@ -92,6 +92,10 @@ class BoltInteractiveStep extends withLitHtml() {
     );
   }
 
+  getThemeFromParent() {
+
+  }
+
   render() {
     // validate the original prop data passed along -- returns back the validated data w/ added default values
     const { disabled, tabTitle } = this.validateProps(this.props);
@@ -120,7 +124,6 @@ class BoltInteractiveStep extends withLitHtml() {
         <header
           class="${titleClasses}"
           @click=${() => this.triggerStepChange()}
-          style="font-weight: ${this._isActiveStep ? 'bold' : 'normal'}"
         >
           ${tabTitle}
         </header>

--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -1,91 +1,50 @@
 @import '@bolt/core';
 @import '@bolt/animations';
-
-// Local interactive-step Variables
-
-// Register Custom Block Element
-@include bolt-custom-element('bolt-interactive-step', block, medium);
-
-$bolt-tooltip-bubble-triangle-width: 8px;
-$bolt-tooltip-bubble-border-color: bolt-color(gray, light);
-$bolt-tooltip-transition: $bolt-transition;
-$bolt-interactive-step-left-padding: 42px;
-$bolt-interactive-step-line-left-pos: 4.5px;
-$bolt-interactive-step--dot-size: 1.2rem;
-$bolt-interactive-step-bottom-padding: 5rem;
-
+@import './nav-shared';
 
 bolt-interactive-step {
   // Override generic styles from _generic-shared.scss
-  &:not(:last-child) {
-    margin-bottom: 0;
-  }
+  margin-bottom: 0 !important;
 }
 
+
 .c-bolt-interactive-step {
+  $nav-circle-size: 12px;
+  $nav-circle-size--active: 14px;
+
   position: relative;
-  overflow: hidden;
-  //Styles go here. /* [1] */
   text-align: left;
 
-  //transition: font-size 0.5s ease;
+  &__title {
 
-  @include bolt-mq(medium) {
-    &__title {
+    @include bolt-micro-journeys-nav-title;
+    @include bolt-mq(medium) {
       display: none;
     }
-  }
 
-  &__nav-item-wrapper {
-    display: flex;
-    align-items: center;
-    padding-bottom: $bolt-interactive-step-bottom-padding;
-
-    @include bolt-mq(medium) {
-      position: relative;
-      top: 0;
-    }
-  }
-
-  &__line {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: $bolt-interactive-step-line-left-pos;
-    z-index: 5;
-    height: 100%;
-    margin-left: 5px;
-    border-left: 1px solid #AAB2F2;
-
-    .c-bolt-interactive-step--first & {
-      top: 1em;
-      height: calc(100% - 1em);
+    .c-bolt-interactive-step--active & {
+      @include bolt-micro-journeys-nav-title($active: true);
     }
 
-    .c-bolt-interactive-step--last & {
-      height: calc(#{$bolt-interactive-step--dot-size});
+    // The nav dot on mobile
+    &:before {
+      @include bolt-micro-journeys-nav-dot;
+
+      .c-bolt-interactive-step--active & {
+        @include bolt-micro-journeys-nav-dot($active: true);
+      }
     }
-  }
 
-  &__dot {
-    position: absolute;
-    top: 0;
-    left: 4px;
-    z-index: 10;
-    margin-bottom: 1.65rem;
-    color: #AAB2F2;
-    cursor: pointer;
-    font-size: $bolt-interactive-step--dot-size;
-    transition: color 0.5s ease, transform 0.5s ease;
-  }
+    //c-bolt-interactive-pathway__nav-item c-bolt-interactive-pathway__nav-item--active
 
-  &__title {
-    display: inline-block;
-    margin-bottom: 1.65rem;
-    padding-top: .2em;
-    padding-left: $bolt-interactive-step-left-padding;
-    cursor: pointer;
-    transition: color 0.5s ease, transform 0.5s ease;
+    // The nav line on mobile
+    &:after {
+      @include bolt-micro-journeys-nav-line;
+
+      .c-bolt-interactive-step--last & {
+        display: none;
+      }
+    }
   }
 
   &__body {
@@ -94,19 +53,17 @@ bolt-interactive-step {
     align-items: center;
     position: absolute;
     left: -9999px;
+    padding-bottom: bolt-spacing(medium);
+    padding-left: bolt-spacing(medium);
 
     .c-bolt-interactive-step--active & {
       position: static;
-
-
-      //@include bolt-mq(medium) {
-      //  margin-left: 0;
-      //  padding-bottom: 0;
-      //}
     }
 
     .c-bolt-interactive-step--last & {
-      padding-left: .75rem; // This puts it aligned with the line, relative to dot width.
+      width: calc(100% + #{$nav-circle-size / 2});
+      margin-left: -$nav-circle-size / 2;
+      padding-left: 0;
     }
   }
 
@@ -116,23 +73,13 @@ bolt-interactive-step {
     justify-content: center;
     align-items: center;
     max-width: 100%;
+    overflow: hidden;
+
     @include bolt-mq(medium) {
       max-width: 700px;
     }
   }
-
-  // Generates the active state styling for the nav list
-  &--active {
-    font-weight: bolder;
-    .c-bolt-interactive-step__dot {
-      left: 4.5px;
-      transform: scale(1.5);
-      color: orange;
-    }
-
-    .c-bolt-interactive-step__title {
-      transform: scale(1.1) translateX(4px);
-      color: orange;
-    }
-  }
 }
+
+// Register Custom Block Element
+@include bolt-custom-element('bolt-interactive-step', block, medium);

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -1,0 +1,61 @@
+$header-text-size: 1rem;
+$header-text-line-height: 1.65;
+
+@mixin bolt-micro-journeys-nav-dot(
+  $nav-circle-size: 12px,
+  $nav-circle-size--active: 14px,
+  $active: false
+) {
+  @if $active {
+    $border-size: 2px;
+    background-color: bolt-theme(secondary);
+    width: $nav-circle-size--active;
+    height: $nav-circle-size--active;
+    margin-left: -$nav-circle-size--active / 2 - $border-size;
+    // @TODO only add this border on dark themes.
+    border: $border-size solid bolt-theme(primary);
+  }
+
+  @else {
+    content: '';
+    display: inline-block;
+    border-radius: 50%;
+    background-color: bolt-theme(primary);
+    width: $nav-circle-size;
+    height: $nav-circle-size;
+    margin-left: -$nav-circle-size / 2;
+    margin-right: bolt-spacing(small);
+    z-index: 1;
+  }
+}
+
+@mixin bolt-micro-journeys-nav-line() {
+  $top: $header-text-size * $header-text-line-height / 2;
+  $line-width: 1px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: $top;
+  left: -$line-width / 2;
+  width: $line-width;
+  height: 100%;
+  background-color: bolt-theme(primary);
+}
+
+@mixin bolt-micro-journeys-nav-title($active: false) {
+  @if $active {
+    font-weight: bolder;
+    color: bolt-theme(primary);
+    cursor: default;
+  }
+  @else {
+    white-space: nowrap;
+    font-size: $header-text-size;
+    line-height: $header-text-line-height;
+    display: flex;
+    align-items: center;
+    padding-bottom: 1.65rem;
+    cursor: pointer;
+    transition: color 0.5s ease, transform 0.5s ease;
+  }
+}

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -8,24 +8,24 @@ $header-text-line-height: 1.65;
 ) {
   @if $active {
     $border-size: 2px;
-    background-color: bolt-theme(secondary);
     width: $nav-circle-size--active;
     height: $nav-circle-size--active;
     margin-left: -$nav-circle-size--active / 2 - $border-size;
-    // @TODO only add this border on dark themes.
     border: $border-size solid bolt-theme(primary);
+    // @TODO there's no good way to match the comps here given we can't know what theme we're in b/c shadow dom.
+    background-color: bolt-theme(secondary);
   }
 
   @else {
     content: '';
     display: inline-block;
-    border-radius: 50%;
-    background-color: bolt-theme(primary);
+    z-index: 1;
     width: $nav-circle-size;
     height: $nav-circle-size;
-    margin-left: -$nav-circle-size / 2;
     margin-right: bolt-spacing(small);
-    z-index: 1;
+    margin-left: -$nav-circle-size / 2;
+    border-radius: 50%;
+    background-color: bolt-theme(primary);
   }
 }
 
@@ -44,18 +44,18 @@ $header-text-line-height: 1.65;
 
 @mixin bolt-micro-journeys-nav-title($active: false) {
   @if $active {
-    font-weight: bolder;
     color: bolt-theme(primary);
     cursor: default;
+    font-weight: bolder;
   }
   @else {
-    white-space: nowrap;
-    font-size: $header-text-size;
-    line-height: $header-text-line-height;
     display: flex;
     align-items: center;
     padding-bottom: 1.65rem;
+    white-space: nowrap;
+    line-height: $header-text-line-height;
     cursor: pointer;
+    font-size: $header-text-size;
     transition: color 0.5s ease, transform 0.5s ease;
   }
 }


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1137193458910292/f

Screenshot of themed component:
<img width="284" alt="image" src="https://user-images.githubusercontent.com/1361104/63967486-28682e00-ca63-11e9-99a4-8b2716b59ea7.png">

## Summary

Re-styled the tab panel after refactor and match comp colors.

## Details

I tested this in Chrome, FF, and Safari. Still can't test IE because it doesn't work there.

I talked to Mike Mai about this, and if a color var doesn't pass through `bolt_theme` or `bolt_color`, then it won't get themeified and if you use a css var directly it won't work in IE. So we can't use css vars directly

Since we are in the shadow dom, we can't detect if the wrapping `bolt-band` is `dark` or `light`. This means we can't apply conditionally stying outside of using `bolt_theme`, so we are limited. (Of course we could traverse up in JS and add a class, though.) This only affects the nav dot on `dark.`

Comps:
<img width="43" alt="image" src="https://user-images.githubusercontent.com/1361104/63967780-b6441900-ca63-11e9-8ad9-c3c001c6027b.png">

Our implementation:
<img width="43" alt="image" src="https://user-images.githubusercontent.com/1361104/63967799-c4923500-ca63-11e9-8228-7611996b0499.png">

## How to test

Make sure the nav panel matches the comps.


