### PR TITLE
Fix/horizontal scroll on micro journeys

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/06-experiments/micro-journeys/_shadow-dom-demo.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/06-experiments/micro-journeys/_shadow-dom-demo.twig
@@ -17,9 +17,14 @@
 {% else %}
   {{ content }}
 {% endif %}
-<hr>
-<h2>Shadow DOM – yes:☝️ no:👇</h2>
-<hr>
+
+{# @TODO It makes no sense, but this and this alone fixes the 2px content overflow. #}
+<div style="width: calc(100vw - 2px);">
+  <hr>
+  <h2>Shadow DOM – yes:☝️ no:👇</h2>
+  <hr>
+</div>
+
 {# When Bolt Web Components are wrapped in a `<form>` element all children have Shadow DOM disabled automatically #}
 <form onsubmit="event.preventDefault()">
   {{ content }}

--- a/packages/micro-journeys/src/connection.js
+++ b/packages/micro-journeys/src/connection.js
@@ -18,7 +18,6 @@ class BoltConnection extends withLitHtml() {
     ...convertSchemaToProps(schema),
   };
 
-  // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
   constructor(self) {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
@@ -28,23 +27,27 @@ class BoltConnection extends withLitHtml() {
   render() {
     const { direction, animType, speed } = this.validateProps(this.props);
     const classes = cx('c-bolt-connection');
-
-    // @TODO hide top slot if there's no content
     return html`
       ${this.addStyles([styles])}
       <div class="${classes}">
-        <span class="c-bolt-connection__slot--top">
-          ${this.slot('top')}
-        </span>
+        ${this.slots.top &&
+          html`
+            <span class="c-bolt-connection__slot--top">
+              ${this.slot('top')}
+            </span>
+          `}
         <bolt-svg-animations
           class="c-bolt-connection__main-image"
           speed="${speed}"
           anim-type="${animType}"
           direction="${direction}"
         />
-        <span class="c-bolt-connection__slot--bottom">
-          ${this.slot('bottom')}
-        </span>
+        ${this.slots.bottom &&
+          html`
+            <span class="c-bolt-connection__slot--bottom">
+              ${this.slot('bottom')}
+            </span>
+          `}
       </div>
     `;
   }

--- a/packages/micro-journeys/src/interactive-pathway.scss
+++ b/packages/micro-journeys/src/interactive-pathway.scss
@@ -24,6 +24,7 @@ $bolt-interactive-step--dot-size: 1.2rem;
   &__nav {
     display: none;
   }
+
   @include bolt-mq(medium) {
     flex-wrap: nowrap;
     justify-content: space-between;
@@ -33,6 +34,7 @@ $bolt-interactive-step--dot-size: 1.2rem;
       flex: 0 1;
       position: relative;
       margin-right: bolt-spacing(large);
+      @include bolt-micro-journeys-nav-items-wrapper;
     }
 
     &__nav-item {

--- a/packages/micro-journeys/src/interactive-pathway.scss
+++ b/packages/micro-journeys/src/interactive-pathway.scss
@@ -35,8 +35,8 @@ $bolt-interactive-step--dot-size: 1.2rem;
     &__nav {
       display: block;
       position: relative;
-      margin-right: bolt-spacing(large);
       width: calc(30% - #{$half-gutter});
+      margin-right: bolt-spacing(large);
       @include bolt-micro-journeys-nav-items-wrapper;
     }
 

--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -35,8 +35,6 @@ bolt-interactive-step {
       }
     }
 
-    //c-bolt-interactive-pathway__nav-item c-bolt-interactive-pathway__nav-item--active
-
     // The nav line on mobile
     &:after {
       @include bolt-micro-journeys-nav-line;

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -61,3 +61,7 @@ $nav-circle-border-size: 2px;
     }
   }
 }
+
+@mixin bolt-micro-journeys-nav-items-wrapper() {
+  padding-left: ($nav-circle-size--active / 2) + $nav-circle-border-size;
+}


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1138723683848313/f

## Summary

* wrap shadow dom hrs in width to remove 2px horizontal scroll
* fix(interactive-step): add padding for nav dot truncation
* fix(micro-journeys): don't print top and bottom slots when empty

## Details

This PR was a bit of a saga. I started by fixing two things I thought were likely candidates:

1. In connection, don't print top or bottom slot if it has no content. 

This is what the ticket recommended. Great, that was easy, but still horizontal scroll.

2. Fix dot and line nav  overflowing the left margin.

Alright, great. But still had overflow.

3. I started hiding elements. When the following did not remove the horizontal scroll, I knew it was something weird:
```
body > div { display: none;}
```
What's more, this fixed it:

```
body { width: calc(100vw - 2px);}
```


I figured out that it was the `hr` components overflowing. So my fix was this:
```
<div style="width: calc(100vw - 2px);">
  <hr>
  <h2>Shadow DOM – yes:☝️ no:👇</h2>
  <hr>
</div>
```

WTF. But tested and working on Chrome and FF.

At least I wasn't losing my mind when I removed the horizontal scroll previously (I had removed all the shadow dom markup when I was testing, because otherwise I would have had to make fixes in two places.)

## How to test

Visit Micro Journeys page, see horizontal scroll remove on mobile and desktop widths.
