### PR TITLE
chore(bolt): increment testing utils in root package json to fix Unha…

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-prettier": "^3.1.0",
     "globby": "^10.0.1",
-    "@bolt/testing-utils": "^2.8.0-beta.2",
+    "@bolt/testing-utils": "^2.8.0-beta.3",
     "find-pkg": "^2.0.0",
     "haunted": "^4.4.0",
     "husky": "^3.0.0",


### PR DESCRIPTION
Fixes the following error by matching the testing utils version in root `package.json` with `packages/testing/testing-utils/package.json`:
```
(node:56465) UnhandledPromiseRejectionWarning: Error: Custom message:
  Error 🛑: the /Users/jeremy/www/bolt2/node_modules/@bolt/testing-utils package installed to the root "node_modules/@bolt/" folder isn't symlinked to the packages folder!

 In the Bolt monorepo we require all Bolt packages to be a symbolic link pointing back to the local package's code to ensure packages are configured and working correctly + use up to date dependencies. A Bolt package requiring /Users/jeremy/www/bolt2/node_modules/@bolt/testing-utils package likely needs to have it's package.json updated to use a more up to date version of this Bolt particular dependency.
```