### PR TITLE
feat: add three icon group for quick editor slot drop-in

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -81,6 +81,42 @@ const link = {
   content: `<bolt-link display="inline" valign="start">I'm a link</bolt-link>`,
 };
 
+const iconGroupVerticle = {
+  id: 'bolt-icon-group-vertical',
+  title: 'Icon Group (vertical)',
+  content: `
+<bolt-list display="block" spacing="small">
+  <bolt-list-item>
+    <bolt-icon name="mobility" size="large"></bolt-icon>
+  </bolt-list-item>
+  <bolt-list-item>
+    <bolt-icon name="documentation" size="large"></bolt-icon>
+  </bolt-list-item>
+  <bolt-list-item last="">
+    <bolt-icon name="print" size="large"></bolt-icon>
+  </bolt-list-item>
+</bolt-list>
+  `,
+};
+
+const iconGroupHorizontal = {
+  id: 'bolt-icon-group-horizontal',
+  title: 'Icon Group (horizontal)',
+  content: `
+<bolt-list display="inline" spacing="small">
+  <bolt-list-item>
+    <bolt-icon name="mobility" size="large"></bolt-icon>
+  </bolt-list-item>
+  <bolt-list-item>
+    <bolt-icon name="documentation" size="large"></bolt-icon>
+  </bolt-list-item>
+  <bolt-list-item last="">
+    <bolt-icon name="print" size="large"></bolt-icon>
+  </bolt-list-item>
+</bolt-list>
+  `,
+};
+
 const svgAnimations = {
   id: 'bolt-svg-animations',
   title: 'Svg Animtions',
@@ -95,6 +131,8 @@ const basicSlottableComponents = [
   basicText,
   cta,
   link,
+  iconGroupVerticle,
+  iconGroupHorizontal,
 ];
 
 const characterSlottableComponents = [];


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1126340469288208/1133408741134181/f

## Summary

Add two starter templates (vertical and horizontal) with three icons so an editor can quickly setup up the three icon set.

## Details

All the needed components were already available in the editor. However, it would have taken several convoluted steps to re-create the layout of three icons in a group. These templates make it simple for an editor to add a three icon group to any of the standard slots. 

## How to test

- Pull this branch and rebuild. 
- Go to http://localhost:3000/pattern-lab/patterns/06-experiments-micro-journeys-combos--92-micro-journey-in-themes/06-experiments-micro-journeys-combos--92-micro-journey-in-themes.html
- Turn on editing
- Select a character. Using the slot dropdowns, add a three icon group.
- Play with it. You can customize the icons etc.
