### PR TITLE
feat(bolt-animate): add debug optional debug flag

### DIFF
--- a/packages/components/bolt-animate/utils.js
+++ b/packages/components/bolt-animate/utils.js
@@ -77,7 +77,7 @@ export async function triggerAnims({ animEls, stage = 'IN', debug = false }) {
   let eventName;
   switch (stage) {
     case 'IN':
-      eventName = 'bolt-animate:end:out';
+      eventName = 'bolt-animate:end:in';
       orderProp = 'inOrder';
       hasAnimProp = 'hasAnimIn';
       break;

--- a/packages/components/bolt-animate/utils.js
+++ b/packages/components/bolt-animate/utils.js
@@ -2,9 +2,11 @@
  * @param {Object} opt
  * @param {BoltAnimate[]} opt.animEls
  * @param {string} [opt.stage='IN']
+ * @param {boolean} [opt.debug=false]
+ *
  * @return {Promise<{ success: boolean, animEl: BoltAnimate }[]>}
  */
-async function triggerAnimOnEls({ animEls, stage }) {
+async function triggerAnimOnEls({ animEls, stage, debug = false }) {
   let eventName = '';
   switch (stage) {
     case 'IN':
@@ -44,6 +46,9 @@ async function triggerAnimOnEls({ animEls, stage }) {
               triggered = animEl.triggerAnimOut();
               break;
           }
+          if (debug) {
+            console.debug(`${eventName}`, animEl);
+          }
           if (!triggered) {
             reject(
               new Error(
@@ -64,16 +69,20 @@ async function triggerAnimOnEls({ animEls, stage }) {
  * @param {Object} opt
  * @param {BoltAnimate[]} opt.animEls
  * @param {string} [opt.stage='IN']
+ * @param {boolean=} [opt.debug=false]
  */
-export async function triggerAnims({ animEls, stage = 'IN' }) {
+export async function triggerAnims({ animEls, stage = 'IN', debug = false }) {
   let orderProp;
   let hasAnimProp;
+  let eventName;
   switch (stage) {
     case 'IN':
+      eventName = 'bolt-animate:end:out';
       orderProp = 'inOrder';
       hasAnimProp = 'hasAnimIn';
       break;
     case 'OUT':
+      eventName = 'bolt-animate:end:out';
       orderProp = 'outOrder';
       hasAnimProp = 'hasAnimOut';
       break;
@@ -89,11 +98,15 @@ export async function triggerAnims({ animEls, stage = 'IN' }) {
   const animOrders = [...orders].sort((a, b) => a - b);
 
   for (const order of animOrders) {
+    const animElsToTrigger = animEls
+      .filter(a => a[hasAnimProp])
+      .filter(a => a[orderProp] === order);
+    if (debug) {
+      console.debug(`${eventName}: order:${order}`, animElsToTrigger);
+    }
     // eslint-disable-next-line no-await-in-loop
     await triggerAnimOnEls({
-      animEls: animEls
-        .filter(a => a[hasAnimProp])
-        .filter(a => a[orderProp] === order),
+      animEls: animElsToTrigger,
       stage,
     });
   }

--- a/packages/components/bolt-animate/utils.js
+++ b/packages/components/bolt-animate/utils.js
@@ -108,6 +108,7 @@ export async function triggerAnims({ animEls, stage = 'IN', debug = false }) {
     await triggerAnimOnEls({
       animEls: animElsToTrigger,
       stage,
+      debug,
     });
   }
 


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1139247289936295/f

## Summary

Add debug code to bolt-animate

## Details

In with/without, I needed to see what animations were failing and why.

Having permanent debug code in place made it much easier to see.

I think we should make this permanent because animation sequencing is often tricky to debug.

## How to test
```
  await triggerAnims({
    animEls,
    stage: 'IN',
    debug: true, // <- here is the flag you can now use
  });
```
