### PR TITLE
Feature/micro journey character background slot

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -622,9 +622,17 @@ export function setupBolt(editor) {
     },
   });
 
+  // The bolt-svg-animations component is only used internally by the connection component,
+  // and as a background slot for the character component. The following bit of logic removes
+  // the connection bands from the schema so that they do not appear as options when editing
+  // the svg animations behind a character.
+  const svgAnimationsSchemaForCharacter = svgAnimationsSchema;
+  svgAnimationsSchemaForCharacter.properties.animType.enum = svgAnimationsSchema.properties.animType.enum.filter(
+    item => item !== 'connectionBand' && item !== 'tripleConnectionBand',
+  );
   registerBoltComponent({
     name: 'bolt-svg-animations',
-    schema: svgAnimationsSchema,
+    schema: svgAnimationsSchemaForCharacter,
     registerBlock: false,
     propsToTraits: ['animType', 'direction', 'speed', 'theme'],
   });


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1126340469288208/1139896238748449/f

## Summary

SVG animations slot behind character no longer offers the bands as options. The bands still work in bolt-connection (which uses SVG animations under the hood).

## Details


## How to test

- Start an editing session on a full micro-journey
- Select the svg-animations component behind a character (if it has one) -OR- select a character and add a background component (if it does not have one)
- Once the animation behind the character is selected, use the dropdown to select an "animType". Connection bands should NOT be an options here.
- Also check the bolt-connection. you should be able to edit this with no change from previous behavior