### PR TITLE
fix: comment-out findIndex polyfill for now, exposing a bug in table JS

### DIFF
--- a/packages/components/bolt-table/src/table.js
+++ b/packages/components/bolt-table/src/table.js
@@ -237,6 +237,8 @@ class BoltTable extends withLitHtml() {
     }
 
     function injectClasses(classes, attributes) {
+      // @todo: `findIndex` does not work in IE11 without a polyfill, so it silently stops/fails here.
+      // Once polyfilled, the table markup disappears on load. Come back to this, polyfill it, and fix he underlying table bug.
       const classIndex = attributes.findIndex(item => item.key === 'class');
 
       if (classIndex === -1) {

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -73,9 +73,15 @@ class BoltTabs extends withContext(withLitHtml()) {
     this.selectedIndex = this.validateIndex(selectedTab - 1);
 
     // Check if any panels have `selected` prop set, return index
-    const preselectedIndex = Array.from(panels).findIndex(element => {
-      return element.hasAttribute('selected');
-    });
+    // const preselectedIndex = Array.from(panels).findIndex(element => {
+    //   return element.hasAttribute('selected');
+    // });
+
+    // @todo: replace this with the block above once `findIndex` can be safely polyfilled
+    const panelsArray = Array.from(panels);
+    const preselectedIndex = panelsArray.indexOf(
+      panelsArray.find(element => element.hasAttribute('selected')),
+    );
 
     // If there is a preselected panel, it overrides `selectedTab` prop
     const initialSelectedTab =

--- a/packages/core/polyfills/index.js
+++ b/packages/core/polyfills/index.js
@@ -11,7 +11,8 @@ import 'core-js/modules/es.string.includes';
 import 'core-js/modules/es.string.repeat';
 import './custom-event-polyfill';
 import 'core-js/modules/es.array.find';
-import 'core-js/modules/es.array.find-index';
+// @todo: find-index polyfill is temporarily disabled until we can fix bug in table.js
+// import 'core-js/modules/es.array.find-index';
 import './symbol-polyfill';
 import './remove-polyfill';
 import '@webcomponents/template/template.js';


### PR DESCRIPTION
## Summary

Quick fix to address table JS bug exposed by polyfilling `findIndex`.