### PR TITLE
test(testing-utils): remove error when multiple Twig files found

### DIFF
--- a/packages/testing/testing-utils/dependency-map.js
+++ b/packages/testing/testing-utils/dependency-map.js
@@ -62,16 +62,11 @@ async function getTwigFilePath(templateName) {
 
   const files = await globby(globPatterns);
 
-  if (files.length > 1) {
-    throw new Error(
-      `More than 1 possible Twig file found when looking for "${templateName}".`,
-    );
-  }
-
   if (files.length === 0) {
     throw new Error(`No Twig files found when looking for "${templateName}".`);
   }
 
+  // Return the first file found that matches, which is the behavior that PHP Twig does with Namespaces
   return files[0];
 }
 


### PR DESCRIPTION
I had seen this error on [another build](https://travis-ci.com/bolt-design-system/bolt/jobs/235285326#L509-L530):

```
FAIL __tests__/monorepo-deps.test.js (40.529s)
510  ● Bolt Components declare dependencies in package.json if used in Twig files › pkg: @bolt/components-action-blocks
511
512    More than 1 possible Twig file found when looking for "@bolt/icon.twig".
513
514  ● Bolt Components declare dependencies in package.json if used in Twig files › pkg: @bolt/components-device-viewer
515
516    More than 1 possible Twig file found when looking for "@bolt/icon.twig".
517
518  ● Bolt Components declare dependencies in package.json if used in Twig files › pkg: @bolt/components-form
519
520    More than 1 possible Twig file found when looking for "@bolt/icon.twig".
521
522  ● Bolt Components declare dependencies in package.json if used in Twig files › pkg: @bolt/components-headline
523
524    More than 1 possible Twig file found when looking for "@bolt/icon.twig".
525
526  ● Bolt Components declare dependencies in package.json if used in Twig files › pkg: @bolt/components-navbar
527
528    More than 1 possible Twig file found when looking for "@bolt/icon.twig".
529
530Test Suites: 1 failed, 1 passed, 2 total
```

Since PHP Twig will use the first file it finds in all of it's paths, I removed the error where more than one is found to match it.