### PR TITLE
Add Theme Support To Interactive Pathways / Interactive Pathway

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-prettier": "^3.1.0",
     "globby": "^10.0.1",
-    "@bolt/testing-utils": "^2.6.0-beta.1",
+    "@bolt/testing-utils": "^2.8.0-beta.2",
     "find-pkg": "^2.0.0",
     "haunted": "^4.4.0",
     "husky": "^3.0.0",

--- a/packages/editor/src/editor.js
+++ b/packages/editor/src/editor.js
@@ -263,9 +263,15 @@ export function enableEditor({ space, uiWrapper, config }) {
     }
 
     const newComponent = tempComponent.replaceWith(content);
-    if (selectAfterAdd) editor.select(newComponent);
+    // if `content` has more than one top level element, we'll get an array, so we need to get the parent element to select in editor and trigger possible animations
+    const singleComponent =
+      Array.isArray(newComponent) && newComponent.length > 0
+        ? newComponent[0].parent()
+        : newComponent;
+
+    if (selectAfterAdd) editor.select(singleComponent);
     if (triggerAnimsAfterAdd) {
-      const newEl = newComponent.getEl();
+      const newEl = singleComponent.getEl();
       triggerAnimsInEl(newEl);
     }
     return newComponent;

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -225,13 +225,24 @@ function init() {
           const container = editor.getContainer();
           cleanup();
           container.innerHTML = html;
+
+          // We need to make sure that any `<bolt-animate>` elements that are empty get removed. These are usually added via the slot controls, then had their children/contents (the actual elements being animated) deleted by user but the `<bolt-animate>` (which is almost always a slot) remains. We need this gone so that conditionals that check for empty slots don't return a false positive (i.e. conditional that says a slot is not empty but no visible elements are shown)
+          container.querySelectorAll('bolt-animate').forEach(
+            /** @type {HTMLElement} */
+            animEl => {
+              if (animEl.innerHTML === '') {
+                animEl.remove();
+              }
+            },
+          );
+
           trigger.innerText = 'Edit';
           editorState = EDITOR_STATES.CLOSED;
           pegaEditor.dispatchEvent(
             new CustomEvent('editor:save', {
               bubbles: true,
               detail: {
-                html,
+                html: container.innerHTML,
                 id: config.id,
               },
             }),

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -461,7 +461,7 @@ export function setupBolt(editor) {
   registerBoltComponent({
     name: 'bolt-interactive-pathways',
     schema: pathwaysSchema,
-    propsToTraits: ['customImageSrc', 'imageAlt'],
+    propsToTraits: ['customImageSrc', 'imageAlt', 'theme'],
     category: 'Starters',
     blockTitle: 'Pathways',
     draggable: true,

--- a/packages/micro-journeys/src/interactive-pathway.js
+++ b/packages/micro-journeys/src/interactive-pathway.js
@@ -3,18 +3,21 @@ import {
   define,
   hasNativeShadowDomSupport,
   query,
+  withContext,
   convertSchemaToProps,
 } from '@bolt/core/utils';
 import { withLitHtml, html } from '@bolt/core';
 import classNames from 'classnames';
 import debounce from 'lodash.debounce';
+import { BoltInteractivePathwaysContext } from './interactive-pathways';
 import styles from './interactive-pathway.scss';
 import schema from './interactive-pathway.schema';
+
 
 let cx = classNames.bind(styles);
 
 @define
-class BoltInteractivePathway extends withLitHtml() {
+class BoltInteractivePathway extends withContext(withLitHtml()) {
   static is = 'bolt-interactive-pathway';
 
   static props = {
@@ -24,6 +27,14 @@ class BoltInteractivePathway extends withLitHtml() {
     },
     ...convertSchemaToProps(schema),
   };
+
+   // subscribe to specific props that are defined and available on the parent container
+  // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
+  static get consumes() {
+    return [
+      [BoltInteractivePathwaysContext, 'theme'],
+    ];
+  }
 
   // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
   // @ts-ignore
@@ -64,6 +75,7 @@ class BoltInteractivePathway extends withLitHtml() {
 
   connectedCallback() {
     super.connectedCallback();
+    this.context = this.contexts.get(BoltInteractivePathwaysContext);
 
     setTimeout(() => {
       this.dispatchEvent(
@@ -185,9 +197,13 @@ class BoltInteractivePathway extends withLitHtml() {
   };
 
   render() {
+    // Inherit theme from `interactive-pathways`
+    this.theme = this.context.theme;
+
     const classes = cx('c-bolt-interactive-pathway', {
       [`c-bolt-interactive-pathway--disabled`]: !this.isActivePathway,
       [`c-bolt-interactive-pathway--active`]: this.isActivePathway,
+      [`t-bolt-${this.theme}`]: this.theme,
     });
 
     const navClasses = cx('c-bolt-interactive-pathway__nav');

--- a/packages/micro-journeys/src/interactive-pathway.js
+++ b/packages/micro-journeys/src/interactive-pathway.js
@@ -13,7 +13,6 @@ import { BoltInteractivePathwaysContext } from './interactive-pathways';
 import styles from './interactive-pathway.scss';
 import schema from './interactive-pathway.schema';
 
-
 let cx = classNames.bind(styles);
 
 @define
@@ -28,12 +27,10 @@ class BoltInteractivePathway extends withContext(withLitHtml()) {
     ...convertSchemaToProps(schema),
   };
 
-   // subscribe to specific props that are defined and available on the parent container
+  // subscribe to specific props that are defined and available on the parent container
   // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
   static get consumes() {
-    return [
-      [BoltInteractivePathwaysContext, 'theme'],
-    ];
+    return [[BoltInteractivePathwaysContext, 'theme']];
   }
 
   // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context

--- a/packages/micro-journeys/src/interactive-pathway.scss
+++ b/packages/micro-journeys/src/interactive-pathway.scss
@@ -25,6 +25,18 @@ $bolt-interactive-step--dot-size: 1.2rem;
     display: none;
   }
 
+  &__nav-item {
+    &:before {
+      @include bolt-micro-journeys-nav-dot;
+    }
+
+    &--active {
+      &:before {
+        @include bolt-micro-journeys-nav-dot($active: true);
+      }
+    }
+  }
+
   @include bolt-mq(medium) {
     flex-wrap: nowrap;
     justify-content: space-between;
@@ -44,9 +56,6 @@ $bolt-interactive-step--dot-size: 1.2rem;
       position: relative;
       @include bolt-micro-journeys-nav-title;
 
-      &:before {
-        @include bolt-micro-journeys-nav-dot;
-      }
 
       &:after {
         @include bolt-micro-journeys-nav-line;
@@ -55,9 +64,6 @@ $bolt-interactive-step--dot-size: 1.2rem;
       &--active {
         @include bolt-micro-journeys-nav-title($active: true);
 
-        &:before {
-          @include bolt-micro-journeys-nav-dot($active: true);
-        }
       }
 
       &:last-of-type:after {

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -1,15 +1,26 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import {
+  props,
+  define,
+  hasNativeShadowDomSupport,
+  withContext,
+  defineContext,
+} from '@bolt/core/utils';
 import { withLitHtml, html, convertSchemaToProps } from '@bolt/core';
 import classNames from 'classnames/bind';
 import debounce from 'lodash.debounce';
 import styles from './interactive-pathways.scss';
+import themes from '@bolt/global/styles/06-themes/_themes.all.scss';
 import pathwaysLogo from './images/interactive-pathways-logo.png';
 import schema from './interactive-pathways.schema';
 
 let cx = classNames.bind(styles);
 
+export const BoltInteractivePathwaysContext = defineContext({
+  theme: schema.properties.theme.default,
+});
+
 @define
-class BoltInteractivePathways extends withLitHtml() {
+class BoltInteractivePathways extends withContext(withLitHtml()) {
   static is = 'bolt-interactive-pathways';
 
   static props = {
@@ -19,6 +30,12 @@ class BoltInteractivePathways extends withLitHtml() {
     },
     ...convertSchemaToProps(schema),
   };
+
+  // provide context info to children that subscribe
+  // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
+  static get provides() {
+    return [BoltInteractivePathwaysContext];
+  }
 
   // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
   // @ts-ignore
@@ -138,10 +155,17 @@ class BoltInteractivePathways extends withLitHtml() {
   }
 
   render() {
-    const { customImageSrc = pathwaysLogo, imageAlt } = this.validateProps(
-      this.props,
-    );
-    const classes = cx('c-bolt-interactive-pathways');
+    const {
+      customImageSrc = pathwaysLogo,
+      imageAlt,
+      theme,
+    } = this.validateProps(this.props);
+
+    this.contexts.get(BoltInteractivePathwaysContext).theme = theme;
+
+    const classes = cx('c-bolt-interactive-pathways', {
+      [`t-bolt-${theme}`]: theme,
+    });
 
     const titles = this.pathways.map((pathway, i) => pathway.getTitle());
 
@@ -192,7 +216,7 @@ class BoltInteractivePathways extends withLitHtml() {
     `;
 
     return html`
-      ${this.addStyles([styles])}
+      ${this.addStyles([styles, themes])}
       <div class="${classes}">
         <div class="c-bolt-interactive-pathways__header">
           <bolt-image

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -8,8 +8,8 @@ import {
 import { withLitHtml, html, convertSchemaToProps } from '@bolt/core';
 import classNames from 'classnames/bind';
 import debounce from 'lodash.debounce';
-import styles from './interactive-pathways.scss';
 import themes from '@bolt/global/styles/06-themes/_themes.all.scss';
+import styles from './interactive-pathways.scss';
 import pathwaysLogo from './images/interactive-pathways-logo.png';
 import schema from './interactive-pathways.schema';
 

--- a/packages/micro-journeys/src/interactive-pathways.schema.js
+++ b/packages/micro-journeys/src/interactive-pathways.schema.js
@@ -3,6 +3,12 @@ module.exports = {
   title: 'Interactive Pathways',
   type: 'object',
   properties: {
+    theme: {
+      type: 'string',
+      description: 'Sets the color theme used by an interactive pathway',
+      default: '',
+      enum: ['xlight', 'light', 'dark', 'xdark'],
+    },
     customImageSrc: {
       type: 'string',
       description:

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -1,8 +1,13 @@
+// @TODO these are just here for testing as per Mike Mai, and should be removed, not needed.
+@import '@bolt/global/styles/06-themes/themes.all.scss';
+@import "@bolt/global/styles/index.scss";
+
 $header-text-size: 1rem;
 $header-text-line-height: 1.65;
 $nav-circle-size: 12px;
 $nav-circle-size--active: 14px;
 $nav-circle-border-size: 2px;
+
 
 @mixin bolt-micro-journeys-nav-dot($active: false) {
   @if $active {
@@ -13,10 +18,12 @@ $nav-circle-border-size: 2px;
     // @TODO there's no good way to match the comps here given we can't know what theme we're in b/c shadow dom.
     background-color: bolt-theme(
       (
-        xdark: primary 1,
-        dark: primary 1,
-        light: secondary 1,
-        xlight: secondary 1
+        // needs to be yellow
+        xdark: primary,
+        dark: primary,
+        // needs to be white
+        light: secondary,
+        xlight: secondary,
       )
     );
   }

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -14,14 +14,19 @@ $nav-circle-border-size: 2px;
     width: $nav-circle-size--active;
     height: $nav-circle-size--active;
     margin-left: -$nav-circle-size--active / 2 - $nav-circle-border-size;
-    border: $nav-circle-border-size solid bolt-theme(primary);
-    // @TODO there's no good way to match the comps here given we can't know what theme we're in b/c shadow dom.
+    border: $nav-circle-border-size solid;
+    border-color: bolt-theme(
+      (
+        xdark: secondary,
+        dark: secondary,
+        light: primary,
+        xlight: primary,
+      )
+    );
     background-color: bolt-theme(
       (
-        // needs to be yellow
         xdark: primary,
         dark: primary,
-        // needs to be white
         light: secondary,
         xlight: secondary,
       )

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -11,7 +11,14 @@ $nav-circle-border-size: 2px;
     margin-left: -$nav-circle-size--active / 2 - $nav-circle-border-size;
     border: $nav-circle-border-size solid bolt-theme(primary);
     // @TODO there's no good way to match the comps here given we can't know what theme we're in b/c shadow dom.
-    background-color: bolt-theme(secondary);
+    background-color: bolt-theme(
+      (
+        xdark: primary 1,
+        dark: primary 1,
+        light: secondary 1,
+        xlight: secondary 1
+      )
+    );
   }
 
   @else {

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -4,6 +4,7 @@
 
 $header-text-size: 1rem;
 $header-text-line-height: 1.65;
+// @todo: switch to 20px when enabling consolidated / animated dot styles
 $nav-circle-size: 12px;
 $nav-circle-size--active: 14px;
 $nav-circle-border-size: 2px;
@@ -45,6 +46,45 @@ $nav-circle-border-size: 2px;
     border-radius: 50%;
     background-color: bolt-theme(primary);
   }
+
+  // @todo: enable animated dot + more consolidated styles
+  // @if $active {
+  //   transform: translateX(-50%) scale(0.85);
+  //   border: $nav-circle-border-size solid;
+  //   border-color: bolt-theme(
+  //     (
+  //       xdark: secondary,
+  //       dark: secondary,
+  //       light: primary,
+  //       xlight: primary,
+  //     )
+  //   );
+  //   background-color: bolt-theme(
+  //     (
+  //       xdark: primary,
+  //       dark: primary,
+  //       light: secondary,
+  //       xlight: secondary,
+  //     )
+  //   );
+  // }
+
+  // @else {
+  //   content: '';
+  //   display: inline-block;
+  //   box-sizing: content-box;
+  //   transform: translateX(-50%) scale(0.5);
+  //   z-index: 1;
+  //   width: $nav-circle-size;
+  //   height: $nav-circle-size;
+  //   margin-right: bolt-spacing(small);
+  //   border-radius: 50%;
+  //   border-width: 2px;
+  //   border-style: solid;
+  //   border-color: transparent;
+  //   background-color: bolt-theme(primary);
+  //   transition: all 0.2s ease;
+  // }
 }
 
 @mixin bolt-micro-journeys-nav-line() {

--- a/packages/micro-journeys/starters/one-character-1.html
+++ b/packages/micro-journeys/starters/one-character-1.html
@@ -7,8 +7,6 @@
         </p>
       </bolt-status-dialogue-bar>
     </bolt-animate>
-    <bolt-animate slot="left"></bolt-animate>
-    <bolt-animate slot="right"></bolt-animate>
     <bolt-animate slot="bottom">
           <bolt-cta>
             <bolt-animate slot="icon">

--- a/packages/micro-journeys/starters/one-character-lorem.html
+++ b/packages/micro-journeys/starters/one-character-lorem.html
@@ -7,8 +7,6 @@
         </p>
       </bolt-status-dialogue-bar>
     </bolt-animate>
-    <bolt-animate slot="left"></bolt-animate>
-    <bolt-animate slot="right"></bolt-animate>
     <bolt-animate slot="bottom">
           <bolt-cta>
             <bolt-animate slot="icon">

--- a/packages/micro-journeys/starters/steo-one-character-lorem.html
+++ b/packages/micro-journeys/starters/steo-one-character-lorem.html
@@ -10,8 +10,6 @@
             </p>
           </bolt-status-dialogue-bar>
         </bolt-animate>
-        <bolt-animate slot="left"></bolt-animate>
-        <bolt-animate slot="right"></bolt-animate>
         <bolt-animate slot="bottom">
           <bolt-cta>
             <bolt-animate slot="icon">

--- a/packages/micro-journeys/starters/steo-two-character-lorem.html
+++ b/packages/micro-journeys/starters/steo-two-character-lorem.html
@@ -4,7 +4,6 @@
     <bolt-two-character-layout>
       <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="1">
         <bolt-character size="medium" character-image="customer-surprise">
-          <bolt-animate slot="top"></bolt-animate>
           <bolt-animate slot="bottom"><bolt-text font-size="xsmall">lorem</bolt-text></bolt-animate>
           <bolt-animate slot="background" in="fade-in" in-order="1">
             <bolt-svg-animations

--- a/packages/micro-journeys/starters/two-characters-1.html
+++ b/packages/micro-journeys/starters/two-characters-1.html
@@ -1,7 +1,6 @@
 <bolt-two-character-layout>
   <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="10">
     <bolt-character size="medium" character-image="u-comm-plus">
-      <bolt-animate slot="top"></bolt-animate>
       <bolt-animate slot="bottom"><bolt-text font-size="xsmall">Company</bolt-text></bolt-animate>
       <bolt-animate slot="background" in="fade-in-fade-out" in-order="2" in-duration="2500">
         <bolt-svg-animations

--- a/packages/micro-journeys/starters/two-characters-3.html
+++ b/packages/micro-journeys/starters/two-characters-3.html
@@ -35,7 +35,6 @@
           </p>
         </bolt-status-dialogue-bar>
       </bolt-animate>
-      <bolt-animate slot="bottom" idle="none"></bolt-animate>
     </bolt-character>
   </bolt-animate>
 </bolt-two-character-layout>

--- a/packages/micro-journeys/starters/two-characters-4.html
+++ b/packages/micro-journeys/starters/two-characters-4.html
@@ -8,7 +8,6 @@
           </p>
         </bolt-status-dialogue-bar>
       </bolt-animate>
-      <bolt-animate slot="bottom"></bolt-animate>
     </bolt-character>
   </bolt-animate>
   <bolt-animate slot="connection" in="fade-in-slide-up" in-order="5" out="fade-out" out-order="1">
@@ -23,7 +22,6 @@
           </p>
         </bolt-status-dialogue-bar>
       </bolt-animate>
-      <bolt-animate slot="bottom" idle="none"></bolt-animate>
     </bolt-character>
   </bolt-animate>
 </bolt-two-character-layout>

--- a/packages/micro-journeys/starters/two-characters-lorem.html
+++ b/packages/micro-journeys/starters/two-characters-lorem.html
@@ -1,7 +1,6 @@
 <bolt-two-character-layout>
   <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="1">
     <bolt-character size="medium" character-image="customer-surprise">
-      <bolt-animate slot="top"></bolt-animate>
       <bolt-animate slot="bottom"><bolt-text font-size="xsmall">lorem</bolt-text></bolt-animate>
       <bolt-animate slot="background" in="fade-in" in-order="1">
         <bolt-svg-animations


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds color theming support to the Interactive Pathways / Interactive Pathway components (even when Shadow DOM is fully enabled) via `defineContext` and `withContext` + a top level `theme` prop that the parent / children are hooked into.

## Details
This should address the immediate issues flagged in #1443 and #1437 by no longer using `bolt-theme` inside of media queries in addition to superseding the POC approach in #1442 and #1423 

NOTE: Check out my last 4 commits on this to see what I specifically changed (you might want to cherry pick these updates into a fresh branch since I branched off of #1442 as my starting point for these). 

I noticed this [original branch](https://boltdesignsystem-q2pne98si.now.sh/pattern-lab/?p=viewall-experiments-micro-journeys) had some issues in IE 11 before these updates so I wanted to make sure this was called out ahead of time!

![image](https://user-images.githubusercontent.com/1617209/65545855-3e430480-dee4-11e9-8fb4-89f91a2c0778.png)

## How to test
- Review updates
- Cherry pick code / use as a starting point
- Double-check supported browsers
