### PR TITLE
Chore/bump test utils version

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/20-editor-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/20-editor-modal.twig
@@ -1,0 +1,36 @@
+{% set content %}
+  <bolt-button size="medium" width="auto" border-radius="regular" color="primary" on-click-target="editor-demo__modal" on-click="show">
+    <span>This is a Button triggering an on-page Modal</span>
+  </bolt-button>
+  <bolt-link on-click-target="editor-demo__modal" on-click="show" url="#">
+    This is a Link triggering an on-page Modal
+  </bolt-link>
+{% endset %}
+
+{% include '@bolt-components-editor/editor-in-pl.twig' with {
+  content: content,
+} only %}
+
+{% set video_content %}
+  {% include "@bolt-components-video/video.twig" with {
+    videoId: "3861325118001",
+    accountId: "1900410236",
+    playerId: "r1CAdLzTW",
+    showMeta: true,
+    showMetaTitle: true,
+    attributes: {
+      class: "editor-demo__modal"
+    }
+  } only %}
+{% endset %}
+
+{% include "@bolt-components-modal/modal.twig" with {
+  attributes: {
+    class: "editor-demo__modal"
+  },
+  content: video_content,
+  width: "optimal",
+  spacing: "none",
+  theme: "none",
+  scroll: "overall",
+} only %}

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-prettier": "^3.1.0",
     "globby": "^10.0.1",
-    "@bolt/testing-utils": "^2.8.0-beta.2",
+    "@bolt/testing-utils": "^2.8.0-beta.3",
     "find-pkg": "^2.0.0",
     "haunted": "^4.4.0",
     "husky": "^3.0.0",

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -349,7 +349,32 @@ export function setupBolt(editor) {
     extend: 'text',
     initialContent: ['Button'],
     propsToTraits: ['size', 'width', 'border_radius'],
-    extraTraits: [colorTrait],
+    extraTraits: [
+      colorTrait,
+      {
+        label: 'On Click',
+        name: 'on-click',
+        type: 'select',
+        options: ['none', 'show'],
+        default: 'none',
+      },
+      {
+        label: 'On Click Target',
+        name: 'on-click-target',
+        type: 'string',
+      },
+      {
+        label: 'Url',
+        name: 'url',
+        type: 'string',
+      },
+      {
+        label: 'Disabled',
+        name: 'disabled',
+        type: 'checkbox',
+        default: false,
+      },
+    ],
   });
 
   registerBoltComponent({
@@ -606,6 +631,20 @@ export function setupBolt(editor) {
       default: true,
     },
     initialContent: [`I'm a link`],
+    extraTraits: [
+      {
+        label: 'On Click',
+        name: 'on-click',
+        type: 'select',
+        options: ['none', 'show'],
+        default: 'none',
+      },
+      {
+        label: 'On Click Target',
+        name: 'on-click-target',
+        type: 'string',
+      },
+    ],
   });
 
   registerBoltComponent({


### PR DESCRIPTION
## Summary

Fixes the following error by matching the testing utils version in root `package.json` with `packages/testing/testing-utils/package.json`: 
```
(node:56465) UnhandledPromiseRejectionWarning: Error: Custom message:
  Error 🛑: the /Users/jeremy/www/bolt2/node_modules/@bolt/testing-utils package installed to the root "node_modules/@bolt/" folder isn't symlinked to the packages folder!

 In the Bolt monorepo we require all Bolt packages to be a symbolic link pointing back to the local package's code to ensure packages are configured and working correctly + use up to date dependencies. A Bolt package requiring /Users/jeremy/www/bolt2/node_modules/@bolt/testing-utils package likely needs to have it's package.json updated to use a more up to date version of this Bolt particular dependency.
```