### PR TITLE
Fix/dialogue bar mobile

### DIFF
--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -10,7 +10,7 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 .c-bolt-status-dialogue-bar {
   display: flex;
   align-items: center;
-  max-width: 110px;
+  max-width: 170px;
   padding: bolt-spacing(xsmall) bolt-spacing(small);
   color: bolt-color(black);
   border-radius: $bolt-border-radius;


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1141695888436665/f

## Summary

Dialogue bar has some issues with overlapping on extremely small IE11 machines, as well as on mobile in general.  This PR includes a quick test to see if we can increase the max-width to fix IE11 without further breaking the other browsers.  

## Details

(Explain the changes in enough detail fo reviewers to understand.  Raise any questions for reviewers to consider.)

## How to test
Visit 
/pattern-lab/patterns/06-experiments-micro-journeys-combos--92-micro-journey-in-themes/06-experiments-micro-journeys-combos--92-micro-journey-in-themes.html
