### PR TITLE
Feat/add modal to button

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/20-editor-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/20-editor-modal.twig
@@ -1,7 +1,10 @@
 {% set content %}
-  <bolt-button size="medium" width="auto" border-radius="regular" color="primary" on-click-target="editor-demo-modal" on-click="show">
-    <span>This is a Button triggering on on-page Modal</span>
+  <bolt-button size="medium" width="auto" border-radius="regular" color="primary" on-click-target="editor-demo__modal" on-click="show">
+    <span>This is a Button triggering an on-page Modal</span>
   </bolt-button>
+  <bolt-link on-click-target="editor-demo__modal" on-click="show" url="#">
+    This is a Link triggering an on-page Modal
+  </bolt-link>
 {% endset %}
 
 {% include '@bolt-components-editor/editor-in-pl.twig' with {
@@ -16,14 +19,14 @@
     showMeta: true,
     showMetaTitle: true,
     attributes: {
-      class: "editor-demo-modal"
+      class: "editor-demo__modal"
     }
   } only %}
 {% endset %}
 
 {% include "@bolt-components-modal/modal.twig" with {
   attributes: {
-    class: "editor-demo-modal"
+    class: "editor-demo__modal"
   },
   content: video_content,
   width: "optimal",

--- a/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/20-editor-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/20-editor-modal.twig
@@ -1,0 +1,33 @@
+{% set content %}
+  <bolt-button size="medium" width="auto" border-radius="regular" color="primary" on-click-target="editor-demo-modal" on-click="show">
+    <span>This is a Button triggering on on-page Modal</span>
+  </bolt-button>
+{% endset %}
+
+{% include '@bolt-components-editor/editor-in-pl.twig' with {
+  content: content,
+} only %}
+
+{% set video_content %}
+  {% include "@bolt-components-video/video.twig" with {
+    videoId: "3861325118001",
+    accountId: "1900410236",
+    playerId: "r1CAdLzTW",
+    showMeta: true,
+    showMetaTitle: true,
+    attributes: {
+      class: "editor-demo-modal"
+    }
+  } only %}
+{% endset %}
+
+{% include "@bolt-components-modal/modal.twig" with {
+  attributes: {
+    class: "editor-demo-modal"
+  },
+  content: video_content,
+  width: "optimal",
+  spacing: "none",
+  theme: "none",
+  scroll: "overall",
+} only %}

--- a/packages/components/bolt-button/button.schema.yml
+++ b/packages/components/bolt-button/button.schema.yml
@@ -69,6 +69,12 @@ properties:
     enum:
       - regular
       - full
+  on_click_target:
+    description: '`className` (e.g. "js-click-me") used in `querySelector` to reference a web component on the page. `onClick`, the `on_click` method name will be called on this element.'
+    type: string
+  on_click:
+    description: 'The name of a method on the `on_click_target`.'
+    type: string
   align:
     description: 'Horizontal alignment of items (text and icon) inside the button. Note: the values left and right are deprecated, use start and end instead.'
     type: string

--- a/packages/components/bolt-link/link.schema.yml
+++ b/packages/components/bolt-link/link.schema.yml
@@ -27,6 +27,12 @@ properties:
   target:
     type: string
     description: Specifies where to display the linked URL. This may also be passed as part of `attributes`.
+  on_click_target:
+    description: '`className` (e.g. "js-click-me") used in `querySelector` to reference a web component on the page. `onClick`, the `on_click` method name will be called on this element.'
+    type: string
+  on_click:
+    description: 'The name of a method on the `on_click_target`.'
+    type: string
   icon:
     type: object
     description: Bolt icon. Accepts the same options as Bolt Icon Component `@bolt-components-icon` plus an additional 'position' parameter that determines placement within the button.

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -604,7 +604,14 @@ export function setupBolt(editor) {
     extend: 'link',
     registerBlock: true,
     draggable: true,
-    propsToTraits: ['display', 'valign', 'url', 'isHeadline'],
+    propsToTraits: [
+      'display',
+      'valign',
+      'url',
+      'isHeadline',
+      'on_click',
+      'on_click_target',
+    ],
     slots: {
       default: true,
     },

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -81,7 +81,7 @@ const link = {
   content: `<bolt-link display="inline" valign="start">I'm a link</bolt-link>`,
 };
 
-const iconGroupVerticle = {
+const iconGroupVertical = {
   id: 'bolt-icon-group-vertical',
   title: 'Icon Group (vertical)',
   content: `
@@ -131,7 +131,7 @@ const basicSlottableComponents = [
   basicText,
   cta,
   link,
-  iconGroupVerticle,
+  iconGroupVertical,
   iconGroupHorizontal,
 ];
 
@@ -347,7 +347,13 @@ export function setupBolt(editor) {
     schema: buttonSchema,
     extend: 'text',
     initialContent: ['Button'],
-    propsToTraits: ['size', 'width', 'border_radius'],
+    propsToTraits: [
+      'size',
+      'width',
+      'border_radius',
+      'on_click',
+      'on_click_target',
+    ],
     extraTraits: [colorTrait],
   });
 


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1134089946798896

## Summary

Adds Modal functionality to Link and Button in Editor.

## Details

This adds attributes to Button and Link which trigger Modals. `on_click` has to be `show` and `on_click_target` has to match the class of the modal that's already on the page, presumably created by Drupal.

I have created these two PRs targeting `master` because we need the schema changes in Link and Button:
* https://github.com/bolt-design-system/bolt/pull/1415
* https://github.com/bolt-design-system/bolt/pull/1416

## How to test

Visit Editor > Editor Modal
