### PR TITLE
fix: manually backport Jest testing server fix added in v2.8.0-beta.1

### DIFF
--- a/.boltrc.js
+++ b/.boltrc.js
@@ -78,6 +78,7 @@ module.exports = {
     sets: imageSets,
   },
   prod: true,
+  sourceMaps: false,
   enableCache: true,
   verbosity: 1,
   copy: [...itemsToCopy],

--- a/packages/servers/testing-server/index.js
+++ b/packages/servers/testing-server/index.js
@@ -1,87 +1,26 @@
 const { handleRequest } = require('@bolt/api');
-const {
-  devMiddleware,
-  webpack,
-  express,
-} = require('@bolt/build-tools/webpack-dev-server');
-const { join } = require('path');
-const globby = require('globby');
+const { express } = require('@bolt/build-tools/webpack-dev-server');
 const app = express();
 const path = require('path');
 
 const port = process.env.PORT || 4444;
-const createWebpackConfig = require('@bolt/build-tools/create-webpack-config');
 const { getConfig } = require('@bolt/build-tools/utils/config-store');
+const webpackTasks = require('@bolt/build-tools/tasks/webpack-tasks');
 
 let server;
 
-// @todo: re-evaluate if this is worthwhile to re-enable
-// const allComponentsWithTests = globby
-//   .sync(
-//     path.join(__dirname, '../../../', '/packages/components/**/__tests__'),
-//     {
-//       onlyDirectories: true,
-//     },
-//   )
-//   .map(testsDirPath =>
-//     require(path.join(path.resolve(testsDirPath, '..'), 'package.json')),
-//   )
-//   .map(pkg => pkg.name);
-
 getConfig().then(async boltConfig => {
   let config = boltConfig;
-
-  // don't compile anything in Webpack except for the exported JSON data from Bolt's Design Tokens + all packages with tests
-  // config.components.global = [
-  //   './packages/core/styles/index.scss',
-  //   '@bolt/global',
-  //   ...allComponentsWithTests,
-  // ];
-
-  config.mode = 'client';
-  config.components.individual = [];
-  config.prod = true;
-  config.sourceMaps = false;
-
-  const webpackConfig = await createWebpackConfig(config);
-  const compiler = webpack(webpackConfig);
-
-  // This function makes server rendering of asset references consistent with different webpack chunk/entry configurations
-  function normalizeAssets(assets) {
-    return Array.isArray(assets) ? assets : [assets];
-  }
-
-  app.use(
-    devMiddleware(compiler, {
-      serverSideRender: true,
-      stats: webpackConfig[0].devServer.stats,
-    }),
-  );
-
+  await webpackTasks.compile();
   app.use(express.static(path.relative(process.cwd(), config.wwwDir)));
 
-  // The following middleware would not be invoked until the latest build is finished.
   app.use((req, res) => {
-    const assetsByChunkName = res.locals.webpackStats.toJson().children[0]
-      .assetsByChunkName;
-    const fs = res.locals.fs;
-    const outputPath = res.locals.webpackStats.toJson().children[0].outputPath;
-
-    // then use `assetsByChunkName` for server-sider rendering
-    // For example, if you have only one main chunk:
     res.send(
       `<html class="js-fonts-loaded">
         <head>
           <title>Test</title>
-          <style>${normalizeAssets(assetsByChunkName['bolt-global'])
-            .filter(path => path.endsWith('.css'))
-            .map(path => fs.readFileSync(outputPath + '/' + path))
-            .join('\n')}</style>
-
-            ${normalizeAssets(assetsByChunkName['bolt-global'])
-              .filter(path => path.endsWith('.js'))
-              .map(path => `<script src="${path}"></script>`)
-              .join('\n')}
+          <link rel="stylesheet" href="/build/bolt-global.css" />
+          <script src="/build/bolt-global.js"></script>
         </head>
         <body>
           <!-- set #root to inline-block so VRT screenshots are only as wide as the component vs are always full width -->
@@ -110,7 +49,6 @@ getConfig().then(async boltConfig => {
   });
 
   app.redirect;
-
   // handle cleaning up + shutting down the server instance
   process.on('SIGTERM', shutDownSSRServer);
   process.on('SIGINT', shutDownSSRServer);


### PR DESCRIPTION
## Jira
N/A

## Summary
Precompiles Webpack vs using Webpack Dev Server to address Jest tests never running on Travis due to low memory. 
