### PR TITLE
fix(status-dialogue-bar): force black text

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/30-status-dialogue-bar.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/30-status-dialogue-bar.twig
@@ -1,9 +1,9 @@
 {% set content %}
   <div class="u-bolt-padding-large">
     <bolt-status-dialogue-bar>
-      <bolt-text size="xsmall" slot="text">
+      <p slot="text">
         Hey now!
-      </bolt-text>
+      </p>
     </bolt-status-dialogue-bar>
   </div>
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-five.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-five.twig
@@ -7,9 +7,9 @@
         <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
           <bolt-animate in="fade-in-slide-up" in-order="20" out="fade-out" slot="top" out-order="5">
             <bolt-status-dialogue-bar  dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
+              <p slot="text">
                 Thanks for being a valued customer!
-              </bolt-text>
+              </p>
             </bolt-status-dialogue-bar>
           </bolt-animate>
           <span slot="left"></span>
@@ -23,9 +23,9 @@
         <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-happy.png">
           <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
             <bolt-status-dialogue-bar dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
+              <p slot="text">
                 Thanks so much for waiving my late fee!
-              </bolt-text>
+              </p>
             </bolt-status-dialogue-bar>
           </bolt-animate>
           <span slot="right" idle="none"></span>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-four.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-four.twig
@@ -7,9 +7,9 @@
         <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
           <bolt-animate in="fade-in-slide-up" in-order="2" out="fade-out" slot="top" out-order="5">
             <bolt-status-dialogue-bar  dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
+              <p slot="text">
                 You have a data roaming charge and a late fee. Would you like to waive the late fee?
-              </bolt-text>
+              </p>
             </bolt-status-dialogue-bar>
           </bolt-animate>
           <span slot="left"></span>
@@ -31,9 +31,9 @@
         <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-sad.png">
           <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
             <bolt-status-dialogue-bar icon-name="email" dialogue-arrow-direction="down">
-              <bolt-text slot="text" align="start" font-size="xsmall">
+              <p slot="text">
                 Why is my bill so high?
-              </bolt-text>
+              </p>
             </bolt-status-dialogue-bar>
           </bolt-animate>
           <span slot="right" idle="none"></span>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-one.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-one.twig
@@ -24,9 +24,9 @@
         <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-surprise.png">
           <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
             <bolt-status-dialogue-bar icon-name="mobility">
-              <bolt-text slot="text" align="start" font-size="xsmall">
+              <p slot="text">
                 You are about to reach <br>your monthly data limit...
-              </bolt-text>
+              </p>
             </bolt-status-dialogue-bar>
           </bolt-animate>
           <span slot="right" idle="none"></span>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-three.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-three.twig
@@ -7,10 +7,11 @@
         <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/u-comm-plus.png">
           <bolt-animate in="fade-in-slide-up" in-order="2" out="fade-out" slot="top" out-order="5">
             <bolt-status-dialogue-bar>
-              <bolt-text slot="text" align="start" font-size="xsmall">
+              <p slot="text">
                 Customer is 79% likely to call<br>about their bill.
-              </bolt-text>
+              </p>
             </bolt-status-dialogue-bar>
+              <p slot="text">
           </bolt-animate>
           <span slot="left"></span>
           <span slot="bottom"><bolt-text font-size="xsmall">Company</bolt-text></span>
@@ -28,9 +29,9 @@
         <bolt-character size="medium" character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-neutral.png">
           <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
             <bolt-status-dialogue-bar icon-name="email">
-              <bolt-text slot="text" align="start" font-size="xsmall">
+              <p slot="text">
                 Offer to waive late fee.
-              </bolt-text>
+              </p>
             </bolt-status-dialogue-bar>
           </bolt-animate>
           <span slot="right" idle="none"></span>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-two.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/micro-journeys/billing-micro-journey-fragments/_step-two.twig
@@ -6,9 +6,9 @@
       <bolt-character size="medium"  character-url="https://github.com/basaltinc/temp-pega-dummy-assets/raw/master/customer-sad.png">
         <bolt-animate in="fade-in-slide-up" in-order="15" out="fade-out" slot="top" out-order="5">
           <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="down">
-            <bolt-text slot="text" align="start" font-size="xsmall">
+            <p slot="text">
               Why is my bill so high? Let me check.
-            </bolt-text>
+            </p>
           </bolt-status-dialogue-bar>
         </bolt-animate>
         <span slot="left"></span>

--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -11,10 +11,10 @@ $bolt-tooltip-bubble-triangle-width: 8px;
   display: flex;
   align-items: center;
   max-width: 300px;
+  padding: bolt-spacing(xsmall) bolt-spacing(small);
   color: bolt-color(black);
   border-radius: $bolt-border-radius;
   background-color: bolt-color(white);
-  @include bolt-padding(xsmall);
   @include bolt-shadow('level-20', true);
 
   &--alert {
@@ -32,7 +32,11 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 
   &__slot {
     &--text {
-      font-size: $bolt-font-size--xsmall;
+      color: bolt-color(black);
+      line-height: ($bolt-line-height--xsmall + 0.2);
+      text-align: left;
+      @include bolt-font-weight(regular);
+      @include bolt-font-size(xsmall);
     }
   }
 


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1136467560091702

## Summary

force black text; remove bolt-text passed to dialog; widen left/right padding

## Details

The problem was that `bolt-text` components embedded in `bolt-status-dialogue-bar` can only use the color of the theme text (unless you pass in an additional class in the `attributes` property). 

The solution was to only pass in `p` tags and then style the component to match the `<bolt-text font-size="xsmall">`

## How to test

Check out tpattern-lab/patterns/02-components-micro-journeys-92-micro-journey-in-band/02-components-micro-journeys-92-micro-journey-in-band.html, make sure that the `dark` theme text in the dialog is visible.
