### PR TITLE
fix(editor): remove empty <bolt-animate>s on save

### DIFF
--- a/packages/editor/src/editor.js
+++ b/packages/editor/src/editor.js
@@ -263,9 +263,15 @@ export function enableEditor({ space, uiWrapper, config }) {
     }
 
     const newComponent = tempComponent.replaceWith(content);
-    if (selectAfterAdd) editor.select(newComponent);
+    // if `content` has more than one top level element, we'll get an array, so we need to get the parent element to select in editor and trigger possible animations
+    const singleComponent =
+      Array.isArray(newComponent) && newComponent.length > 0
+        ? newComponent[0].parent()
+        : newComponent;
+
+    if (selectAfterAdd) editor.select(singleComponent);
     if (triggerAnimsAfterAdd) {
-      const newEl = newComponent.getEl();
+      const newEl = singleComponent.getEl();
       triggerAnimsInEl(newEl);
     }
     return newComponent;

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -225,13 +225,24 @@ function init() {
           const container = editor.getContainer();
           cleanup();
           container.innerHTML = html;
+
+          // We need to make sure that any `<bolt-animate>` elements that are empty get removed. These are usually added via the slot controls, then had their children/contents (the actual elements being animated) deleted by user but the `<bolt-animate>` (which is almost always a slot) remains. We need this gone so that conditionals that check for empty slots don't return a false positive (i.e. conditional that says a slot is not empty but no visible elements are shown)
+          container.querySelectorAll('bolt-animate').forEach(
+            /** @type {HTMLElement} */
+            animEl => {
+              if (animEl.innerHTML === '') {
+                animEl.remove();
+              }
+            },
+          );
+
           trigger.innerText = 'Edit';
           editorState = EDITOR_STATES.CLOSED;
           pegaEditor.dispatchEvent(
             new CustomEvent('editor:save', {
               bubbles: true,
               detail: {
-                html,
+                html: container.innerHTML,
                 id: config.id,
               },
             }),

--- a/packages/micro-journeys/starters/one-character-1.html
+++ b/packages/micro-journeys/starters/one-character-1.html
@@ -7,8 +7,6 @@
         </p>
       </bolt-status-dialogue-bar>
     </bolt-animate>
-    <bolt-animate slot="left"></bolt-animate>
-    <bolt-animate slot="right"></bolt-animate>
     <bolt-animate slot="bottom">
           <bolt-cta>
             <bolt-animate slot="icon">

--- a/packages/micro-journeys/starters/one-character-lorem.html
+++ b/packages/micro-journeys/starters/one-character-lorem.html
@@ -7,8 +7,6 @@
         </p>
       </bolt-status-dialogue-bar>
     </bolt-animate>
-    <bolt-animate slot="left"></bolt-animate>
-    <bolt-animate slot="right"></bolt-animate>
     <bolt-animate slot="bottom">
           <bolt-cta>
             <bolt-animate slot="icon">

--- a/packages/micro-journeys/starters/steo-one-character-lorem.html
+++ b/packages/micro-journeys/starters/steo-one-character-lorem.html
@@ -10,8 +10,6 @@
             </p>
           </bolt-status-dialogue-bar>
         </bolt-animate>
-        <bolt-animate slot="left"></bolt-animate>
-        <bolt-animate slot="right"></bolt-animate>
         <bolt-animate slot="bottom">
           <bolt-cta>
             <bolt-animate slot="icon">

--- a/packages/micro-journeys/starters/steo-two-character-lorem.html
+++ b/packages/micro-journeys/starters/steo-two-character-lorem.html
@@ -4,7 +4,6 @@
     <bolt-two-character-layout>
       <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="1">
         <bolt-character size="medium" character-image="customer-surprise">
-          <bolt-animate slot="top"></bolt-animate>
           <bolt-animate slot="bottom"><bolt-text font-size="xsmall">lorem</bolt-text></bolt-animate>
           <bolt-animate slot="background" in="fade-in" in-order="1">
             <bolt-svg-animations

--- a/packages/micro-journeys/starters/two-characters-1.html
+++ b/packages/micro-journeys/starters/two-characters-1.html
@@ -1,7 +1,6 @@
 <bolt-two-character-layout>
   <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="10">
     <bolt-character size="medium" character-image="u-comm-plus">
-      <bolt-animate slot="top"></bolt-animate>
       <bolt-animate slot="bottom"><bolt-text font-size="xsmall">Company</bolt-text></bolt-animate>
       <bolt-animate slot="background" in="fade-in-fade-out" in-order="2" in-duration="2500">
         <bolt-svg-animations

--- a/packages/micro-journeys/starters/two-characters-3.html
+++ b/packages/micro-journeys/starters/two-characters-3.html
@@ -35,7 +35,6 @@
           </p>
         </bolt-status-dialogue-bar>
       </bolt-animate>
-      <bolt-animate slot="bottom" idle="none"></bolt-animate>
     </bolt-character>
   </bolt-animate>
 </bolt-two-character-layout>

--- a/packages/micro-journeys/starters/two-characters-4.html
+++ b/packages/micro-journeys/starters/two-characters-4.html
@@ -8,7 +8,6 @@
           </p>
         </bolt-status-dialogue-bar>
       </bolt-animate>
-      <bolt-animate slot="bottom"></bolt-animate>
     </bolt-character>
   </bolt-animate>
   <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
@@ -23,7 +22,6 @@
           </p>
         </bolt-status-dialogue-bar>
       </bolt-animate>
-      <bolt-animate slot="bottom" idle="none"></bolt-animate>
     </bolt-character>
   </bolt-animate>
 </bolt-two-character-layout>

--- a/packages/micro-journeys/starters/two-characters-lorem.html
+++ b/packages/micro-journeys/starters/two-characters-lorem.html
@@ -1,7 +1,6 @@
 <bolt-two-character-layout>
   <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="1">
     <bolt-character size="medium" character-image="customer-surprise">
-      <bolt-animate slot="top"></bolt-animate>
       <bolt-animate slot="bottom"><bolt-text font-size="xsmall">lorem</bolt-text></bolt-animate>
       <bolt-animate slot="background" in="fade-in" in-order="1">
         <bolt-svg-animations


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1126340469288208/1140098113160425/f

## Summary

remove empty `<bolt-animate>`s on save

## Details

We need to make sure that any `<bolt-animate>` elements that are empty get removed. These are usually added via the slot controls, then had their children/contents (the actual elements being animated) deleted by user but the `<bolt-animate>` (which is almost always a slot) remains. We need this gone so that conditionals that check for empty slots don't return a false positive (i.e. conditional that says a slot is not empty but no visible elements are shown)

## How to test

- Go to http://localhost:3000/pattern-lab/patterns/06-experiments-micro-journeys-combos--92-micro-journey-in-themes/06-experiments-micro-journeys-combos--92-micro-journey-in-themes.html
- Open console and run this to show there are no empty `<bolt-animate>` elements currently:
    - `[...document.querySelectorAll('bolt-animate')].filter(x => x.innerHTML === '').length`
- Click edit, find any bolt-animate and remove all of the children but not it using the editor
- Click save
- Click edit, go back to bolt-animate where you removed children; not that it is not present
