### PR TITLE
fix(bolt-animate): remove animation-delay of 0 and force animation-du…

### DIFF
--- a/packages/components/bolt-animate/src/animate.js
+++ b/packages/components/bolt-animate/src/animate.js
@@ -134,12 +134,17 @@ class BoltAnimate extends withLitHtml() {
   }) {
     this._animStyle = {
       animationName,
-      animationDuration: `${animationDuration}ms`,
-      animationDelay: `${animationDelay}ms`,
+      // Safari breaks with 0ms animation-duration
+      animationDuration: `${Math.max(1, animationDuration)}ms`,
       animationFillMode,
       animationTimingFunction,
       animationIterationCount,
     };
+
+    // Safari breaks with 0ms animation-delay
+    if (animationDelay > 0) {
+      this._animStyle.animationDelay = `${animationDelay}ms`;
+    }
   }
 
   triggerAnimIn() {


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1139247289936292/f

## Summary

Fix bolt-animate in Safari

## Details

Remove animation-delay of 0 and force animation-duration to be 1 to fix Safari

## How to test

Roll through Micro Journeys in Safari
