### PR TITLE
fix: mobile styling of status bars, no longer overlap

### DIFF
--- a/packages/micro-journeys/src/one-character-layout.scss
+++ b/packages/micro-journeys/src/one-character-layout.scss
@@ -1,6 +1,12 @@
+@import "@bolt/core";
+
 .c-bolt-one-character-layout {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  margin: 80px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters
+  margin: 110px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters
+
+  @include bolt-mq(small) {
+    margin: 90px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters
+  }
 }

--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -10,12 +10,16 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 .c-bolt-status-dialogue-bar {
   display: flex;
   align-items: center;
-  max-width: 300px;
+  max-width: 110px;
   padding: bolt-spacing(xsmall) bolt-spacing(small);
   color: bolt-color(black);
   border-radius: $bolt-border-radius;
   background-color: bolt-color(white);
   @include bolt-shadow('level-20', true);
+
+  @include bolt-mq(small) {
+    max-width: 300px;
+  }
 
   &--alert {
     color: bolt-color(white);

--- a/packages/micro-journeys/src/two-character-layout.scss
+++ b/packages/micro-journeys/src/two-character-layout.scss
@@ -1,9 +1,15 @@
+@import '@bolt/core';
+
 .c-bolt-two-character-layout {
   &__character-row {
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    margin: 80px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters
+    margin: 90px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters
+
+    @include bolt-mq(small) {
+      margin: 110px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters
+    }
   }
 
   &__character {


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1126340469288208/1138736873218902/f

## Summary

Status bars no longer overlap on mobile layouts.
